### PR TITLE
feat(command): add /discordlogger webhook, and prefix the nightly chat notice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,7 +234,9 @@ Path-filtered (`dorny/paths-filter`): `build` runs on `src/**`/`pom.xml` changes
 
 ### Commands
 - Root `/discordlogger` (aliases `/dlogger`, `/dlog`). The **command itself is deliberately ungated** — it used to require `discordlogger.reload`, which would have locked a `regen`-only admin out of the whole command once a second subcommand existed. `Commands` routes `Subcommand` implementations (LinkedHashMap) and filters both help and tab-complete by each subcommand's own permission, so an unprivileged sender sees nothing and can run nothing.
-- Subcommands: `reload` (`discordlogger.reload`) and `regen` (`discordlogger.regen`), both default op. `regen` requires a literal `confirm` argument — it is destructive and one keystroke from `reload`.
+- Subcommands, all default op: `reload` (`discordlogger.reload`), `webhook <url>` (`discordlogger.webhook`), `regen confirm` (`discordlogger.regen`). `regen` requires the literal `confirm` — it is destructive and one keystroke from `reload`.
+- **`webhook` never echoes the URL.** It is a bearer credential, so confirmation names the channel id only, tab-complete returns nothing, and `Log.redactWebhooks` masks the token in command logging — without which running the command would publish the new URL to the channel currently configured, i.e. the old webhook. Redacting rather than suppressing keeps the audit trail: you still see that someone changed it.
+- **Never write config with `saveConfig()`.** Bukkit's YAML writer re-serialises the whole file and drops every comment, including the `CONFIG VERSION V<n>` trailer `ConfigMigrator` reads — a config saved that way looks like it has no schema at all. Use `ConfigMigrator.setScalar(file, path, value)`, which rewrites exactly one line (verified: one line changed, comment and line counts unchanged, trailer intact).
 - Adding one: implement `Subcommand`, add to the `new Commands(...)` varargs in `onEnable`, register any new permission in `plugin.yml`.
 
 ### `UpdateChecker`

--- a/src/main/java/com/discordlogger/DiscordLogger.java
+++ b/src/main/java/com/discordlogger/DiscordLogger.java
@@ -3,6 +3,7 @@ package com.discordlogger;
 import com.discordlogger.command.Commands;
 import com.discordlogger.command.Regen;
 import com.discordlogger.command.Reload;
+import com.discordlogger.command.Webhook;
 import com.discordlogger.config.ConfigMigrator;
 import com.discordlogger.config.ConfigVersionNotice;
 import com.discordlogger.event.EventRegistry;
@@ -49,7 +50,7 @@ public final class DiscordLogger extends JavaPlugin {
         boolean ok = applyRuntimeConfig();
         if (!ok) {
             getLogger().warning("No valid Discord webhook URL in config.yml. Please add the webhook URL.");
-            getLogger().warning("Set webhook.url and run /discordlogger reload to enable Discord posting.");
+            getLogger().warning("Set it with /discordlogger webhook <url>, or edit config.yml and run /discordlogger reload.");
         }
 
         // Start the webhook sender before any listener can produce a message.
@@ -60,7 +61,7 @@ public final class DiscordLogger extends JavaPlugin {
         events.registerAll();
 
         if (getCommand("discordlogger") != null) {
-            Commands router = new Commands(new Reload(this), new Regen(this));
+            Commands router = new Commands(new Reload(this), new Webhook(this), new Regen(this));
             getCommand("discordlogger").setExecutor(router);
             getCommand("discordlogger").setTabCompleter(router);
         }

--- a/src/main/java/com/discordlogger/command/Webhook.java
+++ b/src/main/java/com/discordlogger/command/Webhook.java
@@ -1,0 +1,108 @@
+package com.discordlogger.command;
+
+import com.discordlogger.DiscordLogger;
+import com.discordlogger.config.ConfigMigrator;
+import com.discordlogger.log.Log;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Sets {@code webhook.url} and reloads, so a server can be wired up without
+ * opening a file at all — the step most people get stuck on.
+ *
+ * <p>The URL is a bearer credential: anyone holding it can post to that channel.
+ * Two consequences are handled here rather than left to the user:
+ *
+ * <ul>
+ *   <li>It is never echoed back. Confirmation names the channel id only, so the
+ *       secret does not end up in a screenshot or a stream.</li>
+ *   <li>Command logging redacts it ({@link Log#redactWebhooks}), so running this
+ *       does not publish the new URL to the channel the plugin is currently
+ *       posting to — which, when changing webhooks, is the old one.</li>
+ * </ul>
+ *
+ * <p>The file is edited surgically rather than through Bukkit's config writer,
+ * which would strip every comment and the schema trailer. See
+ * {@link ConfigMigrator#setScalar}.
+ */
+public final class Webhook implements Subcommand {
+
+    private final DiscordLogger plugin;
+
+    public Webhook(DiscordLogger plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override public String name() { return "webhook"; }
+    @Override public String description() { return "Sets the Discord webhook URL and reloads."; }
+    @Override public String permission() { return "discordlogger.webhook"; }
+
+    @Override
+    public boolean execute(CommandSender sender, String[] args) {
+        if (args.length == 0) {
+            sender.sendMessage(ChatColor.YELLOW + "Usage: " + ChatColor.WHITE
+                    + "/discordlogger webhook <url>");
+            sender.sendMessage(ChatColor.GRAY
+                    + "Create one in Discord under Channel Settings > Integrations > Webhooks.");
+            if (sender instanceof Player) {
+                sender.sendMessage(ChatColor.GRAY
+                        + "Anyone who sees the URL can post to that channel, so avoid typing it "
+                        + "on a shared screen. It is never shown back to you.");
+            }
+            return true;
+        }
+
+        final String url = args[0].trim();
+
+        if (!Log.isValidWebhookUrl(url)) {
+            sender.sendMessage(ChatColor.RED + "That doesn't look like a Discord webhook URL.");
+            sender.sendMessage(ChatColor.GRAY
+                    + "Expected: https://discord.com/api/webhooks/<id>/<token>");
+            return true;
+        }
+
+        final File configFile = new File(plugin.getDataFolder(), "config.yml");
+        if (!ConfigMigrator.setScalar(configFile, "webhook.url", url)) {
+            sender.sendMessage(ChatColor.RED
+                    + "Could not write webhook.url to config.yml. Check the file exists and is writable.");
+            return true;
+        }
+
+        plugin.reloadConfig();
+        final boolean ok = plugin.applyRuntimeConfig();
+
+        if (ok) {
+            sender.sendMessage(ChatColor.GREEN + "Webhook set and reloaded — logging to channel "
+                    + channelId(url) + ".");
+        } else {
+            // setScalar succeeded and the URL passed the format check, so this means
+            // the reload rejected it for some other reason -- worth saying plainly
+            // rather than reporting success.
+            sender.sendMessage(ChatColor.RED
+                    + "Saved, but the plugin did not accept it. Check config.yml and the console.");
+        }
+
+        // Console record without the token, so the server log is safe to share.
+        plugin.getLogger().info("webhook.url updated by " + sender.getName()
+                + " (channel " + channelId(url) + ")");
+        return true;
+    }
+
+    /** The id half of the URL — enough to confirm the right channel, useless as a credential. */
+    private static String channelId(String url) {
+        String[] parts = url.split("/");
+        return parts.length >= 2 ? parts[parts.length - 2] : "unknown";
+    }
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String[] args) {
+        // Never suggest anything: a completion list is exactly where a previously
+        // typed webhook URL would resurface in front of someone else.
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/com/discordlogger/config/ConfigMigrator.java
+++ b/src/main/java/com/discordlogger/config/ConfigMigrator.java
@@ -53,6 +53,35 @@ public final class ConfigMigrator {
         return shipped > installed ? Status.UPGRADED : Status.AHEAD;
     }
 
+    /**
+     * Rewrites one scalar in config.yml in place, leaving every other byte alone.
+     *
+     * <p>Deliberately not {@code plugin.getConfig().set(...)} + {@code saveConfig()}:
+     * that re-serialises the whole file through Bukkit's YAML writer, which drops
+     * every comment — the banners, the per-option explanations, and, fatally, the
+     * {@code CONFIG VERSION V<n>} trailer this class reads to decide whether to
+     * migrate. A config saved that way would look like it had no schema at all.
+     *
+     * @return true if the key was found and rewritten
+     */
+    public static boolean setScalar(File configFile, String path, Object value) {
+        try {
+            List<String> lines = new ArrayList<>(
+                    Arrays.asList(Files.readString(configFile.toPath(), StandardCharsets.UTF_8)
+                            .split("\r?\n", -1)));
+            List<String> reference = List.copyOf(lines);
+            if (findLeafLine(reference, path) == null) return false;
+
+            replaceLeafValueInDefault(lines, reference, path, value);
+            Files.writeString(configFile.toPath(), String.join("\n", lines),
+                    StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            return true;
+        } catch (Exception ex) {
+            return false;
+        }
+    }
+
     /** The config schema number baked into this JAR. Null if the trailer is missing. */
     public static Integer shippedVersion(JavaPlugin plugin, String resourcePath) {
         try (InputStream in = plugin.getResource(resourcePath)) {

--- a/src/main/java/com/discordlogger/listener/player/PlayerCommand.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerCommand.java
@@ -19,7 +19,7 @@ public final class PlayerCommand implements Listener {
         if (!plugin.getConfig().getBoolean("log.player.command.enabled", true)) return;
 
         String who = Names.display(e.getPlayer(), plugin);
-        String cmd = Log.mdEscape(e.getMessage()); // includes leading '/'
+        String cmd = Log.mdEscape(Log.redactWebhooks(e.getMessage())); // includes leading '/'
         String msg = who + " ran: " + cmd;
         Log.eventWithThumb("Player Command", msg, Log.playerAvatarUrl(e.getPlayer().getUniqueId()));
     }

--- a/src/main/java/com/discordlogger/listener/server/ServerCommand.java
+++ b/src/main/java/com/discordlogger/listener/server/ServerCommand.java
@@ -18,7 +18,7 @@ public final class ServerCommand implements Listener {
     public void onServerCommand(ServerCommandEvent e) {
         if (!plugin.getConfig().getBoolean("log.server.command.enabled", true)) return;
         final String who = Log.mdEscape(e.getSender().getName()); // "Server" for console
-        final String cmd = Log.mdEscape("/" + e.getCommand());
+        final String cmd = Log.mdEscape(Log.redactWebhooks("/" + e.getCommand()));
         Log.eventWithThumb("Server Command", who + " ran: " + cmd, THUMB_SERVER);
     }
 }

--- a/src/main/java/com/discordlogger/log/Log.java
+++ b/src/main/java/com/discordlogger/log/Log.java
@@ -156,7 +156,7 @@ public final class Log {
 
     // ---- Internal utilities ----
 
-    private static boolean isValidWebhookUrl(String url) {
+    public static boolean isValidWebhookUrl(String url) {
         if (url == null || url.isBlank()) return false;
         return url.startsWith("https://discord.com/api/webhooks/")
                 || url.startsWith("https://discordapp.com/api/webhooks/")
@@ -200,6 +200,25 @@ public final class Log {
     }
 
     /** Minimal Markdown escape for names/messages. */
+    /**
+     * Masks the secret half of any Discord webhook URL in text bound for Discord.
+     *
+     * <p>A webhook URL is a bearer credential: anyone holding it can post to that
+     * channel. Command logging echoes whatever was typed, so without this,
+     * {@code /discordlogger webhook <url>} would publish the new URL to the
+     * channel — quite possibly the OLD webhook, i.e. the one being moved away
+     * from. Redacting the token rather than suppressing the command keeps the
+     * audit trail: you still see that someone changed it, just not to what.
+     */
+    public static String redactWebhooks(String s) {
+        if (s == null || s.isEmpty()) return s;
+        return WEBHOOK_URL_RE.matcher(s).replaceAll("$1/***");
+    }
+
+    private static final java.util.regex.Pattern WEBHOOK_URL_RE =
+            java.util.regex.Pattern.compile(
+                    "(https://(?:ptb\\.|canary\\.)?discord(?:app)?\\.com/api/webhooks/\\d+)/\\S+");
+
     public static String mdEscape(String s) {
         if (s == null) return "";
         return s.replace("\\", "\\\\")

--- a/src/main/java/com/discordlogger/update/NightlyNotice.java
+++ b/src/main/java/com/discordlogger/update/NightlyNotice.java
@@ -1,5 +1,6 @@
 package com.discordlogger.update;
 
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -18,10 +19,17 @@ import java.nio.file.Files;
  * why that's build-time-baked rather than parsed from the version string.
  */
 public final class NightlyNotice implements Listener {
+    /** Console form: the logger already prefixes "[DiscordLogger]", so no prefix here. */
     private static final String MESSAGE =
             "This is a nightly release, it may be unstable and have bugs, "
                     + "it is recommended to upgrade frequently, you can upgrade at "
                     + "https://discordlogger.godtiergamers.xyz";
+
+    /** Chat form: nothing prefixes in-game messages, so say who is talking. */
+    private static final String CHAT_MESSAGE =
+            ChatColor.GOLD + "[DiscordLogger] " + ChatColor.YELLOW
+                    + "This is a nightly build — it may be unstable. Upgrade often: "
+                    + ChatColor.WHITE + "https://discordlogger.godtiergamers.xyz";
 
     private final boolean announceToOpsThisBoot;
 
@@ -44,7 +52,7 @@ public final class NightlyNotice implements Listener {
     public void onJoin(PlayerJoinEvent e) {
         Player p = e.getPlayer();
         if (p.isOp()) {
-            p.sendMessage(MESSAGE);
+            p.sendMessage(CHAT_MESSAGE);
         }
     }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,12 +8,15 @@ description: Logs server events to a Discord channel via webhooks.
 commands:
   discordlogger:
     description: DiscordLogger reload command
-    usage: "/discordlogger <reload|regen>"
+    usage: "/discordlogger <reload|webhook|regen>"
     aliases: [dlogger, dlog]
 
 permissions:
   discordlogger.reload:
     description: Allows reloading DiscordLogger config
+    default: op
+  discordlogger.webhook:
+    description: Allows setting the Discord webhook URL in-game
     default: op
   discordlogger.regen:
     description: Allows rebuilding config.yml from the version bundled with this build


### PR DESCRIPTION
## `/discordlogger webhook <url>`

Writes `webhook.url` and reloads, so wiring up a server never needs a file editor — the step most people get stuck on.

## Two things this had to get right

**The URL is a bearer credential.** Command logging echoes whatever was typed, so without handling, running this would have posted the new webhook URL to Discord — to the channel *currently* configured, which when changing webhooks is the **old** one.

- `Log.redactWebhooks` masks the token in both command listeners. Redacting rather than suppressing keeps the audit trail: you still see someone changed it, just not to what.
- Confirmation names only the channel id.
- Tab-complete returns nothing — a completion list is exactly where a previously typed URL resurfaces in front of someone else.

**`saveConfig()` would have destroyed the config.** Bukkit's YAML writer re-serialises the whole file and drops every comment — the ASCII banners, the per-option explanations, and the `CONFIG VERSION V10` trailer `ConfigMigrator` reads. A config saved that way looks like it has *no schema at all*, which would break migration for that user permanently.

So it edits one line via `ConfigMigrator.setScalar`, reusing the migrator's tested line-finding. Verified on the real shipped config:

```
exactly one line changed        OK
comment count unchanged         OK
line count unchanged            OK
trailer survived                OK
ASCII banners survived          OK
still valid YAML                OK
```

Redaction verified too, including canary/ptb hosts, URLs mid-sentence, and ordinary commands passing through untouched.

## Nightly notice

Was plain white text with nothing saying where it came from. Now carries the same gold `[DiscordLogger]` prefix as the config warning. Console form unchanged — the logger already prefixes it.
