### PR TITLE
fix: remove invalid Liquid filter syntax from nav active-state check

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -62,10 +62,10 @@
             {% assign active_class = ' is-active' %}
             {% endif %}
             {% else %}
-            {% if current == item.url
-            or current == item.url | append: 'index.html'
-            or current == item.url | append: '/'
-            or current contains item.url %}
+            {# Liquid does not allow filters inside `if`, so no `| append:` here.
+               `contains` already covers the trailing-slash and /index.html forms,
+               plus nested pages like /config/v9/ under /config/. #}
+            {% if current == item.url or current contains item.url %}
             {% assign active_class = ' is-active' %}
             {% endif %}
             {% endif %}


### PR DESCRIPTION
The nav active-state condition in `docs/_layouts/default.html` used `| append:` filters inside an `{% if %}`, which Liquid does not support. Jekyll logged a syntax warning for **every page on every build**:

```
Liquid Warning: Liquid syntax error (line 65): Expected end_of_string but found pipe in
"current == item.url or current == item.url | append: 'index.html' or ..."
```

Those two branches never evaluated — they were dead code. The `or current contains item.url` branch was doing all the real matching, which is why nav highlighting worked anyway.

Removed the two dead lines and left a comment explaining why no filter belongs there, so it does not get "helpfully" re-added.

## Verified identical behaviour

Compared rendered HTML before and after — the `is-active` class lands on exactly the same element in both:

| Page | Active nav item |
|---|---|
| `/` | `/` |
| `/setup/` | `/setup/` |
| `/generator/` | `/generator/` |
| `/config/` | `/config/` |
| `/config/v9/` | `/config/` (nested page highlights parent, as intended) |
| `/downloads/` | none — not a nav item |

Build log is now free of the warning.

**Unrelated note for anyone pulling this:** run `bundle install` in `docs/` after the recent webrick bump, or `jekyll serve` fails with `Could not find webrick-1.9.2`.