### PR TITLE
chore: retarget next release to 2.2.0 and record planned work

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,4 +8,23 @@ Got an idea that isn't here? Open a [feature request](https://github.com/GodTier
 
 ---
 
-_Nothing outstanding._
+## Plugin
+
+- **Rate limiter and send queue** — Discord returns HTTP 429 when a busy server logs faster than the webhook allows. Queue outgoing messages and respect the rate limit rather than dropping them.
+- **Per-category webhook routing** — send different log categories to different Discord channels (e.g. moderation to a private staff channel, chat to a public one).
+- **Deeper logging modes** — option to relay the full server console rather than only the specific events currently supported.
+- **Log filtering (allow/deny lists)** — exclude specific entries within a category: e.g. don't log `/whisper` when command logging is on, or ignore a particular player by UUID.
+- **Bedrock vs Java indicator** — show which platform a player connected from.
+- **`lang.yml` with MiniMessage** — move every user-facing string into a language file so wording and formatting can be fully rewritten without touching code.
+
+## Config schema v10
+
+- **Move embed colour options to sub-options under their event toggles** — requires introducing nested sub-options, including in the config generator. This is the change that starts config schema **v10**.
+
+## Website & docs
+
+- **Discord OAuth webhook creation** — let the config generator create the webhook via Discord OAuth instead of making people copy a URL by hand.
+- **Complete website redesign.**
+- **Improve SEO.**
+- **Full docs quality pass** — review everything for accuracy and clarity.
+- **Verify every plugin-version reference is correct** across the site and repo.


### PR DESCRIPTION
Two things, both maintainer-directed.

## Next release is 2.2.0, not 2.1.7

`main` currently carries a **breaking compatibility change** — Java 25 and Paper 26.1 minimums, so servers on MC 1.21 / Java 21 can no longer run the plugin — plus genuine `feat:` work (the non-Paper startup guard, the rewritten config generator). release-please had computed 2.1.7 from the commit types alone, which understates that considerably.

An empty commit carrying a `Release-As: 2.2.0` footer retargets it. The nightly workflow honours the same footer, so beta builds stay numbered consistently with what will actually ship.

## TODO.md populated

Recording planned work as requested, grouped so the v10-triggering change is not buried among the rest:

- **Plugin** — rate limiter + send queue, per-category webhook routing, full-console logging mode, allow/deny log filtering, Bedrock vs Java indicator, `lang.yml` with MiniMessage
- **Config schema v10** — moving embed colours to sub-options under their event toggles; this is the item that introduces nested sub-options and starts v10
- **Website & docs** — Discord OAuth webhook creation, full redesign, SEO, docs quality pass, plugin-version reference audit

Per the TODO protocol these are deleted outright as they are completed, so the file always reflects only what is still outstanding.