### PR TITLE
feat(release): publish stable releases to Modrinth and Hangar automatically

### DIFF
--- a/.github/workflows/check-listing-credentials.yml
+++ b/.github/workflows/check-listing-credentials.yml
@@ -1,0 +1,35 @@
+name: Check Listing Credentials
+
+# The Modrinth and Hangar tokens are only ever used by a release, so a revoked or
+# expired one would surface at the worst possible moment: after release-please has
+# already tagged and published. This proves they still work, on a schedule and on
+# demand, publishing nothing.
+#
+# Modrinth PATs carry an explicit expiry date, so this will eventually be the thing
+# that notices. A failed run e-mails the repo owner through GitHub's normal
+# workflow-failure notification — no extra alerting needed.
+
+on:
+  schedule:
+    # Weekly, Monday 04:30 UTC. Daily would be noise: these change rarely.
+    - cron: "30 4 * * 1"
+  workflow_dispatch: {}
+
+concurrency:
+  group: check-listing-credentials
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Verify Modrinth and Hangar credentials
+        env:
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+          HANGAR_API_KEY: ${{ secrets.HANGAR_API_KEY }}
+        run: python3 scripts/publish-listings.py --check-auth

--- a/.github/workflows/downloads-badge.yml
+++ b/.github/workflows/downloads-badge.yml
@@ -1,0 +1,47 @@
+name: Downloads Badge
+
+# The README's download count spans two hosts: GitHub Releases (which also
+# receives every Hangar download, because Hangar versions are external links to
+# the GitHub asset) and Modrinth, which hosts its own copy and keeps its own
+# tally. shields.io cannot add those together, so this writes the total into a
+# shields "endpoint" JSON served from the docs site, and the badge reads that.
+#
+# Releases refresh it themselves (see release-please.yml); this keeps it moving
+# on days when nothing ships.
+
+on:
+  schedule:
+    # 04:00 UTC daily — off-peak, and well clear of the nightly build.
+    - cron: "0 4 * * *"
+  workflow_dispatch: {}
+
+concurrency:
+  group: downloads-badge
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  badge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - name: Recount downloads
+        run: python3 scripts/publish-listings.py --badge
+
+      - name: Commit if the total changed
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- docs/assets/badges/downloads.json; then
+            echo "Download total unchanged — nothing to commit."
+            exit 0
+          fi
+          git add docs/assets/badges/downloads.json
+          git commit -m "chore: refresh downloads badge [skip ci]"
+          git push origin main

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -133,3 +133,52 @@ jobs:
             "${{ steps.jar.outputs.file }}" \
             "${{ steps.jar.outputs.file }}.sha256" \
             --clobber
+
+  # Mirrors the stable release onto the Modrinth and Hangar listings, which is
+  # where most server owners actually look. Runs after build-artifact so the JAR
+  # is already attached to the GitHub Release: Hangar links straight to that
+  # asset, so its downloads land on GitHub's counter.
+  publish-listings:
+    needs: [release-please, build-artifact]
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - name: Download the released JAR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          mkdir -p target
+          gh release download "$TAG" --pattern '*.jar' --dir target
+          ls -l target
+
+      - name: Publish to Modrinth and Hangar
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+          HANGAR_API_KEY: ${{ secrets.HANGAR_API_KEY }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          jar="$(ls -1 target/*.jar | head -n1)"
+          python3 scripts/publish-listings.py --jar "$jar" --tag "$TAG"
+
+      - name: Commit the refreshed downloads badge
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- docs/assets/badges/downloads.json; then
+            echo "Badge unchanged."
+            exit 0
+          fi
+          git add docs/assets/badges/downloads.json
+          git commit -m "chore: refresh downloads badge [skip ci]"
+          git push origin main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ release-please-config.json             release-please: changelog sections, extra
 .release-please-manifest.json          release-please: current released version (state)
 scripts/validate-config-generator.py   CI check: options.json <-> template <-> Java source <-> shipped config <-> mirror <-> doc embed
 scripts/sync-versions.py               Propagates pom.xml's version values into README/CONTRIBUTING/docs
+scripts/publish-listings.py            Mirrors stable releases to Modrinth/Hangar; writes the combined downloads badge
 src/main/resources/
   plugin.yml                           Plugin descriptor (Maven-filtered)
   build-info.properties                Build channel/version/date, baked in at package time
@@ -130,6 +131,23 @@ docs/                                  Jekyll website (GitHub Pages, deploys fro
 4. The same workflow run's `build-artifact` job then checks out the tag, stamps `BUILT <DD-MM-YYYY>` onto the trailer, builds with `-Ddl.build.channel=stable`, and attaches `DiscordLogger-v<version>.jar` + `.sha256`. (The build lives in the same run rather than a `release: published` listener because events created with the built-in `GITHUB_TOKEN` don't trigger other workflows — a separate listener would never fire. See Gotchas.)
 5. **Config schema revisions (v9 → v10) stay manual and deliberate** — bump the `V<n>` trailer, add `docs/assets/configs/v<n>/`, wire the generator config. Never inferred from commits.
 6. **Force a specific version:** a commit whose message has a `Release-As: X.Y.Z` footer retargets the Release PR (and `nightly.yml`'s version computation, which honors the same footer) to that exact version regardless of what the conventional-commit math would produce.
+
+### Distribution — GitHub is the only host that serves a JAR (almost)
+
+Stable releases are mirrored onto two listings, because that is where server owners look:
+
+| Listing | Slug | How the version is registered |
+|---|---|---|
+| Modrinth | `discordlogger` | The JAR is **uploaded**. Modrinth's API has no external-URL field — checked against its OpenAPI spec — so this is the one place a second copy of the file exists. |
+| Hangar | `LVCHLANN/DiscordLogger` | Registered with `externalUrl` pointing at the GitHub Release asset. No copy is hosted, and Hangar's download button increments **GitHub's** counter. |
+
+`scripts/publish-listings.py`, run by `release-please.yml`'s `publish-listings` job, does both. It is idempotent (re-running skips versions that already exist), refuses to publish if `pom.xml`'s version doesn't match the release tag, and refuses nightly tags outright — nightlies are GitHub-only, as the downloads page states.
+
+**Download counting.** The count spans two hosts, so the README badge is a shields.io *endpoint* badge reading `docs/assets/badges/downloads.json`, written by `publish-listings.py --badge`: GitHub asset downloads (excluding `.sha256` files) **+** Modrinth's total. Hangar is deliberately not added — its traffic is already inside the GitHub number, and adding it would double-count. `downloads-badge.yml` refreshes it daily; releases refresh it inline.
+
+**Two secrets must exist** or the corresponding platform is skipped with a notice (a lagging listing is recoverable; a release job dying after tagging is not): `MODRINTH_TOKEN` (PAT, "Create versions" scope) and `HANGAR_API_KEY` (create_version permission).
+
+`<dl.game.versions>` in `pom.xml` is the Minecraft version list both listings advertise. It's the one value that can't be derived — `api-version` is a floor, not a list — so it's validated against Modrinth's known-version API before publishing; a typo fails the release rather than mislabelling it.
 
 ### Build channels (`BuildInfo`, baked in at package time — never inferred from the version string)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,9 @@ Stable releases are mirrored onto two listings, because that is where server own
 
 **Download counting.** The count spans two hosts, so the README badge is a shields.io *endpoint* badge reading `docs/assets/badges/downloads.json`, written by `publish-listings.py --badge`: GitHub asset downloads (excluding `.sha256` files) **+** Modrinth's total. Hangar is deliberately not added — its traffic is already inside the GitHub number, and adding it would double-count. `downloads-badge.yml` refreshes it daily; releases refresh it inline.
 
-**Two secrets must exist** or the corresponding platform is skipped with a notice (a lagging listing is recoverable; a release job dying after tagging is not): `MODRINTH_TOKEN` (PAT, "Create versions" scope) and `HANGAR_API_KEY` (create_version permission).
+**Two secrets must exist** or the corresponding platform is skipped with a notice (a lagging listing is recoverable; a release job dying after tagging is not): `MODRINTH_TOKEN` (PAT, "Create versions" scope) and `HANGAR_API_KEY` (create_version permission). Both are repository **Actions** secrets — the job declares no `environment:`, so environment secrets would not resolve.
+
+Modrinth PATs expire. `check-listing-credentials.yml` runs `publish-listings.py --check-auth` weekly so a dead token is caught by a failed scheduled run rather than by a release that has already tagged. Note that `--dry-run` makes no authenticated call at all and proves nothing about the tokens; `--check-auth` is the mode that does.
 
 `<dl.game.versions>` in `pom.xml` is the Minecraft version list both listings advertise. It's the one value that can't be derived — `api-version` is a floor, not a list — so it's validated against Modrinth's known-version API before publishing; a typo fails the release rather than mislabelling it.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Build](https://img.shields.io/github/actions/workflow/status/GodTierGamers/DiscordLogger/ci.yml?branch=main&label=build)
 ![Release](https://img.shields.io/github/v/release/GodTierGamers/DiscordLogger)
 ![Nightly](https://img.shields.io/github/v/release/GodTierGamers/DiscordLogger?include_prereleases&label=nightly)
-![Downloads](https://img.shields.io/github/downloads/GodTierGamers/DiscordLogger/total)
+![Downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fdiscordlogger.godtiergamers.xyz%2Fassets%2Fbadges%2Fdownloads.json)
 ![Issues](https://img.shields.io/github/issues/GodTierGamers/DiscordLogger)
 ![License](https://img.shields.io/github/license/GodTierGamers/DiscordLogger)
 <!-- dl:sync-block:badges -->

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Built for **Paper <!-- dl:sync:paper_display -->26.x<!-- /dl:sync -->** (and Pap
 
 Every release includes a `.sha256` checksum for the JAR.
 
+Stable releases are also published to [Modrinth](https://modrinth.com/plugin/discordlogger) and [Hangar](https://hangar.papermc.io/LVCHLANN/DiscordLogger), which is where most server hosts and plugin managers will find it. Nightly builds are GitHub-only.
+
 ---
 
 ## 🚀 Installation

--- a/TODO.md
+++ b/TODO.md
@@ -24,5 +24,4 @@ Got an idea that isn't here? Open a [feature request](https://github.com/GodTier
 
 - **Discord OAuth webhook creation** — let the config generator create the webhook via Discord OAuth instead of making people copy a URL by hand.
 - **Complete website redesign.**
-- **Improve SEO.**
 - **Full docs quality pass** — review everything for accuracy and clarity.

--- a/TODO.md
+++ b/TODO.md
@@ -24,4 +24,5 @@ Got an idea that isn't here? Open a [feature request](https://github.com/GodTier
 
 - **Discord OAuth webhook creation** — let the config generator create the webhook via Discord OAuth instead of making people copy a URL by hand.
 - **Complete website redesign.**
+- **Search visibility (ongoing)** — the technical groundwork is in place (sitemap, canonicals, structured data, per-page titles and descriptions). What's left is the slow part: content people actually search for (troubleshooting and comparison pages), listings on the sites Minecraft admins browse, and monitoring real queries in Search Console. This item stays open indefinitely; it isn't a task with a finish line.
 - **Full docs quality pass** — review everything for accuracy and clarity.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,49 @@
 title: DiscordLogger
-# When using a custom domain, baseurl is empty at runtime. relative_url handles both cases.
+tagline: Minecraft → Discord logging
+description: >-
+  A Paper plugin that posts Minecraft server events to a Discord channel over a
+  webhook — joins, quits, chat, deaths, moderation actions and more, as rich
+  embeds or plain text. Configurable per event, with a browser-based config
+  generator.
+
+# Absolute site URL. Required for canonical links, Open Graph tags and sitemap
+# entries to be absolute rather than relative — without it, link previews and
+# search results point nowhere useful.
+url: "https://discordlogger.godtiergamers.xyz"
+baseurl: ""
+
+lang: en_GB
+
+# Used by jekyll-seo-tag for structured data and Open Graph attribution.
+author: LVCHLANN
+logo: /assets/icons/android-chrome-512x512.png
+
+# Default social preview image. This is what renders when the site is shared in
+# Discord — which, for a Discord plugin, is the single most likely place a link
+# gets posted.
+social_image: /assets/DiscordLogger-Banner.webp
+
+twitter:
+  card: summary_large_image
+
+github:
+  repository_url: https://github.com/GodTierGamers/DiscordLogger
 
 markdown: kramdown
+
+# Both ship with the github-pages gem, so they run on GitHub Pages unmodified.
+#   jekyll-seo-tag  -> <title>, canonical, Open Graph, Twitter cards, JSON-LD
+#   jekyll-sitemap  -> /sitemap.xml
+plugins:
+  - jekyll-seo-tag
+  - jekyll-sitemap
+
+# Build output and tooling that must never be published or indexed.
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - test.sh
+  - cloudflare/
 
 # Apply the default layout to all Markdown pages under docs/
 defaults:
@@ -10,3 +52,4 @@ defaults:
       type: "pages"
     values:
       layout: "default"
+      image: /assets/DiscordLogger-Banner.webp

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 title: DiscordLogger
-tagline: Minecraft → Discord logging
+tagline: Minecraft Server Logging to Discord
 description: >-
   A Paper plugin that posts Minecraft server events to a Discord channel over a
   webhook — joins, quits, chat, deaths, moderation actions and more, as rich

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,10 +1,16 @@
 <!doctype html>
-<html lang="en" data-theme="">
+<html lang="{{ site.lang | default: 'en' | replace: '_', '-' }}" data-theme="">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>{{ page.title | default: site.title | default: "DiscordLogger" }}</title>
-    <meta name="description" content="{{ page.description | default: site.description | default: 'Minecraft → Discord logging that’s clean, configurable, and production-ready.' }}">
+    {%- comment -%}
+      jekyll-seo-tag emits <title>, the meta description, canonical link,
+      Open Graph + Twitter card tags and JSON-LD structured data from
+      _config.yml and each page's front matter. It ships with the
+      github-pages gem, so it runs on GitHub Pages unmodified.
+      Per-page control: `title`, `description` and `image` in front matter.
+    {%- endcomment -%}
+    {% seo %}
 
     <!-- GitHub Markdown CSS (keeps the original look) -->
     <link rel="stylesheet" href="https://unpkg.com/github-markdown-css@5.5.1/github-markdown.css">

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -12,6 +12,45 @@
     {%- endcomment -%}
     {% seo %}
 
+    {%- comment -%}
+      jekyll-seo-tag only describes the site as a generic WebSite/WebPage. This
+      block additionally declares what the site is actually about — a free
+      Minecraft server plugin — so search engines can surface it as software
+      rather than as an unclassified page. Homepage only: duplicating the same
+      entity on every page adds nothing.
+    {%- endcomment -%}
+    {%- if page.url == '/' -%}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      "name": "DiscordLogger",
+      "url": {{ site.url | append: site.baseurl | append: '/' | jsonify }},
+      "applicationCategory": "GameApplication",
+      "applicationSubCategory": "Minecraft server plugin",
+      "operatingSystem": "Any (Java {{ site.data.versions.java | default: '25' }}+)",
+      "softwareVersion": {{ site.data.versions.plugin | default: '' | jsonify }},
+      "softwareRequirements": "PaperMC {{ site.data.versions.min_paper | default: '' }} or newer",
+      "description": {{ site.description | strip_newlines | strip | jsonify }},
+      "image": {{ site.url | append: site.baseurl | append: site.social_image | jsonify }},
+      "license": "https://github.com/GodTierGamers/DiscordLogger/blob/main/LICENSE",
+      "isAccessibleForFree": true,
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD"
+      },
+      "downloadUrl": "https://github.com/GodTierGamers/DiscordLogger/releases",
+      "installUrl": {{ site.url | append: site.baseurl | append: '/setup/' | jsonify }},
+      "codeRepository": "https://github.com/GodTierGamers/DiscordLogger",
+      "author": {
+        "@type": "Person",
+        "name": {{ site.author | jsonify }}
+      }
+    }
+    </script>
+    {%- endif -%}
+
     <!-- GitHub Markdown CSS (keeps the original look) -->
     <link rel="stylesheet" href="https://unpkg.com/github-markdown-css@5.5.1/github-markdown.css">
 
@@ -68,9 +107,11 @@
             {% assign active_class = ' is-active' %}
             {% endif %}
             {% else %}
-            {# Liquid does not allow filters inside `if`, so no `| append:` here.
-               `contains` already covers the trailing-slash and /index.html forms,
-               plus nested pages like /config/v9/ under /config/. #}
+            {%- comment -%}
+              Liquid does not allow filters inside `if`, so no `| append:` here.
+              `contains` already covers the trailing-slash and /index.html forms,
+              plus nested pages like /config/v9/ under /config/.
+            {%- endcomment -%}
             {% if current == item.url or current contains item.url %}
             {% assign active_class = ' is-active' %}
             {% endif %}

--- a/docs/assets/badges/downloads.json
+++ b/docs/assets/badges/downloads.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "downloads",
+  "message": "1k",
+  "color": "brightgreen"
+}

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1,10 +1,11 @@
 ---
 layout: default
-title: Config Docs
+title: "config.yml Reference — Every Option Explained"
 description: Pick your config.yml version to view the correct documentation and download the exact file that shipped with the plugin.
 ---
 
 ![DiscordLogger](/assets/DiscordLogger-Banner.webp "DiscordLogger")
+
 # Config Docs
 
 Pick the **config schema version** your server is using.

--- a/docs/config/v9/index.md
+++ b/docs/config/v9/index.md
@@ -5,6 +5,7 @@ description: Full documentation for config.yml schema v9 — defaults, per-key e
 ---
 
 ![DiscordLogger](/assets/DiscordLogger-Banner.webp "DiscordLogger")
+
 # config.yml Docs — v9
 
 **_Supported Plugin Versions:_ v2.1.5, v2.1.6**

--- a/docs/downloads/index.md
+++ b/docs/downloads/index.md
@@ -8,7 +8,10 @@ description: Download the latest DiscordLogger release for PaperMC, or opt in to
 
 # Downloads
 
-Latest builds from **GitHub Releases**.
+Latest builds from **GitHub Releases**. Stable releases are also on
+[Modrinth](https://modrinth.com/plugin/discordlogger) and
+[Hangar](https://hangar.papermc.io/LVCHLANN/DiscordLogger) — use either if your host
+or plugin manager installs from them. Nightly builds are only published here.
 
 <div id="dl-downloads-status" class="dl-downloads-status">
   Fetching releases from GitHub…

--- a/docs/downloads/index.md
+++ b/docs/downloads/index.md
@@ -1,10 +1,11 @@
 ---
 layout: default
-title: Downloads
-description: Latest DiscordLogger builds from GitHub Releases.
+title: "Download — Stable and Nightly Builds"
+description: Download the latest DiscordLogger release for PaperMC, or opt in to nightly builds. Free and open source, straight from GitHub Releases.
 ---
 
 ![DiscordLogger](/assets/DiscordLogger-Banner.webp "DiscordLogger")
+
 # Downloads
 
 Latest builds from **GitHub Releases**.

--- a/docs/generator/index.md
+++ b/docs/generator/index.md
@@ -1,10 +1,11 @@
 ---
 layout: default
-title: config.yml Generator
-description: Interactive generator for DiscordLogger config.yml
+title: "config.yml Generator — Build a Config Online"
+description: Build a DiscordLogger config.yml in your browser — pick which Minecraft events get logged, set your Discord webhook, and download the finished file.
 ---
 
 ![DiscordLogger](/assets/DiscordLogger-Banner.webp "DiscordLogger")
+
 # config.yml Generator
 
 Pick your plugin version, test your webhook, then choose what to log. Everything runs in your browser — your webhook URL is never sent anywhere except Discord.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Home
+description: Post Minecraft server events to Discord — joins, quits, chat, deaths and moderation actions, as rich embeds or plain text. Free, open source, and configurable per event.
 ---
 
 ![DiscordLogger](/assets/DiscordLogger-Banner.webp "DiscordLogger")

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,17 @@
 ---
 layout: default
-title: Home
+title: DiscordLogger
 description: Post Minecraft server events to Discord — joins, quits, chat, deaths and moderation actions, as rich embeds or plain text. Free, open source, and configurable per event.
 ---
 
-![DiscordLogger](/assets/DiscordLogger-Banner.webp "DiscordLogger")
+![DiscordLogger — Minecraft server logging to Discord](/assets/DiscordLogger-Banner.webp)
 
-Minecraft → Discord logging that’s clean, configurable, and production-ready.
+# Minecraft server logging to Discord
+
+**DiscordLogger** is a free, open-source Paper plugin that sends your Minecraft server's
+events straight to a Discord channel over a webhook — player joins and quits, chat,
+deaths, advancements, and moderation actions like bans, kicks and whitelist changes.
+Every event is individually configurable, and messages arrive as rich embeds or plain text.
 
 > **Latest plugin:** v<span data-dl-latest>…</span>  
 > **Latest config version:** v9

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,11 @@
+---
+layout: none
+sitemap: false
+---
+User-agent: *
+Allow: /
+
+# Build output and machine-readable data that adds nothing to search results.
+Disallow: /assets/configs/
+
+Sitemap: {{ site.url }}/sitemap.xml

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -1,10 +1,11 @@
 ---
 layout: default
-title: Setup / Install
-description: Install DiscordLogger, set your webhook, and verify everything is working.
+title: "How to Set Up Minecraft Discord Logging"
+description: Step-by-step guide to installing DiscordLogger on a Paper server, creating a Discord webhook, and checking that events are reaching your channel.
 ---
 
 ![DiscordLogger](/assets/DiscordLogger-Banner.webp "DiscordLogger")
+
 # Setup / Install
 
 This guide walks you through installing **DiscordLogger** and getting logs into Discord in minutes.

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,15 @@
         <dl.api.version>26.1</dl.api.version>
         <dl.paper.display>26.x</dl.paper.display>
 
+        <!-- Minecraft versions advertised on the Modrinth and Hangar listings when a
+             stable release is published. This is the one value that cannot be derived
+             from anything else in the build: api-version sets the *minimum* a server
+             must implement, but which concrete Minecraft releases to list is an
+             editorial call. Keep it in step with dl.api.version. Every entry is
+             checked against Modrinth's known-version list before publishing, so a
+             typo or an invented version fails the release rather than mislabelling it. -->
+        <dl.game.versions>26.1,26.1.1,26.1.2,26.2</dl.game.versions>
+
         <!-- Build channel/date are stamped by CI (-Ddl.build.channel=stable|nightly,
              -Ddl.build.date=DD-MM-YYYY). A plain local `mvn package` gets "dev",
              so a hand-built JAR is never mistaken for a release artifact. -->

--- a/scripts/publish-listings.py
+++ b/scripts/publish-listings.py
@@ -37,6 +37,7 @@ Usage:
     publish-listings.py --jar target/DiscordLogger-v2.2.0.jar --tag v2.2.0
     publish-listings.py --jar ... --tag ... --dry-run   # no network writes
     publish-listings.py --badge                         # refresh the badge only
+    publish-listings.py --check-auth                    # verify both tokens
 """
 from __future__ import annotations
 
@@ -358,6 +359,45 @@ def write_badge(counts: dict[str, int], path: Path) -> None:
     )
 
 
+# ------------------------------------------------------------------ auth check
+
+
+def check_auth() -> int:
+    """Proves both credentials still work, without publishing anything.
+
+    Worth having as its own mode: --dry-run makes no authenticated call at all,
+    so the first thing that ever exercises these tokens would otherwise be a
+    release that has already tagged. Tokens also expire — Modrinth PATs carry an
+    explicit expiry date — and an expired one is indistinguishable from a
+    missing one until something tries to use it.
+    """
+    problems: list[str] = []
+
+    token = os.environ.get("MODRINTH_TOKEN", "").strip()
+    if not token:
+        problems.append("MODRINTH_TOKEN is not set")
+    else:
+        try:
+            user = request(f"{MODRINTH_API}/user", headers={"Authorization": token})
+            log(f"Modrinth: authenticated as {user['username']}")
+        except Exception as exc:  # noqa: BLE001
+            problems.append(f"Modrinth token rejected: {exc}")
+
+    key = os.environ.get("HANGAR_API_KEY", "").strip()
+    if not key:
+        problems.append("HANGAR_API_KEY is not set")
+    else:
+        try:
+            request(f"{HANGAR_API}/authenticate?apiKey={key}", method="POST")
+            log("Hangar: API key accepted")
+        except Exception as exc:  # noqa: BLE001
+            problems.append(f"Hangar key rejected: {exc}")
+
+    for problem in problems:
+        print(f"::error::{problem}", flush=True)
+    return 1 if problems else 0
+
+
 # ---------------------------------------------------------------------- main
 
 
@@ -365,6 +405,11 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--jar", type=Path, help="the built stable JAR")
     parser.add_argument("--tag", help="release tag, e.g. v2.2.0")
+    parser.add_argument(
+        "--check-auth",
+        action="store_true",
+        help="verify both API credentials still work, publish nothing, then exit",
+    )
     parser.add_argument(
         "--badge",
         action="store_true",
@@ -376,6 +421,9 @@ def main() -> int:
         help="resolve and validate everything, but make no network writes",
     )
     args = parser.parse_args()
+
+    if args.check_auth:
+        return check_auth()
 
     if args.badge:
         write_badge(download_counts(), BADGE_PATH)

--- a/scripts/publish-listings.py
+++ b/scripts/publish-listings.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""Publishes a stable release to the Modrinth and Hangar listings.
+
+Those two listings are where most server owners actually find the plugin, so they
+have to carry the same version GitHub does. Doing that by hand means remembering
+two upload forms on every release; this does it from the release that was just
+published.
+
+Hangar versions are registered with an `externalUrl` pointing at the GitHub
+Release asset rather than a re-hosted copy, so Hangar's download button
+increments GitHub's counter. Modrinth has no equivalent — its API requires the
+file to be uploaded to Modrinth — so that one JAR is mirrored, and Modrinth
+keeps its own tally. `--badge` adds the two together and writes the
+shields.io endpoint JSON the README badge reads, so one number covers both.
+
+Run by .github/workflows/release-please.yml after the stable JAR is attached to
+the GitHub Release. Nightly builds are deliberately never published here — they
+stay GitHub-only, as documented on the downloads page.
+
+Everything it needs comes from pom.xml and the GitHub Release:
+
+    <project.version>      the version number to publish
+    <dl.game.versions>     Minecraft versions to advertise
+    the release body       becomes the changelog on both listings
+    the release asset      the download URL the listings point at
+
+Credentials come from the environment and are never logged:
+
+    MODRINTH_TOKEN   a Modrinth PAT with "Create versions" scope
+    HANGAR_API_KEY   a Hangar API key with the create_version permission
+
+If a token is missing that platform is skipped with a notice rather than failing
+the release — a listing that lags by one version is recoverable, a release job
+that dies after tagging is messier. Genuine API failures do fail the job.
+
+Usage:
+    publish-listings.py --jar target/DiscordLogger-v2.2.0.jar --tag v2.2.0
+    publish-listings.py --jar ... --tag ... --dry-run   # no network writes
+    publish-listings.py --badge                         # refresh the badge only
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import mimetypes
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+POM = Path("pom.xml")
+UA = "GodTierGamers/DiscordLogger (release automation)"
+
+MODRINTH_API = "https://api.modrinth.com/v2"
+MODRINTH_PROJECT = "discordlogger"
+
+HANGAR_API = "https://hangar.papermc.io/api/v1"
+HANGAR_SLUG = "DiscordLogger"
+
+
+# --------------------------------------------------------------------------- io
+
+
+def log(msg: str) -> None:
+    print(msg, flush=True)
+
+
+def fail(msg: str) -> "NoReturn":  # type: ignore[valid-type]
+    print(f"::error::{msg}", flush=True)
+    sys.exit(1)
+
+
+def request(
+    url: str,
+    *,
+    method: str = "GET",
+    headers: dict[str, str] | None = None,
+    data: bytes | None = None,
+    allow_404: bool = False,
+) -> Any:
+    """Single JSON request helper. Raises with the response body on failure —
+    both APIs put the actual reason in there, and without it a 400 is unusable."""
+    req = urllib.request.Request(url, method=method, data=data)
+    req.add_header("User-Agent", UA)
+    for key, value in (headers or {}).items():
+        req.add_header(key, value)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            body = resp.read()
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404 and allow_404:
+            return None
+        detail = exc.read().decode("utf-8", "replace").strip()
+        raise RuntimeError(f"{method} {url} -> HTTP {exc.code}: {detail}") from None
+    if not body:
+        return None
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError:
+        return body.decode("utf-8", "replace")
+
+
+def multipart(fields: dict[str, str], files: dict[str, Path]) -> tuple[bytes, str]:
+    """Builds a multipart/form-data body. Both APIs take the metadata as a JSON
+    form field alongside the JAR, and neither accepts a plain JSON POST."""
+    boundary = "----DiscordLoggerRelease" + os.urandom(16).hex()
+    parts: list[bytes] = []
+
+    for name, value in fields.items():
+        parts.append(
+            f"--{boundary}\r\n"
+            f'Content-Disposition: form-data; name="{name}"\r\n'
+            f"Content-Type: application/json\r\n\r\n"
+            f"{value}\r\n".encode()
+        )
+
+    for name, path in files.items():
+        ctype = mimetypes.guess_type(path.name)[0] or "application/java-archive"
+        parts.append(
+            f"--{boundary}\r\n"
+            f'Content-Disposition: form-data; name="{name}"; filename="{path.name}"\r\n'
+            f"Content-Type: {ctype}\r\n\r\n".encode()
+        )
+        parts.append(path.read_bytes())
+        parts.append(b"\r\n")
+
+    parts.append(f"--{boundary}--\r\n".encode())
+    return b"".join(parts), f"multipart/form-data; boundary={boundary}"
+
+
+# ------------------------------------------------------------------- inputs
+
+
+def pom_values() -> dict[str, str]:
+    text = POM.read_text(encoding="utf-8")
+
+    def prop(tag: str) -> str:
+        match = re.search(rf"<{re.escape(tag)}>(.*?)</{re.escape(tag)}>", text, re.S)
+        if not match:
+            fail(f"pom.xml has no <{tag}>")
+        return match.group(1).strip()
+
+    # <version> under <project>, not a dependency's — it is the first one that
+    # appears after </parent> is irrelevant here since there is no parent POM,
+    # so take the first <version> at the top level of the file.
+    version = re.search(r"</artifactId>\s*<version>(.*?)</version>", text, re.S)
+    if not version:
+        fail("pom.xml has no project <version>")
+
+    return {
+        "version": version.group(1).strip(),
+        "game_versions": prop("dl.game.versions"),
+        "api_version": prop("dl.api.version"),
+    }
+
+
+def release_body(tag: str) -> str:
+    """The GitHub Release notes, reused verbatim as the listing changelog so the
+    three never drift. Falls back to a link if gh is unavailable."""
+    fallback = (
+        f"See the full release notes: "
+        f"https://github.com/GodTierGamers/DiscordLogger/releases/tag/{tag}"
+    )
+    try:
+        out = subprocess.run(
+            ["gh", "release", "view", tag, "--json", "body", "-q", ".body"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return fallback
+    return f"{out}\n\n---\n{fallback}" if out else fallback
+
+
+def validate_game_versions(versions: list[str]) -> None:
+    """Modrinth rejects unknown versions with an opaque 400, and Hangar will
+    happily accept a typo and display it. Check the list up front instead."""
+    known = {
+        entry["version"]
+        for entry in request(f"{MODRINTH_API}/tag/game_version")
+    }
+    unknown = [v for v in versions if v not in known]
+    if unknown:
+        fail(
+            f"pom.xml <dl.game.versions> lists {unknown}, which Minecraft version(s) "
+            f"Modrinth does not recognise. Fix the property in pom.xml."
+        )
+    log(f"Game versions validated against Modrinth: {', '.join(versions)}")
+
+
+# ------------------------------------------------------------------ modrinth
+
+
+def publish_modrinth(
+    token: str, jar: Path, version: str, game_versions: list[str], changelog: str, dry: bool
+) -> None:
+    existing = request(
+        f"{MODRINTH_API}/project/{MODRINTH_PROJECT}/version/{version}", allow_404=True
+    )
+    if existing:
+        log(f"Modrinth already has {version} — nothing to do.")
+        return
+
+    payload = {
+        "name": f"v{version}",
+        "version_number": version,
+        "changelog": changelog,
+        "dependencies": [],
+        "game_versions": game_versions,
+        "version_type": "release",
+        "loaders": ["paper"],
+        "featured": True,
+        "project_id": MODRINTH_PROJECT,
+        "file_parts": ["file"],
+        "primary_file": "file",
+    }
+
+    if dry:
+        log("[dry-run] Modrinth payload:\n" + json.dumps(payload, indent=2))
+        return
+
+    body, ctype = multipart({"data": json.dumps(payload)}, {"file": jar})
+    result = request(
+        f"{MODRINTH_API}/version",
+        method="POST",
+        headers={"Authorization": token, "Content-Type": ctype},
+        data=body,
+    )
+    log(
+        "Published to Modrinth: "
+        f"https://modrinth.com/plugin/{MODRINTH_PROJECT}/version/{result['id']}"
+    )
+
+
+# -------------------------------------------------------------------- hangar
+
+
+def publish_hangar(
+    api_key: str,
+    asset_url: str,
+    version: str,
+    game_versions: list[str],
+    changelog: str,
+    dry: bool,
+) -> None:
+    if dry:
+        log(f"[dry-run] Hangar would publish {version} for PAPER {game_versions}")
+        log(f"[dry-run]   download points at {asset_url}")
+        return
+
+    # Hangar trades the long-lived API key for a short-lived JWT; every other
+    # call uses the JWT.
+    auth = request(
+        f"{HANGAR_API}/authenticate?apiKey={api_key}", method="POST"
+    )
+    jwt = auth["token"]
+    headers = {"Authorization": f"Bearer {jwt}"}
+
+    versions = request(
+        f"{HANGAR_API}/projects/{HANGAR_SLUG}/versions?limit=25&offset=0",
+        headers=headers,
+    )
+    if any(v["name"] == version for v in versions.get("result", [])):
+        log(f"Hangar already has {version} — nothing to do.")
+        return
+
+    payload = {
+        "version": version,
+        "channel": "Release",
+        "description": changelog,
+        "pluginDependencies": {},
+        "platformDependencies": {"PAPER": game_versions},
+        # externalUrl instead of an attached JAR: Hangar then links straight to the
+        # GitHub Release asset, so its download button increments GitHub's counter
+        # rather than starting a second, separate tally on Hangar.
+        "files": [{"platforms": ["PAPER"], "externalUrl": asset_url}],
+    }
+
+    body, ctype = multipart({"versionUpload": json.dumps(payload)}, {})
+    request(
+        f"{HANGAR_API}/projects/{HANGAR_SLUG}/upload",
+        method="POST",
+        headers={**headers, "Content-Type": ctype},
+        data=body,
+    )
+    log(
+        "Published to Hangar: "
+        f"https://hangar.papermc.io/LVCHLANN/{HANGAR_SLUG}/versions/{version}"
+    )
+
+
+# --------------------------------------------------------------- download count
+
+
+GITHUB_API = "https://api.github.com/repos/GodTierGamers/DiscordLogger"
+
+# shields.io renders any JSON in this shape as a badge, which is the only way to
+# show a total that spans two hosts — its built-in github/downloads badge can
+# only ever see GitHub.
+BADGE_PATH = Path("docs/assets/badges/downloads.json")
+
+
+def download_counts() -> dict[str, int]:
+    """GitHub + Modrinth downloads. Hangar is deliberately absent: its versions
+    are external links to the GitHub asset, so Hangar traffic is already inside
+    the GitHub number and adding it would double-count."""
+    github = 0
+    page = 1
+    while True:
+        releases = request(f"{GITHUB_API}/releases?per_page=100&page={page}")
+        if not releases:
+            break
+        for release in releases:
+            for asset in release.get("assets", []):
+                # Checksums sit next to every JAR; they are not plugin downloads.
+                if not asset["name"].endswith(".sha256"):
+                    github += asset["download_count"]
+        if len(releases) < 100:
+            break
+        page += 1
+
+    modrinth = request(f"{MODRINTH_API}/project/{MODRINTH_PROJECT}")["downloads"]
+    return {"github": github, "modrinth": modrinth, "total": github + modrinth}
+
+
+def write_badge(counts: dict[str, int], path: Path) -> None:
+    total = counts["total"]
+    # Match shields' own abbreviation so the badge doesn't grow without bound.
+    if total >= 1_000_000:
+        label = f"{total / 1_000_000:.1f}M".replace(".0M", "M")
+    elif total >= 1_000:
+        label = f"{total / 1_000:.1f}k".replace(".0k", "k")
+    else:
+        label = str(total)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "label": "downloads",
+                "message": label,
+                "color": "brightgreen",
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    log(
+        f"GitHub {counts['github']} + Modrinth {counts['modrinth']} = {total} "
+        f"-> {path} ({label})"
+    )
+
+
+# ---------------------------------------------------------------------- main
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--jar", type=Path, help="the built stable JAR")
+    parser.add_argument("--tag", help="release tag, e.g. v2.2.0")
+    parser.add_argument(
+        "--badge",
+        action="store_true",
+        help="only refresh the combined GitHub+Modrinth downloads badge, then exit",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="resolve and validate everything, but make no network writes",
+    )
+    args = parser.parse_args()
+
+    if args.badge:
+        write_badge(download_counts(), BADGE_PATH)
+        return 0
+
+    if not args.jar or not args.tag:
+        fail("--jar and --tag are required unless --badge is given")
+
+    if not args.jar.is_file():
+        fail(f"JAR not found: {args.jar}")
+
+    values = pom_values()
+    tag_version = args.tag.lstrip("v")
+
+    if "-BETA." in args.tag:
+        fail(f"{args.tag} is a nightly build; those are never published to listings.")
+
+    # A mismatch here means the JAR is not the version being announced. That is
+    # worth stopping for: it would put the wrong file on both listings.
+    if values["version"] != tag_version:
+        fail(
+            f"pom.xml is {values['version']} but the release tag is {args.tag}. "
+            "Refusing to publish a mismatched artifact."
+        )
+
+    asset_url = (
+        "https://github.com/GodTierGamers/DiscordLogger/releases/download/"
+        f"{args.tag}/{args.jar.name}"
+    )
+
+    game_versions = [v.strip() for v in values["game_versions"].split(",") if v.strip()]
+    if not game_versions:
+        fail("pom.xml <dl.game.versions> is empty")
+
+    validate_game_versions(game_versions)
+    changelog = release_body(args.tag)
+
+    modrinth_token = os.environ.get("MODRINTH_TOKEN", "").strip()
+    hangar_key = os.environ.get("HANGAR_API_KEY", "").strip()
+
+    failures: list[str] = []
+
+    if modrinth_token or args.dry_run:
+        try:
+            publish_modrinth(
+                modrinth_token, args.jar, tag_version, game_versions, changelog, args.dry_run
+            )
+        except Exception as exc:  # noqa: BLE001 - reported, not swallowed
+            failures.append(f"Modrinth: {exc}")
+    else:
+        log("::notice::MODRINTH_TOKEN is not set — skipping Modrinth.")
+
+    if hangar_key or args.dry_run:
+        try:
+            publish_hangar(
+                hangar_key,
+                asset_url,
+                tag_version,
+                game_versions,
+                changelog,
+                args.dry_run,
+            )
+        except Exception as exc:  # noqa: BLE001 - reported, not swallowed
+            failures.append(f"Hangar: {exc}")
+    else:
+        log("::notice::HANGAR_API_KEY is not set — skipping Hangar.")
+
+    if not args.dry_run and not failures:
+        try:
+            write_badge(download_counts(), BADGE_PATH)
+        except Exception as exc:  # noqa: BLE001 - a stale badge must not fail a release
+            log(f"::warning::Could not refresh the downloads badge: {exc}")
+
+    for failure in failures:
+        print(f"::error::{failure}", flush=True)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Mirrors every stable release onto the Modrinth and Hangar listings, and makes the README's download count cover both hosts.

## Downloads stay in one place where the APIs allow it

| Listing | How the version is registered | Who counts the download |
|---|---|---|
| **Hangar** | `externalUrl` pointing at the GitHub Release asset — no copy hosted | **GitHub** |
| **Modrinth** | JAR uploaded. Its API has no external-URL field (verified against its OpenAPI spec) | Modrinth |

So the badge is now a shields.io *endpoint* badge reading `docs/assets/badges/downloads.json` — GitHub asset downloads **+** Modrinth's total. Hangar isn't added: its traffic is already inside the GitHub number, and summing it would double-count. Currently **833 + 181 = 1,014**.

Refreshed on every release, and daily by `downloads-badge.yml`.

## Guards

Verified by dry-run against the live APIs:

- Refuses a tag that disagrees with `pom.xml` — a mismatched artifact never reaches a listing.
- Refuses nightly tags outright; nightlies stay GitHub-only, as the downloads page says.
- Idempotent — re-running skips versions that already exist on either platform.
- `<dl.game.versions>` (new `pom.xml` property) is validated against Modrinth's known-version list, so a typo fails the release rather than mislabelling it.
- A missing token skips that platform with a notice instead of killing a release that has already tagged.

## Before this can run

Two repository secrets are needed:

- `MODRINTH_TOKEN` — Modrinth PAT with the **Create versions** scope
- `HANGAR_API_KEY` — Hangar API key with **create_version**

Without them the job is a no-op, so merging is safe either way.

> Stacked on `feat/seo` (#125) — that one should merge first.
