### PR TITLE
fix: default teleport, gamemode and explosion logging to on

### DIFF
--- a/scripts/validate-config-generator.py
+++ b/scripts/validate-config-generator.py
@@ -20,6 +20,11 @@
    "Full config.yml" code block matches that same mirror copy too. This is
    a 4th place the same content lives -- easy to forget, and it HAD already
    drifted (missing an entire banner block) before this check existed.
+5. Every getConfig().getBoolean("log.*", <fallback>) in the Java source uses
+   the SAME fallback as the value config.yml ships. These only diverge when a
+   user's config is missing the key (hand-edited, partial copy, pre-dating the
+   key), and a mismatch silently disables logging the docs promise is on --
+   which is exactly what happened to teleport/gamemode/explosion.
 
 Exits non-zero (and prints one ERROR line per problem) if anything's wrong.
 """
@@ -187,12 +192,62 @@ def check_doc_page_embedded_configs() -> list[str]:
     return errors
 
 
+def check_java_fallbacks_match_shipped_config() -> list[str]:
+    """Java's getBoolean fallback must equal what config.yml ships for that key.
+
+    The fallback only applies when a user's config is missing the key, so a
+    mismatch is invisible in normal use and silently contradicts the docs --
+    e.g. config.yml shipping `teleport: true` while the listener defaulted to
+    false, so a partial config meant teleport logging never fired.
+    """
+    if not os.path.exists(SHIPPED_CONFIG):
+        return [f"{SHIPPED_CONFIG} not found"]
+
+    # what config.yml ships: log.<category>.<event> -> true/false
+    shipped: dict[str, str] = {}
+    with open(SHIPPED_CONFIG, encoding="utf-8") as f:
+        text = f.read()
+    if "\nlog:" in text:
+        category = None
+        for line in text.split("\nlog:", 1)[1].split("\n"):
+            cat_m = re.match(r"^  (\w+):\s*(?:#.*)?$", line)
+            if cat_m:
+                category = cat_m.group(1)
+                continue
+            leaf_m = re.match(r"^    (\w+):\s*(true|false)\b", line)
+            if leaf_m and category:
+                shipped[f"log.{category}.{leaf_m.group(1)}"] = leaf_m.group(2)
+
+    if not shipped:
+        return [f"{SHIPPED_CONFIG}: could not parse any log.* toggles -- has the structure changed?"]
+
+    errors = []
+    pattern = re.compile(r'getBoolean\(\s*"(log\.[a-z._]+)"\s*,\s*(true|false)\s*\)')
+    for java_file in glob.glob(f"{JAVA_SRC}/**/*.java", recursive=True):
+        with open(java_file, encoding="utf-8") as f:
+            for lineno, line in enumerate(f, 1):
+                for key, fallback in pattern.findall(line):
+                    want = shipped.get(key)
+                    if want is None:
+                        errors.append(
+                            f"{java_file}:{lineno} reads '{key}', which {SHIPPED_CONFIG} doesn't ship"
+                        )
+                    elif want != fallback:
+                        errors.append(
+                            f"{java_file}:{lineno} defaults '{key}' to {fallback}, but "
+                            f"{SHIPPED_CONFIG} ships {want} -- they must match, or a config "
+                            f"missing this key silently behaves against the documented default"
+                        )
+    return errors
+
+
 def main() -> int:
     all_errors = []
     for options_path in sorted(glob.glob("docs/assets/configs/v*/options.json")):
         all_errors.extend(check_version(options_path))
     all_errors.extend(check_shipped_config_matches_mirror())
     all_errors.extend(check_doc_page_embedded_configs())
+    all_errors.extend(check_java_fallbacks_match_shipped_config())
 
     if all_errors:
         for e in all_errors:

--- a/src/main/java/com/discordlogger/listener/player/PlayerGamemode.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerGamemode.java
@@ -21,7 +21,7 @@ public final class PlayerGamemode implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onGamemodeChange(PlayerGameModeChangeEvent e) {
-        if (!plugin.getConfig().getBoolean("log.player.gamemode", false)) return;
+        if (!plugin.getConfig().getBoolean("log.player.gamemode", true)) return;
 
         final Player p = e.getPlayer();
         final GameMode from = p.getGameMode();      // old mode (event fires before apply)

--- a/src/main/java/com/discordlogger/listener/player/PlayerTeleport.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerTeleport.java
@@ -25,7 +25,7 @@ public final class PlayerTeleport implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onTeleport(PlayerTeleportEvent e) {
-        if (!plugin.getConfig().getBoolean("log.player.teleport", false)) return;
+        if (!plugin.getConfig().getBoolean("log.player.teleport", true)) return;
 
         final Player p = e.getPlayer();
         final String playerName = Names.display(p, plugin);

--- a/src/main/java/com/discordlogger/listener/server/Explosion.java
+++ b/src/main/java/com/discordlogger/listener/server/Explosion.java
@@ -44,7 +44,7 @@ public final class Explosion implements Listener {
     public Explosion(JavaPlugin plugin) { this.plugin = plugin; }
 
     private boolean enabled() {
-        return plugin.getConfig().getBoolean("log.server.explosion", false);
+        return plugin.getConfig().getBoolean("log.server.explosion", true);
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)


### PR DESCRIPTION
Three listeners fell back to `false` when their config key was absent, while `config.yml` ships all three as `true`:

| File | Key |
|---|---|
| `PlayerTeleport.java:28` | `log.player.teleport` |
| `PlayerGamemode.java:24` | `log.player.gamemode` |
| `Explosion.java:47` | `log.server.explosion` |

The fallback only applies when a user's `config.yml` is **missing** the key — hand-edited, partially copied, or predating the key. In that case these three silently stayed **off**, contradicting both the shipped default and the docs, while every other event defaulted on. A "why isn't teleport logging working?" report with no obvious cause.

I audited **all 19** `log.*` gates against what `config.yml` ships rather than just fixing the three already known — those three were the only mismatches.

## Also: a check so it can't come back

This bug was documented in AGENTS.md as a known issue and still sat unfixed, which is decent evidence that writing conventions down doesn't keep them true. `scripts/validate-config-generator.py` now parses every `getBoolean("log.*", …)` in the Java source and compares its fallback to the value `config.yml` ships, failing CI on any mismatch with the exact file:line.

Sabotage-tested in both directions: reverting a listener to `false` → caught; flipping a `config.yml` value instead → caught. Restored, passes clean.

**Behaviour note:** for anyone currently running a config that's missing one of these keys, that event starts logging after this change. That's the documented and intended default, but it is a real behaviour change for that edge case rather than a pure no-op.
