### PR TITLE
chore: update Paper API to 26.2 and target Java 25

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     id: javaver
     attributes:
       label: Java version
-      placeholder: "e.g., 21 (Temurin)"
+      placeholder: "e.g., 25 (Temurin)"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -49,7 +49,7 @@ body:
     id: mcversion
     attributes:
       label: Minecraft version
-      placeholder: "e.g., 1.21.8"
+      placeholder: "e.g., 26.2"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/support.yml
+++ b/.github/ISSUE_TEMPLATE/support.yml
@@ -17,7 +17,7 @@ body:
     id: mcversion
     attributes:
       label: Minecraft version
-      placeholder: "e.g., 1.21.8"
+      placeholder: "e.g., 26.2"
   - type: textarea
     id: question
     attributes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: "25"
           cache: maven
 
       - name: Build with Maven (tests on)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -136,7 +136,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: "25"
           cache: maven
 
       - name: Set version (uncommitted, build-local only)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: "25"
           cache: maven
 
       - name: Stamp build date into config.yml trailer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Everything below was verified against the actual source at the time of writing; 
 
 ## What this project is
 
-**DiscordLogger** is a Minecraft **Paper** server plugin (Java 21) that posts server events to a Discord channel via **webhooks** — either as rich embeds (per-event colors, player-head thumbnails, timestamps) or as plain Markdown text. It ships with a versioned `config.yml` that auto-migrates between schema versions, a channel-aware update checker, and a companion **Jekyll website** (in `docs/`) hosted on GitHub Pages at `https://discordlogger.godtiergamers.xyz` that includes an interactive config generator.
+**DiscordLogger** is a Minecraft **Paper** server plugin (Java 25) that posts server events to a Discord channel via **webhooks** — either as rich embeds (per-event colors, player-head thumbnails, timestamps) or as plain Markdown text. It ships with a versioned `config.yml` that auto-migrates between schema versions, a channel-aware update checker, and a companion **Jekyll website** (in `docs/`) hosted on GitHub Pages at `https://discordlogger.godtiergamers.xyz` that includes an interactive config generator.
 
 - **Current plugin version:** tracked by `pom.xml` / `.release-please-manifest.json` — never hand-edit either, see **Releases** below.
 - **Current config schema:** **v9** (trailer comment in `src/main/resources/config.yml`, e.g. `# CONFIG VERSION V9, SHIPPED WITH v2.1.6 (x-release-please-version)`)
@@ -43,7 +43,7 @@ mvn -B -ntp clean compile     # compile only (faster sanity check)
 ```
 
 - **There is no test suite.** `mvn package` compiling cleanly is the only automated check. Real verification means dropping the shaded JAR into a Paper server's `plugins/` folder.
-- The shade plugin relocates SnakeYAML to `com.discordlogger.shaded.snakeyaml` and excludes its `META-INF`. `minimizeJar` is deliberately **off** (ASM/Java 21 bytecode issues).
+- The shade plugin relocates SnakeYAML to `com.discordlogger.shaded.snakeyaml` and excludes its `META-INF`. `minimizeJar` is deliberately **off** (ASM/modern bytecode issues).
 - **Maven resource filtering applies ONLY to `plugin.yml` and `build-info.properties`** (for `${project.version}` / `${dl.build.channel}` / `${dl.build.date}`). `config.yml` is copied **verbatim** — it contains `$` characters in ASCII art that must never be filtered. Don't add filtering to it; CI stamps its trailer via targeted regex replacement instead.
 - A plain local `mvn package` produces a **`dev`-channel** build (`dl.build.channel` defaults to `dev` in `pom.xml`) — see `BuildInfo`.
 
@@ -288,7 +288,7 @@ Renders straight from the releases API. Nightly builds (tag matches `-BETA.N`) g
 
 ## Conventions
 
-- **Java 21, Paper API only**; Adventure preferred for anything new touching chat components (`ChatColor` lingers in command feedback).
+- **Java 25, Paper API only**; Adventure preferred for anything new touching chat components (`ChatColor` lingers in command feedback).
 - Final classes, private constructors on static utility classes, `LinkedHashMap` where iteration order matters.
 - Config keys: lowercase snake_case, grouped `log.<category>.<event>`.
 - Every new logged event, in lockstep: listener (with live config gate) + `EventRegistry` registration + `log.*` key in `config.yml` + default color in `Log.init` + generator `options.json` (including its `defaultColor`, which must match the plugin default) / template entries + docs mention. The validator catches the generator-side half in CI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Everything below was verified against the actual source at the time of writing; 
 
 - **Current plugin version:** tracked by `pom.xml` / `.release-please-manifest.json` — never hand-edit either, see **Releases** below.
 - **Current config schema:** **v9** (trailer comment in `src/main/resources/config.yml`, e.g. `# CONFIG VERSION V9, SHIPPED WITH v2.1.6 (x-release-please-version)`)
-- **Paper API:** `1.21.11-R0.1-SNAPSHOT` (`provided` scope), `api-version: 1.21`
+- **Paper API:** `26.2.build.87-stable` (`provided` scope), `api-version: 26.1`, compiled for **Java 25**
 - **GitHub:** `GodTierGamers/DiscordLogger`
 
 ## Working agreement (binding — not suggestions)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,7 +6,7 @@ A tour of how DiscordLogger is actually built — for contributors, curious user
 
 ## What DiscordLogger is
 
-A Paper server plugin (Java 21) that watches server events and posts them to a Discord channel over a webhook, either as rich embeds or plain Markdown text. It ships a versioned `config.yml` that migrates itself forward automatically, checks for updates in a way that's aware of which release channel it's running on, and is accompanied by a Jekyll website (this `docs/` folder) with an interactive config generator.
+A Paper server plugin (Java 25) that watches server events and posts them to a Discord channel over a webhook, either as rich embeds or plain Markdown text. It ships a versioned `config.yml` that migrates itself forward automatically, checks for updates in a way that's aware of which release channel it's running on, and is accompanied by a Jekyll website (this `docs/` folder) with an interactive config generator.
 
 ## How a request flows through the plugin at startup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Everything after that is automated: merged work appears in the next **nightly bu
 
 - **Java 25** (Temurin recommended) and Maven.
 - `mvn -B -ntp clean package` must pass.
-- Test on a real **Paper 1.21+** server when your change touches runtime behavior — a clean compile is not a functional test.
+- Test on a real **Paper 26.x** server when your change touches runtime behavior — a clean compile is not a functional test.
 - **Config changes travel in lockstep**: if you add or change a `log.*` / `embeds.*` config key, the same PR must update the listener, `src/main/resources/config.yml`, and the website generator data (`docs/assets/configs/v*/options.json` + `config.template.yml`). Run the checker locally:
   ```bash
   python3 scripts/validate-config-generator.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Everything after that is automated: merged work appears in the next **nightly bu
 
 ## Before you open a PR
 
-- **Java 21** (Temurin recommended) and Maven.
+- **Java 25** (Temurin recommended) and Maven.
 - `mvn -B -ntp clean package` must pass.
 - Test on a real **Paper 1.21+** server when your change touches runtime behavior — a clean compile is not a functional test.
 - **Config changes travel in lockstep**: if you add or change a `log.*` / `embeds.*` config key, the same PR must update the listener, `src/main/resources/config.yml`, and the website generator data (`docs/assets/configs/v*/options.json` + `config.template.yml`). Run the checker locally:

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 ![Downloads](https://img.shields.io/github/downloads/GodTierGamers/DiscordLogger/total)
 ![Issues](https://img.shields.io/github/issues/GodTierGamers/DiscordLogger)
 ![License](https://img.shields.io/github/license/GodTierGamers/DiscordLogger)
-![Java](https://img.shields.io/badge/Java-21%2B-orange)
-![Paper](https://img.shields.io/badge/Paper-1.21%2B-blue)
+![Java](https://img.shields.io/badge/Java-25%2B-orange)
+![Paper](https://img.shields.io/badge/Paper-26.x-blue)
 ![Discord Webhooks](https://img.shields.io/badge/Discord-Webhooks-5865F2)
 
 A minimal, reliable Minecraft server **logging plugin** that posts clean messages to a **Discord webhook** — in Markdown **or rich embeds**.
-Built for **Paper 1.21+** (and Paper forks like Purpur), tested with Geyser/Floodgate (Bedrock cross-play).
+Built for **Paper 26.x** (and Paper forks like Purpur) on **Java 25+**, tested with Geyser/Floodgate (Bedrock cross-play).
 
 ---
 
@@ -59,8 +59,8 @@ Every release includes a `.sha256` checksum for the JAR.
 
 ## 🔌 Compatibility
 
-- **Server:** Paper **1.21+**, or a Paper fork such as Purpur. The plugin uses Paper-specific APIs, so Paper is required — it will tell you clearly on startup if the server doesn't provide them.
-- **Java:** **21+**
+- **Server:** Paper **26.x**, or a Paper fork such as Purpur. The plugin uses Paper-specific APIs, so Paper is required — it will tell you clearly on startup if the server doesn't provide them.
+- **Java:** **25+** — Minecraft 26.x requires it, and the plugin is compiled for it. It will not load on older Java runtimes.
 - **Cross-play:** Compatible with **Geyser/Floodgate** — death messages are server-generated for consistency across Java/Bedrock names/locales.
 
 ---

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -16,7 +16,8 @@ This guide walks you through installing **DiscordLogger** and getting logs into 
 
 ## 1) Requirements
 
-- **Server:** Paper 1.21+, or a Paper fork such as Purpur (tested on Paper 1.21.8, supports 1.21.10)
+- **Server:** Paper 26.x, or a Paper fork such as Purpur
+- **Java:** 25 or newer (Minecraft 26.x requires it)
 - **Discord:** A channel where you can create a webhook
 - **Permissions:**
     - Discord:

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <paper.api.version>1.21.11-R0.1-SNAPSHOT</paper.api.version>
+        <paper.api.version>26.2.build.87-stable</paper.api.version>
 
         <!-- Build channel/date are stamped by CI (-Ddl.build.channel=stable|nightly,
              -Ddl.build.date=DD-MM-YYYY). A plain local `mvn package` gets "dev",

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <url>https://github.com/GodTierGamers/DiscordLogger</url>
 
     <properties>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <paper.api.version>26.2.build.87-stable</paper.api.version>
 
@@ -90,7 +90,7 @@
                                     <shadedPattern>com.discordlogger.shaded.snakeyaml</shadedPattern>
                                 </relocation>
                             </relocations>
-                            <!-- Disable to avoid ASM parsing issues with Java 21 bytecode -->
+                            <!-- Disable to avoid ASM parsing issues with modern bytecode -->
                             <minimizeJar>false</minimizeJar>
                             <!-- dependency-reduced-pom.xml only matters when publishing to a
                                  Maven repo (so consumers don't inherit shaded deps). This
@@ -111,9 +111,10 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- maven.compiler.release=21 in <properties> drives the compiler.
-                 No override here so Java 21 features (records, pattern matching, etc.)
-                 compile and target correctly. -->
+            <!-- maven.compiler.release in <properties> drives the compiler; no
+                 override here. Targeting 25 to match Minecraft 26.x, which requires
+                 a Java 25 runtime — so the emitted bytecode can't load on older
+                 Java. See ARCHITECTURE.md for what that means for compatibility. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: DiscordLogger
 main: com.discordlogger.DiscordLogger
 version: ${project.version}
-api-version: 1.21
+api-version: 26.1
 author: LVCHLANN
 description: Logs server events to a Discord channel via webhooks.
 


### PR DESCRIPTION
Updates the compile-time Paper API from `1.21.11-R0.1-SNAPSHOT` to `26.2.build.87-stable`.

Note the versioning scheme change: Minecraft moved to date-based versions, so the sequence is `1.21.10` → `1.21.11` → `26.1.1` → `26.1.2` → `26.2`. The `26.2` in the artifact name **is** the Minecraft version, not a Paper-internal number.

`api-version` in `plugin.yml` is deliberately left at `1.21`. Raising it would gain nothing and would make the plugin refuse to load on 1.21.x servers.

## Compatibility, verified rather than assumed

Compiling against a newer API risks emitting bytecode that references methods absent from older servers, which fails at runtime rather than build time. So this was checked directly:

**1. Source compiles cleanly against every API in the range** — MC 1.21, 1.21.8, 1.21.11, 26.1.2 and 26.2. Identical API surface, no conditional code.

**2. Binary compatibility of the 26.2-compiled bytecode.** Extracted all 142 `org.bukkit.*` / `io.papermc.*` type, method and field references from the compiled classes and resolved each one (walking the type hierarchy for inherited members) against the MC 1.21, 1.21.8, 1.21.11 and 26.1.2 API jars.

Result in every case: **0 missing types, 0 missing members.** The only three initial hits were `name()` / `ordinal()` on enums, which come from `java.lang.Enum` in the JDK — a limitation of the hierarchy walk, not a real gap.

**3. Enum constants**, which unlike methods can genuinely disappear between versions. All 20 `DamageCause` and 8 `TeleportCause` constants used by `PlayerDeath` and `PlayerTeleport` are present in MC 1.21, 1.21.11 and 26.2.

## Deprecation warnings (informational, nothing broken)

26.2 marks several long-standing APIs deprecated. All still function; none are removed:

| API | Used by |
|---|---|
| `BanList.Type.NAME` + `isBanned(String)` | `Ban`, `Unban` |
| `ChatColor` | `Commands`, `Reload` |
| `Player.getDisplayName()` | `Names` |
| `ItemMeta.getDisplayName()` | `PlayerDeath` |
| `JavaPlugin.getDescription()` | `Log` |

Worth migrating eventually — `BanList.Type.PROFILE` and Adventure `Component` equivalents exist — but that's a behavioural change to moderation and message formatting, so it belongs in its own PR rather than riding along with a dependency bump.
