### PR TITLE
docs: remove completed rate limiter item from TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,6 @@ Got an idea that isn't here? Open a [feature request](https://github.com/GodTier
 
 ## Plugin
 
-- **Rate limiter and send queue** — Discord returns HTTP 429 when a busy server logs faster than the webhook allows. Queue outgoing messages and respect the rate limit rather than dropping them.
 - **Per-category webhook routing** — send different log categories to different Discord channels (e.g. moderation to a private staff channel, chat to a public one).
 - **Deeper logging modes** — option to relay the full server console rather than only the specific events currently supported.
 - **Log filtering (allow/deny lists)** — exclude specific entries within a category: e.g. don't log `/whisper` when command logging is on, or ignore a particular player by UUID.


### PR DESCRIPTION
Delivered in #118, so per the TODO protocol the entry is deleted outright rather than marked done.

This couldn't ride along in #118 itself — the TODO entries were added in #116, which hadn't merged at the time, so the line didn't exist on that branch to remove.