### PR TITLE
feat: add bStats metrics and fix badge sync markers breaking Markdown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ How each destination gets its value — all automatic, none needs remembering:
 - **`plugin.yml`, `build-info.properties`** — Maven resource filtering resolves `${project.version}` / `${dl.api.version}` at package time.
 - **CI workflows** — each reads `<maven.compiler.release>` out of `pom.xml` at runtime into a step output, so the JDK installed always matches the compile target. No `java-version:` literal exists anywhere.
 - **README.md, CONTRIBUTING.md** — values sit between `<!-- dl:sync:KEY -->…<!-- /dl:sync -->` markers, rewritten by `scripts/sync-versions.py`. Edit the surrounding prose freely; never the value between markers.
+  - **Inline markers only work in prose.** They cannot go inside Markdown syntax — an HTML comment within a `![badge](url)` breaks the image and GitHub renders the raw `![Java](` as text. Anything of that shape uses a **block** marker instead: `<!-- dl:sync-block:NAME -->` on its own line, with the whole block regenerated from a template in the script (`BLOCK_TEMPLATES`). The shields.io badges use this.
 - **Docs pages** — read `{{ site.data.versions.* }}` from `docs/_data/versions.yml`, which the same script generates. That file is generated: **do not edit it**. Liquid resolves inside fenced code blocks too, which is how the config-trailer examples stay current.
 - **Anything showing the *latest release*** on the site (`data-dl-latest`, the downloads list, the generator's version picker) — reads the GitHub releases API live, so it covers nightlies and stable without any file to update.
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@
 ![Downloads](https://img.shields.io/github/downloads/GodTierGamers/DiscordLogger/total)
 ![Issues](https://img.shields.io/github/issues/GodTierGamers/DiscordLogger)
 ![License](https://img.shields.io/github/license/GodTierGamers/DiscordLogger)
-![Java](https://img.shields.io/badge/Java-<!-- dl:sync:java -->25<!-- /dl:sync -->%2B-orange)
-![Paper](https://img.shields.io/badge/Paper-<!-- dl:sync:paper_display -->26.x<!-- /dl:sync -->-blue)
+<!-- dl:sync-block:badges -->
+![Java](https://img.shields.io/badge/Java-25%2B-orange)
+![Paper](https://img.shields.io/badge/Paper-26.x-blue)
+<!-- /dl:sync-block -->
 ![Discord Webhooks](https://img.shields.io/badge/Discord-Webhooks-5865F2)
 
 A minimal, reliable Minecraft server **logging plugin** that posts clean messages to a **Discord webhook** — in Markdown **or rich embeds**.

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,16 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Anonymous usage metrics (bstats.org). Shaded + relocated below:
+             bStats REQUIRES relocation so copies bundled by different plugins
+             don't collide at runtime. -->
+        <dependency>
+            <groupId>org.bstats</groupId>
+            <artifactId>bstats-bukkit</artifactId>
+            <version>3.2.1</version>
+            <scope>compile</scope>
+        </dependency>
+
         <!-- YAML parsing for config migration (parsing-only) -->
         <dependency>
             <groupId>org.yaml</groupId>
@@ -95,6 +105,10 @@
                                 <relocation>
                                     <pattern>org.yaml.snakeyaml</pattern>
                                     <shadedPattern>com.discordlogger.shaded.snakeyaml</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.bstats</pattern>
+                                    <shadedPattern>com.discordlogger.shaded.bstats</shadedPattern>
                                 </relocation>
                             </relocations>
                             <!-- Disable to avoid ASM parsing issues with modern bytecode -->

--- a/scripts/sync-versions.py
+++ b/scripts/sync-versions.py
@@ -40,6 +40,21 @@ DATA = Path("docs/_data/versions.yml")
 #     <!-- dl:sync:java -->25<!-- /dl:sync -->
 MARKER = re.compile(r"(<!-- dl:sync:(\w+) -->)(.*?)(<!-- /dl:sync -->)", re.DOTALL)
 
+# Some values sit inside Markdown syntax that can't contain HTML comments — a
+# shields.io badge URL is the case in point: `![Java](...<!-- -->25<!-- -->...)`
+# breaks the image entirely and GitHub renders the raw text. Those use a
+# BLOCK marker on its own lines instead, and the whole block is regenerated.
+BLOCK = re.compile(
+    r"(<!-- dl:sync-block:(\w+) -->\n)(.*?)(<!-- /dl:sync-block -->)", re.DOTALL
+)
+
+BLOCK_TEMPLATES = {
+    "badges": lambda v: (
+        f"![Java](https://img.shields.io/badge/Java-{v['java']}%2B-orange)\n"
+        f"![Paper](https://img.shields.io/badge/Paper-{v['paper_display']}-blue)\n"
+    ),
+}
+
 
 def pom_values() -> dict[str, str]:
     text = POM.read_text(encoding="utf-8")
@@ -104,7 +119,15 @@ def fill_markers(path: Path, v: dict[str, str]) -> bool:
             sys.exit(f"{path}: unknown sync key '{key}' (known: {', '.join(sorted(v))})")
         return f"{open_tag}{v[key]}{close_tag}"
 
-    updated = MARKER.sub(repl, original)
+    def repl_block(m: re.Match) -> str:
+        open_tag, name, _old, close_tag = m.groups()
+        if name not in BLOCK_TEMPLATES:
+            sys.exit(f"{path}: unknown sync block '{name}' "
+                     f"(known: {', '.join(sorted(BLOCK_TEMPLATES))})")
+        return f"{open_tag}{BLOCK_TEMPLATES[name](v)}{close_tag}"
+
+    updated = BLOCK.sub(repl_block, original)
+    updated = MARKER.sub(repl, updated)
     if updated != original:
         path.write_text(updated, encoding="utf-8")
         return True

--- a/src/main/java/com/discordlogger/DiscordLogger.java
+++ b/src/main/java/com/discordlogger/DiscordLogger.java
@@ -5,6 +5,7 @@ import com.discordlogger.command.Reload;
 import com.discordlogger.config.ConfigMigrator;
 import com.discordlogger.event.EventRegistry;
 import com.discordlogger.log.Log;
+import com.discordlogger.metrics.PluginMetrics;
 import com.discordlogger.update.BuildInfo;
 import com.discordlogger.update.NightlyNotice;
 import com.discordlogger.update.UpdateChecker;
@@ -56,6 +57,10 @@ public final class DiscordLogger extends JavaPlugin {
             getCommand("discordlogger").setExecutor(router);
             getCommand("discordlogger").setTabCompleter(router);
         }
+
+        // Anonymous usage metrics (bstats.org). Opt out via plugins/bStats/config.yml.
+        // Started after the config is loaded so its charts can read live values.
+        PluginMetrics.start(this);
 
         // Async update check (console + Discord notice if newer version available)
         UpdateChecker.checkAsync(this);

--- a/src/main/java/com/discordlogger/metrics/PluginMetrics.java
+++ b/src/main/java/com/discordlogger/metrics/PluginMetrics.java
@@ -1,0 +1,110 @@
+package com.discordlogger.metrics;
+
+import com.discordlogger.update.BuildInfo;
+import org.bstats.bukkit.Metrics;
+import org.bstats.charts.SimplePie;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Anonymous usage metrics via <a href="https://bstats.org">bStats</a>.
+ *
+ * <p>Opting out is handled by bStats itself through {@code plugins/bStats/config.yml},
+ * which covers every bStats plugin on the server at once — that's where admins
+ * already expect the switch to be, so this plugin deliberately adds no config key
+ * of its own. (A key would also open config schema v10, which should be opened by
+ * a deliberate schema change rather than by metrics.)
+ *
+ * <p>The charts exist to answer questions that actually change decisions:
+ * <ul>
+ *   <li><b>Config schema</b> — when is it safe to stop supporting an old schema?
+ *       The generator freezes a bundle per schema forever, so this is the number
+ *       that says whether anyone would notice.</li>
+ *   <li><b>Release channel</b> — is the nightly channel used enough to be worth
+ *       maintaining?</li>
+ *   <li><b>Output mode</b> — embeds vs plain text, i.e. where formatting effort
+ *       is worth spending.</li>
+ *   <li><b>Enabled events</b> — which log types are actually switched on.</li>
+ * </ul>
+ */
+public final class PluginMetrics {
+
+    /** bStats plugin id for DiscordLogger (bstats.org/plugin/bukkit/DiscordLogger). */
+    private static final int PLUGIN_ID = 33026;
+
+    private static final Pattern SCHEMA_RE =
+            Pattern.compile("CONFIG\\s+VERSION\\s+(V\\d+)", Pattern.CASE_INSENSITIVE);
+
+    private PluginMetrics() {}
+
+    /** Call once from onEnable, after {@link BuildInfo#load}. */
+    public static void start(JavaPlugin plugin) {
+        // A developer's local build would otherwise show up as a real server and
+        // skew every chart. Only shipped artifacts report.
+        if (BuildInfo.isDev()) {
+            plugin.getLogger().fine("Metrics disabled for a local/dev build.");
+            return;
+        }
+
+        try {
+            final Metrics metrics = new Metrics(plugin, PLUGIN_ID);
+
+            metrics.addCustomChart(new SimplePie("config_schema", () -> configSchema(plugin)));
+            metrics.addCustomChart(new SimplePie("release_channel", BuildInfo::channel));
+            metrics.addCustomChart(new SimplePie("output_mode", () ->
+                    plugin.getConfig().getBoolean("embeds.enabled", true) ? "Embeds" : "Plain text"));
+            metrics.addCustomChart(new org.bstats.charts.AdvancedPie("enabled_events", () -> enabledEvents(plugin)));
+
+        } catch (Throwable t) {
+            // Metrics must never be the reason a server fails to start.
+            plugin.getLogger().fine("Metrics could not start: " + t.getMessage());
+        }
+    }
+
+    /**
+     * The schema of the config actually on disk, read from its trailer — not the
+     * schema this build ships. Those differ exactly when a server hasn't restarted
+     * into a migration yet, and the on-disk value is the one worth measuring.
+     */
+    private static String configSchema(JavaPlugin plugin) {
+        try {
+            final File file = new File(plugin.getDataFolder(), "config.yml");
+            if (!file.isFile()) return "Unknown";
+            final String text = Files.readString(file.toPath(), StandardCharsets.UTF_8);
+            final Matcher m = SCHEMA_RE.matcher(text);
+            return m.find() ? m.group(1).toUpperCase() : "Unknown";
+        } catch (Exception e) {
+            return "Unknown";
+        }
+    }
+
+    /**
+     * Every enabled {@code log.<category>.<event>} toggle, counted once each.
+     * Reads the live config rather than a hardcoded list, so events added later
+     * appear here without touching this class.
+     */
+    private static Map<String, Integer> enabledEvents(JavaPlugin plugin) {
+        final Map<String, Integer> counts = new HashMap<>();
+        final ConfigurationSection log = plugin.getConfig().getConfigurationSection("log");
+        if (log == null) return counts;
+
+        for (String category : log.getKeys(false)) {
+            final ConfigurationSection section = log.getConfigurationSection(category);
+            if (section == null) continue;
+            for (String event : section.getKeys(false)) {
+                if (section.getBoolean(event, false)) {
+                    counts.put(category + "." + event, 1);
+                }
+            }
+        }
+        return counts;
+    }
+}


### PR DESCRIPTION
Adds anonymous usage metrics via [bStats](https://bstats.org) (plugin id `33026`), and fixes a Markdown bug in the version-sync markers introduced by #122.

## bStats

- `bstats-bukkit` **3.2.1**, shaded and **relocated** to `com.discordlogger.shaded.bstats`. Relocation is mandatory — unrelocated copies bundled by different plugins collide at runtime. Verified in the built JAR: **0** classes at `org/bstats/`, **19** under the relocated package.
- Started from `onEnable` *after* the config loads, so charts read live values.
- **Skipped entirely on `dev`-channel builds** — a local test server would otherwise appear as a real install and skew every chart.
- Wrapped in `try/catch (Throwable)`: metrics must never be why a server fails to start.

**No new config keys.** Opt-out is bStats' own `plugins/bStats/config.yml`, which covers every bStats plugin at once and is where admins already look. Adding our own key would also have opened config schema v10, which should be opened deliberately by the routing/filtering work rather than incidentally by metrics.

### Charts

| Chart | Question it answers |
|---|---|
| `config_schema` | When is it safe to stop supporting an old schema? The generator freezes a bundle per schema **forever**, so this is the number that says whether anyone would notice. |
| `release_channel` | Is the nightly channel used enough to justify maintaining it? |
| `output_mode` | Embeds vs plain text — where formatting effort is worth spending. |
| `enabled_events` | Which `log.*` toggles are actually on. |

`config_schema` reads the trailer of the config **on disk**, not the schema this build ships — those differ exactly when a server hasn't yet restarted into a migration, and the on-disk value is the one worth measuring. `enabled_events` walks the live config rather than a hardcoded list, so events added later appear without touching this class.

## Fix: sync markers broke the README badges

#122 put inline markers inside the badge URLs:

```markdown
![Java](https://img.shields.io/badge/Java-<!-- dl:sync:java -->25<!-- /dl:sync -->%2B-orange)
```

An HTML comment can't live inside Markdown `![]()` syntax. Confirmed against GitHub's own renderer — it produced:

```html
<p>![Java](<a href="https://img.shields.io/badge/Java-">https://img.shields.io/badge/Java-</a>25%2B-orange)</p>
```

so the badges vanished and the raw `![Java](` showed as text.

Added **block markers** for cases where the value sits inside Markdown syntax — `<!-- dl:sync-block:NAME -->` on its own line, with the whole block regenerated from a template. The badges use this; prose keeps the inline markers, which render fine.

Verified via GitHub's renderer: **11 `<img>` tags, 0 leaked `![`, 0 visible `dl:sync`** in README, and none in CONTRIBUTING. Also re-ran the propagation test (Java 26 / Paper 27.x) — the block updates correctly and was reverted.

AGENTS.md now records *why* inline markers can't go inside Markdown syntax, so it isn't rediscovered the hard way.
