### PR TITLE
docs: expand the version-reference audit into a categorised task

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -26,4 +26,12 @@ Got an idea that isn't here? Open a [feature request](https://github.com/GodTier
 - **Complete website redesign.**
 - **Improve SEO.**
 - **Full docs quality pass** — review everything for accuracy and clarity.
-- **Verify every plugin-version reference is correct** across the site and repo.
+
+## Repo-wide
+
+- **Audit every version reference in the repo.** Find *every* place a version number appears — code, config, docs, website, workflows, templates, comments — not just the obvious ones. Then sort each hit into one of three buckets:
+  1. **Plugin/build-owned** — belongs to the plugin itself and is machine-managed (`pom.xml`, `.release-please-manifest.json`, the `config.yml` trailer). Should never be hand-edited.
+  2. **Docs-only** — describes a config schema or documentation artifact rather than the plugin (`v9` config references, per-schema docs pages). Follows its own lifecycle, not the plugin version.
+  3. **Unknown** — anything that doesn't clearly fall into the first two. These are the dangerous ones: each needs a decision on who owns it and whether it can go stale.
+
+  The goal is knowing which references are automated, which are deliberately independent, and which are landmines waiting to drift.


### PR DESCRIPTION
TODO.md already carried a vague *"verify every plugin-version reference is correct"* line. Replaces it with the actual method rather than adding a second overlapping entry.

The task is now: find **every** version reference in the repo — code, config, docs, website, workflows, templates, comments — and sort each into one of three buckets:

1. **Plugin/build-owned** — machine-managed (`pom.xml`, `.release-please-manifest.json`, the `config.yml` trailer). Never hand-edited.
2. **Docs-only** — describes a config schema rather than the plugin (`v9` references, per-schema docs pages). Follows its own lifecycle.
3. **Unknown** — the dangerous ones. Each needs a decision on who owns it and whether it is allowed to go stale.

Also moved out of *Website & docs* into a new *Repo-wide* section, since the audit covers `pom.xml` and the workflows too — filing it under docs would have understated the scope.

Worth noting this is not hypothetical: stale version strings have bitten this repo repeatedly — the `(2.1.5)` generator hint that shipped inside 2.1.6, the setup page advertising 2.1.5 while the homepage said 2.1.6, and most recently a `Release-As` footer that silently failed to parse. Bucket 3 is where those live.