### PR TITLE
fix(release): explain Modrinth's 401 and document the scope --check-auth needs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,9 +145,18 @@ Stable releases are mirrored onto two listings, because that is where server own
 
 **Download counting.** The count spans two hosts, so the README badge is a shields.io *endpoint* badge reading `docs/assets/badges/downloads.json`, written by `publish-listings.py --badge`: GitHub asset downloads (excluding `.sha256` files) **+** Modrinth's total. Hangar is deliberately not added — its traffic is already inside the GitHub number, and adding it would double-count. `downloads-badge.yml` refreshes it daily; releases refresh it inline.
 
-**Two secrets must exist** or the corresponding platform is skipped with a notice (a lagging listing is recoverable; a release job dying after tagging is not): `MODRINTH_TOKEN` (PAT, "Create versions" **and** "Read user info" scopes) and `HANGAR_API_KEY` (create_version permission). Both are repository **Actions** secrets — the job declares no `environment:`, so environment secrets would not resolve.
+**Two secrets must exist** or the corresponding platform is skipped with a notice (a lagging listing is recoverable; a release job dying after tagging is not): `MODRINTH_TOKEN` (PAT, "Create versions" **plus one read scope** — either "Read analytics" or "Read user info") and `HANGAR_API_KEY` (create_version permission). Both are repository **Actions** secrets — the job declares no `environment:`, so environment secrets would not resolve.
 
-Modrinth's `VERSION_CREATE` scope covers exactly one endpoint — the publish call — so a token holding only that scope cannot be verified without actually publishing. `USER_READ` is therefore required in addition, purely so `--check-auth` has a harmless authenticated endpoint to hit. Modrinth answers both "expired" and "wrong scopes" with a bare 401, so the script's error names both possibilities.
+Modrinth's `VERSION_CREATE` scope covers exactly one endpoint — the publish call — so a token holding only that scope cannot be verified without actually publishing. One read scope is therefore required in addition, purely to give `--check-auth` a harmless authenticated endpoint. It probes two and passes if **either** answers, so it doesn't care which was granted:
+
+| Probe | Scope | Note |
+|---|---|---|
+| `GET /v3/analytics/downloads` | Read analytics | Analytics exists only on **v3**; v2 returns 404. `project_ids` must be percent-encoded — sent raw, it 400s *before* auth is checked, which would silently defeat the probe. |
+| `GET /v2/user` | Read user info | |
+
+Modrinth answers both "expired" and "wrong scopes" with a bare 401, so the failure message names both possibilities rather than implying the token is dead.
+
+The downloads badge does **not** use analytics — Modrinth's public project endpoint already exposes the total with no auth at all. Analytics would only be needed for time-series or per-version breakdowns.
 
 Modrinth PATs expire. `check-listing-credentials.yml` runs `publish-listings.py --check-auth` weekly so a dead token is caught by a failed scheduled run rather than by a release that has already tagged. Note that `--dry-run` makes no authenticated call at all and proves nothing about the tokens; `--check-auth` is the mode that does.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,9 @@ Stable releases are mirrored onto two listings, because that is where server own
 
 **Download counting.** The count spans two hosts, so the README badge is a shields.io *endpoint* badge reading `docs/assets/badges/downloads.json`, written by `publish-listings.py --badge`: GitHub asset downloads (excluding `.sha256` files) **+** Modrinth's total. Hangar is deliberately not added — its traffic is already inside the GitHub number, and adding it would double-count. `downloads-badge.yml` refreshes it daily; releases refresh it inline.
 
-**Two secrets must exist** or the corresponding platform is skipped with a notice (a lagging listing is recoverable; a release job dying after tagging is not): `MODRINTH_TOKEN` (PAT, "Create versions" scope) and `HANGAR_API_KEY` (create_version permission). Both are repository **Actions** secrets — the job declares no `environment:`, so environment secrets would not resolve.
+**Two secrets must exist** or the corresponding platform is skipped with a notice (a lagging listing is recoverable; a release job dying after tagging is not): `MODRINTH_TOKEN` (PAT, "Create versions" **and** "Read user info" scopes) and `HANGAR_API_KEY` (create_version permission). Both are repository **Actions** secrets — the job declares no `environment:`, so environment secrets would not resolve.
+
+Modrinth's `VERSION_CREATE` scope covers exactly one endpoint — the publish call — so a token holding only that scope cannot be verified without actually publishing. `USER_READ` is therefore required in addition, purely so `--check-auth` has a harmless authenticated endpoint to hit. Modrinth answers both "expired" and "wrong scopes" with a bare 401, so the script's error names both possibilities.
 
 Modrinth PATs expire. `check-listing-credentials.yml` runs `publish-listings.py --check-auth` weekly so a dead token is caught by a failed scheduled run rather than by a release that has already tagged. Note that `--dry-run` makes no authenticated call at all and proves nothing about the tokens; `--check-auth` is the mode that does.
 

--- a/scripts/publish-listings.py
+++ b/scripts/publish-listings.py
@@ -26,8 +26,9 @@ Everything it needs comes from pom.xml and the GitHub Release:
 
 Credentials come from the environment and are never logged:
 
-    MODRINTH_TOKEN   a Modrinth PAT with the "Create versions" scope, plus
-                     "Read user info" so --check-auth can verify it
+    MODRINTH_TOKEN   a Modrinth PAT with the "Create versions" scope, plus either
+                     "Read analytics" or "Read user info" so --check-auth can
+                     verify it without publishing anything
     HANGAR_API_KEY   a Hangar API key with the create_version permission
 
 If a token is missing that platform is skipped with a notice rather than failing
@@ -50,6 +51,7 @@ import re
 import subprocess
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import Any
@@ -58,6 +60,8 @@ POM = Path("pom.xml")
 UA = "GodTierGamers/DiscordLogger (release automation)"
 
 MODRINTH_API = "https://api.modrinth.com/v2"
+# Analytics only exists on v3; v2 returns 404 for it. Used solely by --check-auth.
+MODRINTH_API_V3 = "https://api.modrinth.com/v3"
 MODRINTH_PROJECT = "discordlogger"
 
 HANGAR_API = "https://hangar.papermc.io/api/v1"
@@ -378,23 +382,40 @@ def check_auth() -> int:
     if not token:
         problems.append("MODRINTH_TOKEN is not set")
     else:
-        try:
-            user = request(f"{MODRINTH_API}/user", headers={"Authorization": token})
-            log(f"Modrinth: authenticated as {user['username']}")
-        except Exception as exc:  # noqa: BLE001
-            # Modrinth returns a bare 401 for both "this token is dead" and "this
-            # token lacks USER_READ", so the message has to name both. There is no
-            # read-only endpoint a VERSION_CREATE-only token can reach — that scope
-            # appears on exactly one endpoint, the publish call — so USER_READ is
-            # required purely to make the token checkable without publishing.
-            hint = (
-                " — a 401 here means either the token has expired/been revoked, or "
-                "it is missing the USER_READ scope. Publishing needs VERSION_CREATE; "
-                "this check needs USER_READ as well."
-                if "401" in str(exc)
-                else ""
+        # VERSION_CREATE covers exactly one endpoint — the publish call — so the
+        # token cannot be verified without an additional read scope. Either of
+        # these will do, so whichever scope the PAT was granted, the check works:
+        #   /v3/analytics/downloads   "Read analytics"
+        #   /v2/user                  "Read user info"
+        # Only if BOTH are rejected is the token genuinely dead or unscoped.
+        probes = (
+            (
+                "analytics",
+                f"{MODRINTH_API_V3}/analytics/downloads?"
+                + urllib.parse.urlencode(
+                    {"project_ids": json.dumps([MODRINTH_PROJECT])}
+                ),
+            ),
+            ("user", f"{MODRINTH_API}/user"),
+        )
+        errors: list[str] = []
+        for name, url in probes:
+            try:
+                request(url, headers={"Authorization": token})
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"{name}: {exc}")
+                continue
+            log(f"Modrinth: token accepted ({name} scope)")
+            break
+        else:
+            problems.append(
+                "Modrinth token rejected on every probe. This means the token has "
+                "expired or been revoked, OR it holds neither the 'Read analytics' "
+                "nor the 'Read user info' scope — Modrinth answers both cases with a "
+                "bare 401. Publishing itself only needs 'Create versions'; one read "
+                "scope exists purely so the token can be checked without publishing. "
+                + " | ".join(errors)
             )
-            problems.append(f"Modrinth token rejected: {exc}{hint}")
 
     key = os.environ.get("HANGAR_API_KEY", "").strip()
     if not key:

--- a/scripts/publish-listings.py
+++ b/scripts/publish-listings.py
@@ -26,7 +26,8 @@ Everything it needs comes from pom.xml and the GitHub Release:
 
 Credentials come from the environment and are never logged:
 
-    MODRINTH_TOKEN   a Modrinth PAT with "Create versions" scope
+    MODRINTH_TOKEN   a Modrinth PAT with the "Create versions" scope, plus
+                     "Read user info" so --check-auth can verify it
     HANGAR_API_KEY   a Hangar API key with the create_version permission
 
 If a token is missing that platform is skipped with a notice rather than failing
@@ -381,7 +382,19 @@ def check_auth() -> int:
             user = request(f"{MODRINTH_API}/user", headers={"Authorization": token})
             log(f"Modrinth: authenticated as {user['username']}")
         except Exception as exc:  # noqa: BLE001
-            problems.append(f"Modrinth token rejected: {exc}")
+            # Modrinth returns a bare 401 for both "this token is dead" and "this
+            # token lacks USER_READ", so the message has to name both. There is no
+            # read-only endpoint a VERSION_CREATE-only token can reach — that scope
+            # appears on exactly one endpoint, the publish call — so USER_READ is
+            # required purely to make the token checkable without publishing.
+            hint = (
+                " — a 401 here means either the token has expired/been revoked, or "
+                "it is missing the USER_READ scope. Publishing needs VERSION_CREATE; "
+                "this check needs USER_READ as well."
+                if "401" in str(exc)
+                else ""
+            )
+            problems.append(f"Modrinth token rejected: {exc}{hint}")
 
     key = os.environ.get("HANGAR_API_KEY", "").strip()
     if not key:


### PR DESCRIPTION
The weekly credential check failed on its first real run against Modrinth with a bare 401.

The token is most likely fine. Per Modrinth's OpenAPI spec, `VERSION_CREATE` appears on exactly **one** endpoint — the publish call itself — so a token scoped only for publishing has no read-only endpoint it can hit, and `/v2/user` (which `--check-auth` uses) requires `USER_READ`.

Modrinth returns the same bare 401 for an expired token and an under-scoped one, so the error message now names both causes instead of implying the token is dead. Docs updated to ask for both scopes.

**Action needed:** add the **Read user info** (`USER_READ`) scope to the existing Modrinth PAT — read-only, and it does not change what publishing can do. No need to regenerate the token unless the scope can't be edited after creation.