### PR TITLE
ci: disable release-please SNAPSHOT flow, pin plain v-tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,6 +16,8 @@
     ".": {
       "release-type": "maven",
       "package-name": "discordlogger",
+      "skip-snapshot": true,
+      "include-component-in-tag": false,
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         {


### PR DESCRIPTION
First live release-please run opened a `2.1.7-SNAPSHOT` bump PR (#98) — Java-convention snapshot flow this repo doesn't use. `skip-snapshot: true` disables it; `include-component-in-tag: false` pins tags to plain `vX.Y.Z` so UpdateChecker and the nightly tag-math keep working.