### PR TITLE
docs: drop Spigot references and stop hardcoding versions in docs pages

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,7 +37,7 @@ body:
     id: platform
     attributes:
       label: Server platform
-      description: "DiscordLogger requires Paper or a Paper fork — it does not run on plain Spigot."
+      description: "DiscordLogger requires Paper or a Paper fork."
       options:
         - Paper
         - Purpur

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Every release includes a `.sha256` checksum for the JAR.
 
 ## 🔌 Compatibility
 
-- **Server:** Paper **1.21+** (or Paper forks such as Purpur). The plugin uses Paper-specific APIs and does not run on plain Spigot.
+- **Server:** Paper **1.21+**, or a Paper fork such as Purpur. The plugin uses Paper-specific APIs, so Paper is required — it will tell you clearly on startup if the server doesn't provide them.
 - **Java:** **21+**
 - **Cross-play:** Compatible with **Geyser/Floodgate** — death messages are server-generated for consistency across Java/Bedrock names/locales.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ title: Home
 
 Minecraft → Discord logging that’s clean, configurable, and production-ready.
 
-> **Latest plugin:** v2.1.6  
+> **Latest plugin:** v<span data-dl-latest>…</span>  
 > **Latest config version:** v9
 
 ---

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -9,14 +9,14 @@ description: Install DiscordLogger, set your webhook, and verify everything is w
 
 This guide walks you through installing **DiscordLogger** and getting logs into Discord in minutes.
 
-> **Latest plugin:** v2.1.5  
+> **Latest plugin:** v<span data-dl-latest>…</span>  
 > **Config schema:** v9
 
 ---
 
 ## 1) Requirements
 
-- **Server:** Spigot / Paper 1.21+ (tested on paper 1.21.8, supports 1.21.10)
+- **Server:** Paper 1.21+, or a Paper fork such as Purpur (tested on Paper 1.21.8, supports 1.21.10)
 - **Discord:** A channel where you can create a webhook
 - **Permissions:**
     - Discord:
@@ -67,9 +67,11 @@ embeds:
   author: "Server Logs"
 ```
 
-> The last line of your file should read:  
-> `# CONFIG VERSION V9, SHIPPED WITH V2.1.5`  
-> (That’s how the generator/docs map versions.)
+> The last line of your file records which config schema it uses, e.g.  
+> `# CONFIG VERSION V9, SHIPPED WITH v2.1.6 BUILT 30-07-2026`  
+> The `V9` part is what matters — that's how the plugin knows whether your
+> config needs migrating, and how the docs map versions. The version and build
+> date after it are just there to tell you which build wrote the file.
 
 Save the file.
 

--- a/src/main/java/com/discordlogger/DiscordLogger.java
+++ b/src/main/java/com/discordlogger/DiscordLogger.java
@@ -71,9 +71,9 @@ public final class DiscordLogger extends JavaPlugin {
     private void reportUnsupportedPlatform(String missingClass) {
         final String bar = "============================================================";
         getLogger().severe(bar);
-        getLogger().severe("DiscordLogger requires Paper (or a Paper fork such as Purpur).");
+        getLogger().severe("DiscordLogger requires Paper, or a Paper fork such as Purpur.");
         getLogger().severe("This server does not provide the Paper API, so the plugin");
-        getLogger().severe("cannot start. Spigot and CraftBukkit are NOT supported.");
+        getLogger().severe("cannot start.");
         getLogger().severe("");
         getLogger().severe("Missing: " + missingClass);
         getLogger().severe("");

--- a/src/main/java/com/discordlogger/util/Platform.java
+++ b/src/main/java/com/discordlogger/util/Platform.java
@@ -3,12 +3,12 @@ package com.discordlogger.util;
 /**
  * Startup guard for the Paper APIs this plugin genuinely requires.
  *
- * <p>Without this check, a Spigot/CraftBukkit server fails in a way that tells the
- * admin nothing useful: {@code EventRegistry.registerAll()} reflects over
+ * <p>Without this check, a server lacking the Paper API fails in a way that tells
+ * the admin nothing useful: {@code EventRegistry.registerAll()} reflects over
  * {@code PlayerChat}'s handler parameters, hits the missing
  * {@code AsyncChatEvent}, and throws {@link NoClassDefFoundError} out of
- * {@code onEnable()} — Bukkit then disables the plugin with a raw stack trace and
- * no explanation. Detecting it up front turns that into an answerable question.
+ * {@code onEnable()} — the server then disables the plugin with a raw stack trace
+ * and no explanation. Detecting it up front turns that into an answerable question.
  *
  * <p>Deliberately probes the exact classes we depend on rather than "is this
  * Paper?", so a fork missing one of them is reported accurately instead of being


### PR DESCRIPTION
Follows on from the Paper platform check (#112), now that DiscordLogger is no longer listed on SpigotMC.

## Spigot references removed

The important one was an outright **false claim**: the setup page listed requirements as *"Spigot / Paper 1.21+"*, advertising support for a platform the plugin cannot run on at all.

The rest were disclaimers ("does not run on plain Spigot"). Rather than delete those and lose the information, I reframed them **positively** — stating what is *required* instead of what is not supported. Same clarity, no Spigot mention:

| Where | Now reads |
|---|---|
| `docs/setup/index.md` | Server: Paper 1.21+, or a Paper fork such as Purpur |
| `README.md` | ...Paper is required — it will tell you clearly on startup if the server does not provide the APIs |
| `bug_report.yml` | DiscordLogger requires Paper or a Paper fork. |
| `Platform.java` message + javadoc | ...requires Paper, or a Paper fork such as Purpur |

**`Bukkit` references are deliberately kept** — Paper implements the Bukkit API, so `org.bukkit.*` in the code and "Bukkit scheduler" in the architecture docs are technically accurate. Only the *platform* names are gone.

## Hardcoded versions replaced

Found while reviewing — and a violation of our own "never hardcode a version number in the website" rule:

- `docs/setup/index.md` said **"Latest plugin: v2.1.5"** — stale by a release
- `docs/index.md` said **"Latest plugin: v2.1.6"** — correct today, stale at the next release

Both now use the `data-dl-latest` hook, so they track the GitHub releases API and cannot go stale again. Verified in the browser: both render **2.1.6** live.

Also rewrote the setup page note about the config trailer, which quoted a stale `SHIPPED WITH V2.1.5` line and did not explain that the `V9` part is the bit that actually matters.