### PR TITLE
docs: stop leaking repo internals into user-facing config files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,7 +190,9 @@ All `log.*` toggles ship as `true` in the default file.
 
 ### Config file dictionary — four places hold "the config," they are not the same thing
 
-Four near-identical copies of the config content exist. Confusing them is the single most common way this repo drifts — it already happened twice: a hint-text reword landed on two of four copies and nobody noticed the other two for several sessions (one of them, the doc-page embed, had *already* been silently missing an entire banner block before anyone caught it). Files 1–3 carry an identity comment block at the top (`DL_FILE_IDENTITY_START`/`END`) stating which one they are — read it before editing any of them.
+Four near-identical copies of the config content exist. Confusing them is the single most common way this repo drifts — it already happened twice: a hint-text reword landed on two of four copies and nobody noticed the other two for several sessions (one of them, the doc-page embed, had *already* been silently missing an entire banner block before anyone caught it).
+
+**These files carry no in-file "which copy am I" markers, deliberately.** An earlier attempt put identity headers at the top of each one; every path a user obtains a config — fresh install, website download, and generator output — then handed them repo-internal notes referencing `AGENTS.md` and `scripts/`. User-facing artifacts must not leak repo internals, so the table below plus the CI check are the *only* mechanism keeping these in sync. Don't reintroduce in-file markers.
 
 | # | Location | What it actually is | Consumed by |
 |---|---|---|---|
@@ -199,7 +201,7 @@ Four near-identical copies of the config content exist. Confusing them is the si
 | 3 | `docs/assets/configs/v9/config.template.yml` | **The generator template** — `{{TOKEN}}` placeholders, filled in by the wizard based on what the visitor chose. Never downloaded directly; its *output* is. | `docs/assets/configs/v9/generator.js` |
 | 4 | The `## Full config.yml` fenced code block inside `docs/config/v9/index.md` | **The doc-page embed** — the full file shown inline in prose, for people reading the docs who don't want to click through. Easiest of the four to forget since it lives inside Markdown, not a config file. | Rendered directly on the config docs page |
 
-**The rule:** 1, 2, and 4 must be **content-identical** — same real values, same comments, same banners — except each one's own trailer line (`SHIPPED WITH vX.Y.Z` vs `DOWNLOADED FROM WEBSITE`) and (for 1 and 2) identity header. `scripts/validate-config-generator.py` enforces this automatically in CI for both 1↔2 and 2↔4 — it will fail the build if any of them drift. File 3 isn't byte-compared (it has tokens instead of real values), but its `{{LOG_*}}`/`{{COLOR_*}}` tokens are cross-checked against `options.json` and the Java source by the same script.
+**The rule:** 1, 2, and 4 must be **content-identical** — same real values, same comments, same banners — except each one's own trailer line (`SHIPPED WITH vX.Y.Z` vs `DOWNLOADED FROM WEBSITE`). `scripts/validate-config-generator.py` enforces this automatically in CI for both 1↔2 and 2↔4 — it will fail the build if any of them drift. File 3 isn't byte-compared (it has tokens instead of real values), but its `{{LOG_*}}`/`{{COLOR_*}}` tokens are cross-checked against `options.json` and the Java source by the same script.
 
 **Practical consequence:** any edit to the real config content (webhook/format/embeds/log.\* structure or their comments, including the banners) touches file 1 first, then files 2 and 4 need the identical change, and file 3 needs the matching `{{TOKEN}}` version. Don't rely on memory for this — run `python3 scripts/validate-config-generator.py` locally before opening the PR; CI runs it too, but catching it before pushing is faster.
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,10 @@
 # TODO
 
-Things the maintainer has explicitly asked to be reminded about. Nothing else belongs here.
+Planned work that hasn't been done yet.
 
-**Rules (see AGENTS.md → "TODO.md protocol"):**
-- An item is added **only** when the maintainer explicitly says so — "remind me to…", "add this to TODO.md", or equivalent. Never self-populated.
-- When an item is done it is **deleted outright**. No strikethrough, no "completed" section, no history — the file only ever shows what is still outstanding.
-- An empty list below is the normal, healthy state.
+This list is deliberately short. Items land here when work is actually committed to — it isn't a wishlist or an idea dump — and they're deleted the moment they're finished. So everything listed is genuinely outstanding, and an empty list means nothing is pending.
+
+Got an idea that isn't here? Open a [feature request](https://github.com/GodTierGamers/DiscordLogger/issues/new?template=feature-request.yml) — that's where proposals get discussed, and it keeps this file trustworthy as a picture of committed work.
 
 ---
 

--- a/docs/assets/configs/v9/config.template.yml
+++ b/docs/assets/configs/v9/config.template.yml
@@ -1,12 +1,3 @@
-# ---DL_FILE_IDENTITY_START---
-# [3 of 3 near-identical config files -- see "Config file dictionary" in AGENTS.md before editing]
-# THE GENERATOR TEMPLATE. {{TOKEN}} placeholders get filled in by generator.js when
-# a visitor completes the config wizard. Never downloaded directly. Its {{LOG_*}}
-# and {{COLOR_*}} tokens must match the keys in src/main/resources/config.yml (the
-# real source of truth) and options.json (checked by
-# scripts/validate-config-generator.py) -- but this file's literal content is NOT
-# byte-compared against the other two, since {{TOKENS}} replace real values here.
-# ---DL_FILE_IDENTITY_END---
 ####################################################################################################################################
 #                                                                                                                                  #
 #    /$$$$$$$  /$$                                               /$$ /$$                                                           #

--- a/docs/assets/configs/v9/config.yml
+++ b/docs/assets/configs/v9/config.yml
@@ -1,10 +1,3 @@
-# ---DL_FILE_IDENTITY_START---
-# [2 of 3 near-identical config files -- see "Config file dictionary" in AGENTS.md before editing]
-# THE DOWNLOAD MIRROR. Served by the plain "Download" button on the config docs
-# page -- no generator wizard involved. Must stay identical to the real source of
-# truth, src/main/resources/config.yml, except the trailer line (checked by
-# scripts/validate-config-generator.py). Never edit this file's content alone.
-# ---DL_FILE_IDENTITY_END---
 ####################################################################################################################################
 #                                                                                                                                  #
 #    /$$$$$$$  /$$                                               /$$ /$$                                                           #

--- a/scripts/validate-config-generator.py
+++ b/scripts/validate-config-generator.py
@@ -42,20 +42,7 @@ SHIPPED_CONFIG = "src/main/resources/config.yml"
 DOC_PAGE_GLOB = "docs/config/v*/index.md"
 VERSION_RE = re.compile(r"CONFIG\s+VERSION\s+V(\d+)", re.IGNORECASE)
 FULL_CONFIG_HEADING_RE = re.compile(r"^#+\s*Full config\.yml", re.IGNORECASE | re.MULTILINE)
-IDENTITY_START = "# ---DL_FILE_IDENTITY_START---"
-IDENTITY_END = "# ---DL_FILE_IDENTITY_END---"
 
-
-def strip_identity_block(lines: list[str]) -> list[str]:
-    """Removes the per-file '[N of 3 ...]' header block (each file's identity
-    comment legitimately differs -- only the content below it must match)."""
-    if IDENTITY_START not in lines:
-        return lines
-    start = lines.index(IDENTITY_START)
-    if IDENTITY_END not in lines:
-        return lines
-    end = lines.index(IDENTITY_END, start)
-    return lines[:start] + lines[end + 1:]
 
 
 def check_version(options_path: str) -> list[str]:
@@ -133,10 +120,10 @@ def check_shipped_config_matches_mirror() -> list[str]:
     with open(mirror_path, encoding="utf-8") as f:
         mirror_lines = f.read().splitlines()
 
-    # Compare everything except each file's own trailer line (last line) and its
-    # per-file identity header -- those are the two things SUPPOSED to differ.
-    shipped_body = strip_identity_block(shipped_lines[:-1])
-    mirror_body = strip_identity_block(mirror_lines[:-1])
+    # Compare everything except each file's own trailer line (last line) --
+    # that's the one line that's SUPPOSED to differ between the two.
+    shipped_body = shipped_lines[:-1]
+    mirror_body = mirror_lines[:-1]
 
     if shipped_body != mirror_body:
         return [
@@ -179,10 +166,10 @@ def check_doc_page_embedded_configs() -> list[str]:
         with open(mirror_path, encoding="utf-8") as f:
             mirror_lines = f.read().splitlines()
 
-        # Drop each side's own trailer line (last line) and identity header before
-        # comparing -- same rule as check_shipped_config_matches_mirror.
-        mirror_body = strip_identity_block(mirror_lines[:-1])
-        embedded_body = strip_identity_block(embedded[:-1])
+        # Drop each side's own trailer line before comparing -- same rule as
+        # check_shipped_config_matches_mirror.
+        mirror_body = mirror_lines[:-1]
+        embedded_body = embedded[:-1]
 
         if mirror_body != embedded_body:
             errors.append(

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,10 +1,3 @@
-# ---DL_FILE_IDENTITY_START---
-# [1 of 3 near-identical config files -- see "Config file dictionary" in AGENTS.md before editing]
-# THE SHIPPED CONFIG. Bundled inside the plugin JAR; every server gets this on first
-# run. Must stay identical to docs/assets/configs/v9/config.yml except the trailer
-# line (checked by scripts/validate-config-generator.py). This file is the source
-# of truth -- the other two copies exist to serve it to the website.
-# ---DL_FILE_IDENTITY_END---
 ####################################################################################################################################
 #                                                                                                                                  #
 #    /$$$$$$$  /$$                                               /$$ /$$                                                           #


### PR DESCRIPTION
A pass over everything user-facing to make sure public artifacts read as project documentation, not as internal maintenance notes.

## Repo internals were leaking into every user's config.yml

The bigger find. Each config file carried an identity header at the top:

```yaml
# ---DL_FILE_IDENTITY_START---
# [1 of 3 near-identical config files -- see "Config file dictionary" in AGENTS.md before editing]
# THE SHIPPED CONFIG. Bundled inside the plugin JAR; ...
# Must stay identical to docs/assets/configs/v9/config.yml except the trailer
# line (checked by scripts/validate-config-generator.py). ...
# ---DL_FILE_IDENTITY_END---
```

These were only ever meant for contributors, but they shipped to users through **all three** ways a config is obtained:

1. **Fresh install** — bundled in the JAR, written to every server on first run
2. **Website download** — served verbatim by the download button
3. **Config generator** — the template carried one too, and the generator does token replacement without stripping it, so every generated config included it

So a server admin's brand-new `config.yml` opened with instructions to read `AGENTS.md` before editing, and references to `scripts/` and `docs/assets/` paths that mean nothing outside this repo. They were also already stale — "1 of 3" when there are four copies.

Removed from all three files. The four-copy dictionary in AGENTS.md and the CI drift check already keep these in sync far more reliably than a comment nobody reads, so nothing is lost. `scripts/validate-config-generator.py` is simplified accordingly (the strip-the-header logic it needed is gone), and AGENTS.md now records *why* in-file markers must not be reintroduced.

Verified all three paths are clean: the JAR's config, the website copy, and the template the generator fetches contain no `AGENTS.md` reference, no repo paths, no markers.

## TODO.md reframed

It read as one person's assistant notes — *"Things the maintainer has explicitly asked to be reminded about"*, with rules about when entries may be added. That's an odd thing for a visitor to a public repo to find.

Same guarantees, framed as a project artifact: items are committed work rather than a wishlist, they're deleted once done, so an empty list means nothing is pending. It now also points would-be contributors at the feature-request template instead of implying the file is where ideas go.

The agent-facing rules still exist in full — in AGENTS.md, where instructions to agents belong.

## Checked and deliberately left alone

- **README AI Disclosure / CONTRIBUTING "Using AI tools"** — these already present AI assistance as a governed, reviewed process with human sign-off, which is the point. No change.
- **"the maintainer" phrasing** in CONTRIBUTING/ARCHITECTURE — standard open-source language, reads normally.
- **ARCHITECTURE.md's note that the config copies "drifted apart twice already"** — honest rationale explaining why the CI guard exists; useful to a contributor deciding whether to trust it.
- No personal paths, machine references, or local setup details anywhere in tracked files.
