### PR TITLE
feat: fail with a clear message on non-Paper servers instead of a stack trace

### DIFF
--- a/src/main/java/com/discordlogger/DiscordLogger.java
+++ b/src/main/java/com/discordlogger/DiscordLogger.java
@@ -8,6 +8,7 @@ import com.discordlogger.log.Log;
 import com.discordlogger.update.BuildInfo;
 import com.discordlogger.update.NightlyNotice;
 import com.discordlogger.update.UpdateChecker;
+import com.discordlogger.util.Platform;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
@@ -19,6 +20,15 @@ public final class DiscordLogger extends JavaPlugin {
     @Override
     public void onEnable() {
         BuildInfo.load(this);
+
+        // Bail out before touching the data folder — no point writing a config
+        // to a server that can't run the plugin anyway.
+        final String missing = Platform.missingRequirement();
+        if (missing != null) {
+            reportUnsupportedPlatform(missing);
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
 
         saveDefaultConfig();
         ConfigMigrator.migrateIfVersionChanged(this, "config.yml", new File(getDataFolder(), "config.yml"));
@@ -55,6 +65,22 @@ public final class DiscordLogger extends JavaPlugin {
     public void onDisable() {
         if (events != null) events.fireServerStop();
         getLogger().info("Disabled.");
+    }
+
+    /** Explain, in plain terms, why the plugin can't start on this server. */
+    private void reportUnsupportedPlatform(String missingClass) {
+        final String bar = "============================================================";
+        getLogger().severe(bar);
+        getLogger().severe("DiscordLogger requires Paper (or a Paper fork such as Purpur).");
+        getLogger().severe("This server does not provide the Paper API, so the plugin");
+        getLogger().severe("cannot start. Spigot and CraftBukkit are NOT supported.");
+        getLogger().severe("");
+        getLogger().severe("Missing: " + missingClass);
+        getLogger().severe("");
+        getLogger().severe("Download Paper from https://papermc.io/downloads — it is a");
+        getLogger().severe("drop-in replacement, so your worlds, plugins and configs");
+        getLogger().severe("keep working as they are.");
+        getLogger().severe(bar);
     }
 
     public boolean applyRuntimeConfig() {

--- a/src/main/java/com/discordlogger/util/Platform.java
+++ b/src/main/java/com/discordlogger/util/Platform.java
@@ -1,0 +1,43 @@
+package com.discordlogger.util;
+
+/**
+ * Startup guard for the Paper APIs this plugin genuinely requires.
+ *
+ * <p>Without this check, a Spigot/CraftBukkit server fails in a way that tells the
+ * admin nothing useful: {@code EventRegistry.registerAll()} reflects over
+ * {@code PlayerChat}'s handler parameters, hits the missing
+ * {@code AsyncChatEvent}, and throws {@link NoClassDefFoundError} out of
+ * {@code onEnable()} — Bukkit then disables the plugin with a raw stack trace and
+ * no explanation. Detecting it up front turns that into an answerable question.
+ *
+ * <p>Deliberately probes the exact classes we depend on rather than "is this
+ * Paper?", so a fork missing one of them is reported accurately instead of being
+ * waved through on a brand name.
+ */
+public final class Platform {
+
+    /** Paper/Adventure classes the plugin cannot run without. */
+    private static final String[] REQUIRED_CLASSES = {
+            // Paper's modern chat event — used by listener/player/PlayerChat
+            "io.papermc.paper.event.player.AsyncChatEvent",
+            // Adventure, bundled by Paper — used to flatten chat components to text
+            "net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer",
+    };
+
+    private Platform() {}
+
+    /**
+     * @return the first required class this server doesn't provide, or {@code null}
+     *         when everything needed is present.
+     */
+    public static String missingRequirement() {
+        for (String className : REQUIRED_CLASSES) {
+            try {
+                Class.forName(className);
+            } catch (ClassNotFoundException | LinkageError e) {
+                return className;
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
On a Spigot/CraftBukkit server this plugin currently dies in a way that tells the admin nothing: `EventRegistry.registerAll()` reflects over `PlayerChat`'s handler parameters, hits the missing `AsyncChatEvent`, and throws `NoClassDefFoundError` out of `onEnable()`. Bukkit then disables the plugin with a raw stack trace and no explanation.

This adds a startup check that turns that into an answerable question:

```
============================================================
DiscordLogger requires Paper (or a Paper fork such as Purpur).
This server does not provide the Paper API, so the plugin
cannot start. Spigot and CraftBukkit are NOT supported.

Missing: io.papermc.paper.event.player.AsyncChatEvent

Download Paper from https://papermc.io/downloads — it is a
drop-in replacement, so your worlds, plugins and configs
keep working as they are.
============================================================
```

Then disables cleanly.

## Design notes

- **Probes the exact classes we depend on**, not "is this Paper?" — so a fork that's missing one is reported accurately rather than waved through on a brand name. Currently two: `AsyncChatEvent` and Adventure's `PlainTextComponentSerializer`.
- **Runs before `saveDefaultConfig()`** — no point writing a config file into the data folder of a server that can't run the plugin.
- Catches `LinkageError` as well as `ClassNotFoundException`, so a half-present or incompatible class surfaces the same way instead of escaping as an unhandled error.

## Verified both directions

Ran `Platform.missingRequirement()` against two classpaths:

| Simulated server | Result |
|---|---|
| Paper (paper-api + all transitive deps, Adventure present) | `null` — starts normally |
| Spigot (no Paper deps) | `io.papermc.paper.event.player.AsyncChatEvent` — clean disable |

Worth noting only one file actually blocks Spigot support today — `PlayerChat` — every other listener is pure Bukkit API. This PR does not attempt Spigot compatibility, only an honest failure.
