### PR TITLE
Added nickname support to logs

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.discordlogger</groupId>
   <artifactId>discordlogger</artifactId>
   <name>DiscordLogger</name>
-  <version>2.0.1</version>
+  <version>2.1.1</version>
   <description>Logs server events to a Discord channel via webhooks.</description>
   <url>https://github.com/GodTierGamers/DiscordLogger</url>
   <build>

--- a/src/main/java/com/discordlogger/event/EventRegistry.java
+++ b/src/main/java/com/discordlogger/event/EventRegistry.java
@@ -8,11 +8,12 @@ import com.discordlogger.listener.PlayerQuit;
 import com.discordlogger.listener.ServerCommand;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
+import org.bukkit.plugin.java.JavaPlugin;
 
 public final class EventRegistry {
-    private final Plugin plugin;
+    private final JavaPlugin plugin;
 
-    public EventRegistry(Plugin plugin) { this.plugin = plugin; }
+    public EventRegistry(JavaPlugin plugin) { this.plugin = plugin; }
 
     public void registerAll() {
         PluginManager pm = plugin.getServer().getPluginManager();

--- a/src/main/java/com/discordlogger/listener/PlayerChat.java
+++ b/src/main/java/com/discordlogger/listener/PlayerChat.java
@@ -1,23 +1,26 @@
 package com.discordlogger.listener;
 
 import com.discordlogger.log.Log;
+import com.discordlogger.util.Names;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
-import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
 
 public final class PlayerChat implements Listener {
-    private final Plugin plugin;
+    private final JavaPlugin plugin;
 
-    public PlayerChat(Plugin plugin) { this.plugin = plugin; }
+    public PlayerChat(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
 
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    @EventHandler
     public void onChat(AsyncPlayerChatEvent e) {
         if (!plugin.getConfig().getBoolean("log.player.chat", true)) return;
-        final String name = Log.mdEscape(e.getPlayer().getName());
-        final String msg  = Log.mdEscape(e.getMessage());
-        final String thumb = Log.playerAvatarUrl(e.getPlayer().getUniqueId());
-        Log.eventWithThumb("Player Chat", name + " — " + msg, thumb);
+
+        String who = Names.display(e.getPlayer(), plugin);
+        String text = Log.mdEscape(e.getMessage());
+        String msg = "**" + who + "**: " + text;
+        Log.eventWithThumb("Player Chat", msg, Log.playerAvatarUrl(e.getPlayer().getUniqueId()));
     }
 }

--- a/src/main/java/com/discordlogger/listener/PlayerCommand.java
+++ b/src/main/java/com/discordlogger/listener/PlayerCommand.java
@@ -1,23 +1,26 @@
 package com.discordlogger.listener;
 
 import com.discordlogger.log.Log;
+import com.discordlogger.util.Names;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
-import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
 
 public final class PlayerCommand implements Listener {
-    private final Plugin plugin;
+    private final JavaPlugin plugin;
 
-    public PlayerCommand(Plugin plugin) { this.plugin = plugin; }
+    public PlayerCommand(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
 
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    @EventHandler
     public void onPlayerCommand(PlayerCommandPreprocessEvent e) {
         if (!plugin.getConfig().getBoolean("log.player.command", true)) return;
-        final String name = Log.mdEscape(e.getPlayer().getName());
-        final String cmd  = Log.mdEscape(e.getMessage()); // includes leading slash
-        final String thumb = Log.playerAvatarUrl(e.getPlayer().getUniqueId());
-        Log.eventWithThumb("Player Command", name + " ran: " + cmd, thumb);
+
+        String who = Names.display(e.getPlayer(), plugin);
+        String cmd = Log.mdEscape(e.getMessage()); // includes leading '/'
+        String msg = who + " ran: " + cmd;
+        Log.eventWithThumb("Player Command", msg, Log.playerAvatarUrl(e.getPlayer().getUniqueId()));
     }
 }

--- a/src/main/java/com/discordlogger/listener/PlayerDeath.java
+++ b/src/main/java/com/discordlogger/listener/PlayerDeath.java
@@ -1,6 +1,7 @@
 package com.discordlogger.listener;
 
 import com.discordlogger.log.Log;
+import com.discordlogger.util.Names;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
@@ -13,6 +14,7 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
 
 public final class PlayerDeath implements Listener {
     private final Plugin plugin;
@@ -24,13 +26,13 @@ public final class PlayerDeath implements Listener {
         if (!plugin.getConfig().getBoolean("log.player.death", true)) return;
 
         final Player victim = e.getEntity();
-        final String vName = Log.mdEscape(victim.getName());
+        final String vName = Names.display(victim, (JavaPlugin) plugin);
         final String thumb = Log.playerAvatarUrl(victim.getUniqueId());
 
         // Prefer killer context (player)
         final Player killer = victim.getKiller();
         if (killer != null) {
-            String kName = Log.mdEscape(killer.getName());
+            String kName = Names.display(killer, (JavaPlugin) plugin);
             String weapon = weaponName(killer.getInventory().getItemInMainHand());
             String suffix = weapon.isEmpty() ? "" : " [" + weapon + "]";
             Log.eventWithThumb("Player Death", vName + " was slain by " + kName + suffix, thumb);
@@ -45,7 +47,7 @@ public final class PlayerDeath implements Listener {
             if (damager instanceof Projectile proj) {
                 Object shooter = proj.getShooter();
                 if (shooter instanceof Player pShooter) {
-                    String kName = Log.mdEscape(pShooter.getName());
+                    String kName = Names.display(pShooter, (JavaPlugin) plugin);
                     Log.eventWithThumb("Player Death", vName + " was shot by " + kName, thumb);
                     return;
                 } else if (shooter instanceof Entity eShooter) {

--- a/src/main/java/com/discordlogger/listener/PlayerJoin.java
+++ b/src/main/java/com/discordlogger/listener/PlayerJoin.java
@@ -1,22 +1,28 @@
 package com.discordlogger.listener;
 
 import com.discordlogger.log.Log;
+import com.discordlogger.util.Names;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
 
 public final class PlayerJoin implements Listener {
-    private final Plugin plugin;
+    private final JavaPlugin plugin;
 
-    public PlayerJoin(Plugin plugin) { this.plugin = plugin; }
+    public PlayerJoin(JavaPlugin plugin) { this.plugin = plugin; }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onJoin(PlayerJoinEvent e) {
         if (!plugin.getConfig().getBoolean("log.player.join", true)) return;
-        final String name = Log.mdEscape(e.getPlayer().getName());
-        final String thumb = Log.playerAvatarUrl(e.getPlayer().getUniqueId());
-        Log.eventWithThumb("Player Join", name + " joined the server", thumb);
+
+        // Delay slightly so nickname plugins can set displayName
+        plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
+            Names.capture(e.getPlayer()); // seed/update cache
+            String who = Names.display(e.getPlayer(), plugin);
+            String msg = who + " joined the server";
+            Log.eventWithThumb("Player Join", msg, Log.playerAvatarUrl(e.getPlayer().getUniqueId()));
+        }, 2L);
     }
 }

--- a/src/main/java/com/discordlogger/listener/PlayerQuit.java
+++ b/src/main/java/com/discordlogger/listener/PlayerQuit.java
@@ -1,22 +1,26 @@
 package com.discordlogger.listener;
 
 import com.discordlogger.log.Log;
+import com.discordlogger.util.Names;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
-import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
 
 public final class PlayerQuit implements Listener {
-    private final Plugin plugin;
+    private final JavaPlugin plugin;
 
-    public PlayerQuit(Plugin plugin) { this.plugin = plugin; }
+    public PlayerQuit(JavaPlugin plugin) { this.plugin = plugin; }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onQuit(PlayerQuitEvent e) {
         if (!plugin.getConfig().getBoolean("log.player.quit", true)) return;
-        final String name = Log.mdEscape(e.getPlayer().getName());
-        final String thumb = Log.playerAvatarUrl(e.getPlayer().getUniqueId());
-        Log.eventWithThumb("Player Quit", name + " left the server", thumb);
+
+        String who = Names.display(e.getPlayer(), plugin); // falls back to cache if needed
+        String msg = who + " left the server";
+        Log.eventWithThumb("Player Quit", msg, Log.playerAvatarUrl(e.getPlayer().getUniqueId()));
+
+        Names.remove(e.getPlayer());
     }
 }

--- a/src/main/java/com/discordlogger/util/Names.java
+++ b/src/main/java/com/discordlogger/util/Names.java
@@ -1,0 +1,61 @@
+package com.discordlogger.util;
+
+import com.discordlogger.log.Log;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
+public final class Names {
+    private Names() {}
+
+    private static final Pattern SEC_CODES = Pattern.compile("§[0-9A-FK-ORa-fk-or]");
+    private static final Pattern AMP_CODES = Pattern.compile("&[0-9A-FK-ORa-fk-or]");
+
+    private static final Map<UUID, String> NICK_CACHE = new ConcurrentHashMap<>();
+
+    /** Returns either "Nick (Real)" if nicknames enabled & present, else "Real". */
+    public static String display(Player player, JavaPlugin plugin) {
+        if (player == null) return "";
+        final String real = player.getName();
+        final boolean useNick = plugin.getConfig().getBoolean("format.nicknames", true);
+        if (!useNick) return real;
+
+        // Prefer live displayName, else cached nick
+        String nick = cleanDisplay(player.getDisplayName());
+        if (nick == null || nick.isBlank() || nick.equalsIgnoreCase(real)) {
+            nick = NICK_CACHE.get(player.getUniqueId());
+        }
+
+        if (nick == null || nick.isBlank() || nick.equalsIgnoreCase(real)) {
+            return real; // no distinct nickname
+        }
+        return Log.mdEscape(nick) + " (" + Log.mdEscape(real) + ")";
+    }
+
+    /** Capture & cache nickname if it’s distinct from real name. */
+    public static void capture(Player player) {
+        if (player == null) return;
+        final String real = player.getName();
+        String nick = cleanDisplay(player.getDisplayName());
+        if (nick != null && !nick.isBlank() && !nick.equalsIgnoreCase(real)) {
+            NICK_CACHE.put(player.getUniqueId(), nick);
+        }
+    }
+
+    /** Remove cache entry (optional; useful on quit if desired). */
+    public static void remove(Player player) {
+        if (player != null) NICK_CACHE.remove(player.getUniqueId());
+    }
+
+    private static String cleanDisplay(String s) {
+        if (s == null) return null;
+        String out = SEC_CODES.matcher(s).replaceAll("");
+        out = AMP_CODES.matcher(out).replaceAll("");
+        out = out.replace("§", "").trim();
+        return out;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -31,6 +31,8 @@ format:
   time: "[HH:mm:ss, dd:MM:yyyy]"
   # Only used for plain text, for embeds edit author name
   name: ""
+  # Show nicknames (if set) as "Nickname (RealName)" in all player-related logs
+  nicknames: true
 
 #################
 # EMBED OPTIONS #
@@ -76,4 +78,4 @@ log:
     stop: true # Logged on /stop / clean shutdown
 
 
-# CONFIG VERSION V4, SHIPPED WITH V2.1.1
+# CONFIG VERSION V5, SHIPPED WITH V2.1.1


### PR DESCRIPTION
## What’s changed?
<!-- Short, user-facing bullets. Keep it human. -->
- 

## Type of change
<!-- Tick all that apply; labels should match these. -->
- [ ] ✨ Feature (`feat`)
- [ ] 🐛 Fix (`bug`)
- [ ] 🛠 Refactor (`refactor`)
- [ ] 🧰 Maintenance (`chore`)
- [ ] 🧪 Tests (`test`)
- [ ] 📝 Docs (`docs`)
- [ ] ⚙️ CI/CD (`ci`, `build`)
- [ ] Skip changelog (`skip-changelog`)

## Release notes (optional)
Add any human-written notes **between** the markers below.  
These lines will be inserted **above** the auto-generated changelog in the GitHub Release.

<!-- RELEASE-NOTES:START -->
- Brief highlights users should see first.
- Breaking change? Call it out here.
<!-- RELEASE-NOTES:END -->

## Release Options
- [ ] No changelog for this release
- [ ] Pre-release

### Custom release tag (optional)
Put a tag here to override the default (e.g. `v2.0.0-BETA`).  
If left empty, the workflow uses the version from `pom.xml`.

<!-- RELEASE-TAG:START -->
<!-- e.g. v2.0.0-BETA -->
<!-- RELEASE-TAG:END -->

### Custom release title (optional)
Put a title here to override the default (e.g. `DiscordLogger v2.0.0 BETA`).  
If left empty, the workflow uses `DiscordLogger v<version>`.

<!-- RELEASE-TITLE:START -->
<!-- e.g. DiscordLogger v2.0.0 BETA -->
<!-- RELEASE-TITLE:END -->

### Custom file name (optional)
Put a custom name here to override the default file name (e.g. DiscordLogger V2.0.0 [don't include .jar at the end])

<!-- CUSTOM-JAR-NAME:START -->
<!-- Remember not to include .jar at the end -->
<!-- CUSTOM-JAR-NAME:END -->

## Checklist
- [ ] Code compiles locally
- [ ] Appropriate labels added (matches “Type of change”)
- [ ] Edited version number inside pom.xml and end of config.yml (or removed previous release tag)
