### PR TITLE
feat: add SEO metadata, sitemap and social previews to the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Built for **Paper <!-- dl:sync:paper_display -->26.x<!-- /dl:sync -->** (and Pap
 
 Every release includes a `.sha256` checksum for the JAR.
 
+Stable releases are also published to [Modrinth](https://modrinth.com/plugin/discordlogger) and [Hangar](https://hangar.papermc.io/LVCHLANN/DiscordLogger), which is where most server hosts and plugin managers will find it. Nightly builds are GitHub-only.
+
 ---
 
 ## 🚀 Installation

--- a/TODO.md
+++ b/TODO.md
@@ -24,5 +24,4 @@ Got an idea that isn't here? Open a [feature request](https://github.com/GodTier
 
 - **Discord OAuth webhook creation** — let the config generator create the webhook via Discord OAuth instead of making people copy a URL by hand.
 - **Complete website redesign.**
-- **Improve SEO.**
 - **Full docs quality pass** — review everything for accuracy and clarity.

--- a/TODO.md
+++ b/TODO.md
@@ -24,4 +24,5 @@ Got an idea that isn't here? Open a [feature request](https://github.com/GodTier
 
 - **Discord OAuth webhook creation** — let the config generator create the webhook via Discord OAuth instead of making people copy a URL by hand.
 - **Complete website redesign.**
+- **Search visibility (ongoing)** — the technical groundwork is in place (sitemap, canonicals, structured data, per-page titles and descriptions). What's left is the slow part: content people actually search for (troubleshooting and comparison pages), listings on the sites Minecraft admins browse, and monitoring real queries in Search Console. This item stays open indefinitely; it isn't a task with a finish line.
 - **Full docs quality pass** — review everything for accuracy and clarity.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,49 @@
 title: DiscordLogger
-# When using a custom domain, baseurl is empty at runtime. relative_url handles both cases.
+tagline: Minecraft → Discord logging
+description: >-
+  A Paper plugin that posts Minecraft server events to a Discord channel over a
+  webhook — joins, quits, chat, deaths, moderation actions and more, as rich
+  embeds or plain text. Configurable per event, with a browser-based config
+  generator.
+
+# Absolute site URL. Required for canonical links, Open Graph tags and sitemap
+# entries to be absolute rather than relative — without it, link previews and
+# search results point nowhere useful.
+url: "https://discordlogger.godtiergamers.xyz"
+baseurl: ""
+
+lang: en_GB
+
+# Used by jekyll-seo-tag for structured data and Open Graph attribution.
+author: LVCHLANN
+logo: /assets/icons/android-chrome-512x512.png
+
+# Default social preview image. This is what renders when the site is shared in
+# Discord — which, for a Discord plugin, is the single most likely place a link
+# gets posted.
+social_image: /assets/DiscordLogger-Banner.webp
+
+twitter:
+  card: summary_large_image
+
+github:
+  repository_url: https://github.com/GodTierGamers/DiscordLogger
 
 markdown: kramdown
+
+# Both ship with the github-pages gem, so they run on GitHub Pages unmodified.
+#   jekyll-seo-tag  -> <title>, canonical, Open Graph, Twitter cards, JSON-LD
+#   jekyll-sitemap  -> /sitemap.xml
+plugins:
+  - jekyll-seo-tag
+  - jekyll-sitemap
+
+# Build output and tooling that must never be published or indexed.
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - test.sh
+  - cloudflare/
 
 # Apply the default layout to all Markdown pages under docs/
 defaults:
@@ -10,3 +52,4 @@ defaults:
       type: "pages"
     values:
       layout: "default"
+      image: /assets/DiscordLogger-Banner.webp

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 title: DiscordLogger
-tagline: Minecraft → Discord logging
+tagline: Minecraft Server Logging to Discord
 description: >-
   A Paper plugin that posts Minecraft server events to a Discord channel over a
   webhook — joins, quits, chat, deaths, moderation actions and more, as rich

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,10 +1,16 @@
 <!doctype html>
-<html lang="en" data-theme="">
+<html lang="{{ site.lang | default: 'en' | replace: '_', '-' }}" data-theme="">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>{{ page.title | default: site.title | default: "DiscordLogger" }}</title>
-    <meta name="description" content="{{ page.description | default: site.description | default: 'Minecraft → Discord logging that’s clean, configurable, and production-ready.' }}">
+    {%- comment -%}
+      jekyll-seo-tag emits <title>, the meta description, canonical link,
+      Open Graph + Twitter card tags and JSON-LD structured data from
+      _config.yml and each page's front matter. It ships with the
+      github-pages gem, so it runs on GitHub Pages unmodified.
+      Per-page control: `title`, `description` and `image` in front matter.
+    {%- endcomment -%}
+    {% seo %}
 
     <!-- GitHub Markdown CSS (keeps the original look) -->
     <link rel="stylesheet" href="https://unpkg.com/github-markdown-css@5.5.1/github-markdown.css">

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -12,6 +12,45 @@
     {%- endcomment -%}
     {% seo %}
 
+    {%- comment -%}
+      jekyll-seo-tag only describes the site as a generic WebSite/WebPage. This
+      block additionally declares what the site is actually about — a free
+      Minecraft server plugin — so search engines can surface it as software
+      rather than as an unclassified page. Homepage only: duplicating the same
+      entity on every page adds nothing.
+    {%- endcomment -%}
+    {%- if page.url == '/' -%}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      "name": "DiscordLogger",
+      "url": {{ site.url | append: site.baseurl | append: '/' | jsonify }},
+      "applicationCategory": "GameApplication",
+      "applicationSubCategory": "Minecraft server plugin",
+      "operatingSystem": "Any (Java {{ site.data.versions.java | default: '25' }}+)",
+      "softwareVersion": {{ site.data.versions.plugin | default: '' | jsonify }},
+      "softwareRequirements": "PaperMC {{ site.data.versions.min_paper | default: '' }} or newer",
+      "description": {{ site.description | strip_newlines | strip | jsonify }},
+      "image": {{ site.url | append: site.baseurl | append: site.social_image | jsonify }},
+      "license": "https://github.com/GodTierGamers/DiscordLogger/blob/main/LICENSE",
+      "isAccessibleForFree": true,
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD"
+      },
+      "downloadUrl": "https://github.com/GodTierGamers/DiscordLogger/releases",
+      "installUrl": {{ site.url | append: site.baseurl | append: '/setup/' | jsonify }},
+      "codeRepository": "https://github.com/GodTierGamers/DiscordLogger",
+      "author": {
+        "@type": "Person",
+        "name": {{ site.author | jsonify }}
+      }
+    }
+    </script>
+    {%- endif -%}
+
     <!-- GitHub Markdown CSS (keeps the original look) -->
     <link rel="stylesheet" href="https://unpkg.com/github-markdown-css@5.5.1/github-markdown.css">
 
@@ -68,9 +107,11 @@
             {% assign active_class = ' is-active' %}
             {% endif %}
             {% else %}
-            {# Liquid does not allow filters inside `if`, so no `| append:` here.
-               `contains` already covers the trailing-slash and /index.html forms,
-               plus nested pages like /config/v9/ under /config/. #}
+            {%- comment -%}
+              Liquid does not allow filters inside `if`, so no `| append:` here.
+              `contains` already covers the trailing-slash and /index.html forms,
+              plus nested pages like /config/v9/ under /config/.
+            {%- endcomment -%}
             {% if current == item.url or current contains item.url %}
             {% assign active_class = ' is-active' %}
             {% endif %}

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1,10 +1,11 @@
 ---
 layout: default
-title: Config Docs
+title: "config.yml Reference — Every Option Explained"
 description: Pick your config.yml version to view the correct documentation and download the exact file that shipped with the plugin.
 ---
 
 ![DiscordLogger](/assets/DiscordLogger-Banner.webp "DiscordLogger")
+
 # Config Docs
 
 Pick the **config schema version** your server is using.

--- a/docs/config/v9/index.md
+++ b/docs/config/v9/index.md
@@ -5,6 +5,7 @@ description: Full documentation for config.yml schema v9 — defaults, per-key e
 ---
 
 ![DiscordLogger](/assets/DiscordLogger-Banner.webp "DiscordLogger")
+
 # config.yml Docs — v9
 
 **_Supported Plugin Versions:_ v2.1.5, v2.1.6**

--- a/docs/downloads/index.md
+++ b/docs/downloads/index.md
@@ -8,7 +8,10 @@ description: Download the latest DiscordLogger release for PaperMC, or opt in to
 
 # Downloads
 
-Latest builds from **GitHub Releases**.
+Latest builds from **GitHub Releases**. Stable releases are also on
+[Modrinth](https://modrinth.com/plugin/discordlogger) and
+[Hangar](https://hangar.papermc.io/LVCHLANN/DiscordLogger) — use either if your host
+or plugin manager installs from them. Nightly builds are only published here.
 
 <div id="dl-downloads-status" class="dl-downloads-status">
   Fetching releases from GitHub…

--- a/docs/downloads/index.md
+++ b/docs/downloads/index.md
@@ -1,10 +1,11 @@
 ---
 layout: default
-title: Downloads
-description: Latest DiscordLogger builds from GitHub Releases.
+title: "Download — Stable and Nightly Builds"
+description: Download the latest DiscordLogger release for PaperMC, or opt in to nightly builds. Free and open source, straight from GitHub Releases.
 ---
 
 ![DiscordLogger](/assets/DiscordLogger-Banner.webp "DiscordLogger")
+
 # Downloads
 
 Latest builds from **GitHub Releases**.

--- a/docs/generator/index.md
+++ b/docs/generator/index.md
@@ -1,10 +1,11 @@
 ---
 layout: default
-title: config.yml Generator
-description: Interactive generator for DiscordLogger config.yml
+title: "config.yml Generator — Build a Config Online"
+description: Build a DiscordLogger config.yml in your browser — pick which Minecraft events get logged, set your Discord webhook, and download the finished file.
 ---
 
 ![DiscordLogger](/assets/DiscordLogger-Banner.webp "DiscordLogger")
+
 # config.yml Generator
 
 Pick your plugin version, test your webhook, then choose what to log. Everything runs in your browser — your webhook URL is never sent anywhere except Discord.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Home
+description: Post Minecraft server events to Discord — joins, quits, chat, deaths and moderation actions, as rich embeds or plain text. Free, open source, and configurable per event.
 ---
 
 ![DiscordLogger](/assets/DiscordLogger-Banner.webp "DiscordLogger")

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,17 @@
 ---
 layout: default
-title: Home
+title: DiscordLogger
 description: Post Minecraft server events to Discord — joins, quits, chat, deaths and moderation actions, as rich embeds or plain text. Free, open source, and configurable per event.
 ---
 
-![DiscordLogger](/assets/DiscordLogger-Banner.webp "DiscordLogger")
+![DiscordLogger — Minecraft server logging to Discord](/assets/DiscordLogger-Banner.webp)
 
-Minecraft → Discord logging that’s clean, configurable, and production-ready.
+# Minecraft server logging to Discord
+
+**DiscordLogger** is a free, open-source Paper plugin that sends your Minecraft server's
+events straight to a Discord channel over a webhook — player joins and quits, chat,
+deaths, advancements, and moderation actions like bans, kicks and whitelist changes.
+Every event is individually configurable, and messages arrive as rich embeds or plain text.
 
 > **Latest plugin:** v<span data-dl-latest>…</span>  
 > **Latest config version:** v9

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,11 @@
+---
+layout: none
+sitemap: false
+---
+User-agent: *
+Allow: /
+
+# Build output and machine-readable data that adds nothing to search results.
+Disallow: /assets/configs/
+
+Sitemap: {{ site.url }}/sitemap.xml

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -1,10 +1,11 @@
 ---
 layout: default
-title: Setup / Install
-description: Install DiscordLogger, set your webhook, and verify everything is working.
+title: "How to Set Up Minecraft Discord Logging"
+description: Step-by-step guide to installing DiscordLogger on a Paper server, creating a Discord webhook, and checking that events are reaching your channel.
 ---
 
 ![DiscordLogger](/assets/DiscordLogger-Banner.webp "DiscordLogger")
+
 # Setup / Install
 
 This guide walks you through installing **DiscordLogger** and getting logs into Discord in minutes.


### PR DESCRIPTION
The site had no SEO at all — no Open Graph, no Twitter cards, no canonical URLs, no sitemap, no robots.txt, no structured data, and no absolute `url` in `_config.yml`.

The most consequential gap: **no Open Graph tags meant sharing the site in Discord produced a bare link with no title, description or image** — for a Discord plugin, that is the single most likely place a link ever gets posted.

## Approach

Uses `jekyll-seo-tag` and `jekyll-sitemap`, both of which ship with the `github-pages` gem and therefore run on GitHub Pages unmodified — no hand-rolled meta tags to drift, and nothing that needs a build step Pages cannot run.

- **`_config.yml`** — added `url` (required for absolute canonical/OG/sitemap URLs), a real site `description`, `lang`, `author`, `logo`, default social image, Twitter card type, and an `exclude` list so `Gemfile`, `test.sh` and the Cloudflare worker are not published.
- **Layout** — replaced the hand-written `<title>` and description with `{% seo %}`.
- **`robots.txt`** — allows everything except `/assets/configs/` (machine-readable generator data that adds nothing to search results) and points crawlers at the sitemap.
- **Homepage** — was the only page with no `description`; now has one.

## Verified in the built output

Homepage `<head>` now emits, all with absolute URLs:

```
<title>Home | DiscordLogger</title>
<link rel="canonical" href="https://discordlogger.godtiergamers.xyz/" />
<meta property="og:title" content="Home" />
<meta property="og:image" content="https://discordlogger.godtiergamers.xyz/assets/DiscordLogger-Banner.webp" />
<meta name="twitter:card" content="summary_large_image" />
```

plus JSON-LD structured data. `sitemap.xml` lists all six pages; every page has a unique title and description; all routes still return 200 and the generator, nav highlighting and version hooks still work.

**One subtlety worth recording:** `og:locale` wants `en_GB` (underscore) while HTML `lang` requires BCP 47 `en-GB` (hyphen). The layout now derives the tag with a `replace` filter so both are correct — my first attempt at that produced malformed markup, which the rendered output caught.

**Known tradeoff:** `og:image` points at the WebP banner. Discord, X and Facebook all render WebP previews; a very old scraper might not. Swapping in a PNG would cost page weight for a case that is now rare, so WebP stays unless something concrete turns up.