### PR TITLE
test: cover config migration and webhook redaction with JUnit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,13 @@ To add a new synced location: wrap the value in `<!-- dl:sync:KEY -->` markers (
 
 ## Build & test
 
+**Tests exist and gate CI** (JUnit 5 + surefire; `ci.yml` runs `mvn clean package` with tests on). `mvn test` runs them in ~10s.
+
+They cover `ConfigMigrator` and webhook redaction specifically, because those are the two places a silent bug destroys something the user cannot get back: their settings, or their webhook's secrecy. When touching either, **add the case to the test rather than only checking by hand** — all five suites are written against the genuinely shipped `config.yml` and read the schema number from its trailer, so they keep testing the real thing across schema bumps without edits.
+
+Verified to actually fail: reintroducing bidirectional migration, dropping the v6→v7 step, letting the config writer strip comments, and disabling redaction each break the suite.
+
+
 ```bash
 mvn -B -ntp clean package     # compile + shade → target/discordlogger-<version>.jar
 mvn -B -ntp clean compile     # compile only (faster sanity check)

--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,6 @@ Got an idea that isn't here? Open a [feature request](https://github.com/GodTier
 - **Bedrock vs Java indicator** — show which platform a player connected from.
 - **`lang.yml` with MiniMessage** — move every user-facing string into a language file so wording and formatting can be fully rewritten without touching code.
 
-
 ## Website & docs
 
 - **Discord OAuth webhook creation** — let the config generator create the webhook via Discord's own channel picker instead of making people copy a URL by hand. Design settled, not yet built:

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,9 @@
              so a hand-built JAR is never mistaken for a release artifact. -->
         <dl.build.channel>dev</dl.build.channel>
         <dl.build.date>unknown</dl.build.date>
+
+        <junit.version>5.11.4</junit.version>
+        <surefire.version>3.5.2</surefire.version>
     </properties>
 
     <repositories>
@@ -46,6 +49,17 @@
     </repositories>
 
     <dependencies>
+        <!-- Tests. ConfigMigrator is the reason this exists: it decides whether a
+             user's settings survive an upgrade, and a silent break there is the
+             worst failure this plugin has. CI runs `mvn clean package` with tests
+             on, so these gate every PR. -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Paper API provided by the server at runtime; paper-api is required
              for Paper-specific events such as AsyncChatEvent. -->
         <dependency>
@@ -141,6 +155,12 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+            </plugin>
+
             <!-- maven.compiler.release in <properties> drives the compiler; no
                  override here. Targeting 25 to match Minecraft 26.x, which requires
                  a Java 25 runtime — so the emitted bytecode can't load on older

--- a/src/main/java/com/discordlogger/config/ConfigMigrator.java
+++ b/src/main/java/com/discordlogger/config/ConfigMigrator.java
@@ -54,6 +54,41 @@ public final class ConfigMigrator {
     }
 
     /**
+     * Produces the migrated config text: the new schema's file, with the user's
+     * values transplanted onto it.
+     *
+     * <p>Split out from {@link #migrateIfVersionChanged} so the part that can lose
+     * someone's settings is a pure function of two strings — no server, no files.
+     * What remains around it is only I/O and file rotation.
+     *
+     * @param defaultText the config bundled with this build (the target schema)
+     * @param userText    the config currently on disk
+     * @param fromVersion the schema {@code userText} is written in
+     * @param toVersion   the schema {@code defaultText} is written in
+     */
+    static String migrateText(String defaultText, String userText, int fromVersion, int toVersion) {
+        Map<String, Object> defMap = flattenYaml(new Yaml().load(defaultText));
+        Map<String, Object> usrMap = flattenYaml(new Yaml().load(userText));
+
+        // Start from the default's lines and replace values in place, which is what
+        // preserves the comments, banners and trailer.
+        List<String> defLines = Arrays.asList(defaultText.split("\r?\n", -1));
+        List<String> newLines = new ArrayList<>(defLines);
+
+        // Follow any rename the new schema introduced. Without this a schema that
+        // relocates keys silently resets every setting the user ever changed: the old
+        // path is absent from the new defaults, so the value is dropped and the
+        // default wins — indistinguishable, to the user, from the plugin ignoring
+        // their config.
+        for (Map.Entry<String, Object> e : usrMap.entrySet()) {
+            String target = resolvePath(e.getKey(), defMap, fromVersion, toVersion);
+            if (target == null) continue;  // genuinely removed -> keep the default
+            replaceLeafValueInDefault(newLines, defLines, target, e.getValue());
+        }
+        return String.join("\n", newLines);
+    }
+
+    /**
      * Rewrites one scalar in config.yml in place, leaving every other byte alone.
      *
      * <p>Deliberately not {@code plugin.getConfig().set(...)} + {@code saveConfig()}:
@@ -127,32 +162,14 @@ public final class ConfigMigrator {
                 return new Result(decision, oldVer, newVer);
             }
 
-            // Parse both YAMLs to find scalar leaves to transplant
-            Map<String, Object> defMap = flattenYaml(new Yaml().load(defaultText));
-            Map<String, Object> usrMap = flattenYaml(new Yaml().load(userText));
-
-            // Start from default lines; we will replace values in-place (preserves comments)
-            List<String> defLines = Arrays.asList(defaultText.split("\r?\n", -1));
-            List<String> newLines = new ArrayList<>(defLines);
-
-            // Transplant user values for keys that still exist in defaults, following
-            // any rename the new schema introduced. Without this step a schema that
-            // relocates keys silently resets every setting the user ever changed:
-            // the old path is absent from the new defaults, so the value is dropped
-            // and the default wins. That is indistinguishable, to the user, from the
-            // plugin ignoring their config.
             plugin.getLogger().info("Migrating config schema v" + oldVer + " -> v" + newVer
                     + " (one step at a time, so renames from every intermediate version apply)");
 
-            for (Map.Entry<String, Object> e : usrMap.entrySet()) {
-                String target = resolvePath(e.getKey(), defMap, oldVer, newVer);
-                if (target == null) continue;  // genuinely removed -> keep the default
-                replaceLeafValueInDefault(newLines, defLines, target, e.getValue());
-            }
+            final String merged = migrateText(defaultText, userText, oldVer, newVer);
 
             // Write config.new.yml
             File newFile = new File(userFile.getParentFile(), "config.new.yml");
-            Files.writeString(newFile.toPath(), String.join("\n", newLines), StandardCharsets.UTF_8,
+            Files.writeString(newFile.toPath(), merged, StandardCharsets.UTF_8,
                     StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
 
             // Rotate: config.yml -> config.old.yml, new -> config.yml
@@ -264,7 +281,7 @@ public final class ConfigMigrator {
     // ------- helpers -------
 
     @SuppressWarnings("unchecked")
-    private static Map<String, Object> flattenYaml(Object root) {
+    static Map<String, Object> flattenYaml(Object root) {
         Map<String, Object> out = new LinkedHashMap<>();
         if (!(root instanceof Map)) return out;
         walk("", (Map<String, Object>) root, out);
@@ -397,7 +414,7 @@ public final class ConfigMigrator {
         int i = 0; while (i < s.length() && s.charAt(i) == ' ') i++; return i;
     }
 
-    private static Integer extractVersion(String text) {
+    static Integer extractVersion(String text) {
         if (text == null) return null;
         Matcher m = VERSION_RE.matcher(text);
         return m.find() ? Integer.parseInt(m.group(1)) : null;

--- a/src/test/java/com/discordlogger/config/ConfigMigratorDecisionTest.java
+++ b/src/test/java/com/discordlogger/config/ConfigMigratorDecisionTest.java
@@ -1,0 +1,78 @@
+package com.discordlogger.config;
+
+import com.discordlogger.config.ConfigMigrator.Status;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Which way a migration runs, and whether it runs at all.
+ *
+ * <p>The case that matters is AHEAD: before this logic existed, migration fired
+ * whenever the two schema numbers merely differed, so a config from a newer
+ * install — a rolled-back server, or a file copied between servers — was
+ * rewritten against the older shipped default and every key the newer schema
+ * had added was silently deleted.
+ */
+class ConfigMigratorDecisionTest {
+
+    @ParameterizedTest(name = "config v{0} on a v{1} build -> {2}")
+    @CsvSource({
+            "9,  9,  UP_TO_DATE",
+            "9,  10, UPGRADED",
+            "1,  10, UPGRADED",
+            "2,  10, UPGRADED",
+            "10, 9,  AHEAD",
+            "11, 10, AHEAD",
+    })
+    void decidesFromTheTwoSchemaNumbers(int installed, int shipped, Status expected) {
+        assertEquals(expected, ConfigMigrator.decide(installed, shipped));
+    }
+
+    @Test
+    @DisplayName("an unreadable trailer on either side is never treated as a migration")
+    void unknownWhenEitherVersionIsMissing() {
+        assertEquals(Status.UNKNOWN, ConfigMigrator.decide(null, 10));
+        assertEquals(Status.UNKNOWN, ConfigMigrator.decide(9, null));
+        assertEquals(Status.UNKNOWN, ConfigMigrator.decide(null, null));
+    }
+
+    @Test
+    @DisplayName("versions compare numerically, not as text")
+    void comparesNumericallyNotLexicographically() {
+        // As strings "9" > "10", which would invert the decision and downgrade
+        // every v9 config the moment a two-digit schema shipped.
+        assertEquals(Status.UPGRADED, ConfigMigrator.decide(9, 10));
+        assertEquals(Status.AHEAD, ConfigMigrator.decide(10, 9));
+    }
+
+    @Test
+    @DisplayName("the shipped config's trailer parses")
+    void shippedTrailerIsReadable() throws Exception {
+        String shipped = Files.readString(Path.of("src/main/resources/config.yml"));
+        Integer version = ConfigMigrator.extractVersion(shipped);
+        assertEquals(currentSchema(), version,
+                "the shipped config.yml trailer must match the schema this build claims");
+    }
+
+    @Test
+    @DisplayName("a config with no trailer at all yields no version")
+    void missingTrailerYieldsNull() {
+        assertNull(ConfigMigrator.extractVersion("log:\n  player:\n    join:\n      enabled: true\n"));
+        assertNull(ConfigMigrator.extractVersion(""));
+        assertNull(ConfigMigrator.extractVersion(null));
+    }
+
+    /** Read from the shipped file so this test never needs editing on a schema bump. */
+    private static int currentSchema() throws Exception {
+        String shipped = Files.readString(Path.of("src/main/resources/config.yml"));
+        return ConfigMigrator.extractVersion(shipped);
+    }
+}

--- a/src/test/java/com/discordlogger/config/ConfigMigratorPathTest.java
+++ b/src/test/java/com/discordlogger/config/ConfigMigratorPathTest.java
@@ -1,0 +1,123 @@
+package com.discordlogger.config;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.yaml.snakeyaml.Yaml;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Where an old key lands in the current schema.
+ *
+ * <p>Migration steps one schema at a time because renames compose. Colours were
+ * flat ({@code embeds.colors.player_join}) until v7 nested them, then moved beside
+ * their toggle in v10. Resolving v6 straight to v10 would apply only the last
+ * step's renames, so a v6 user's colours would match nothing and be replaced by
+ * defaults — the exact loss the schema trailer exists to prevent.
+ */
+class ConfigMigratorPathTest {
+
+    /** The live schema's flattened defaults — every resolved path must exist in here. */
+    private static Map<String, Object> defaults;
+    private static int current;
+
+    @BeforeAll
+    static void loadShippedConfig() throws Exception {
+        String shipped = Files.readString(Path.of("src/main/resources/config.yml"));
+        defaults = ConfigMigrator.flattenYaml(new Yaml().load(shipped));
+        current = ConfigMigrator.extractVersion(shipped);
+    }
+
+    @ParameterizedTest(name = "v{1}: {0} -> {2}")
+    @CsvSource({
+            // v6 wrote colours flat; v7 nested them; v10 moved them beside the toggle.
+            "embeds.colors.player_join,          6, log.player.join.color",
+            "embeds.colors.server_command,       6, log.server.command.color",
+            "embeds.colors.player_death,         6, log.player.death.color",
+            // v6 moderation colours had no group at all.
+            "embeds.colors.ban,                  6, log.moderation.ban.color",
+            "embeds.colors.unban,                6, log.moderation.unban.color",
+            "embeds.colors.kick,                 6, log.moderation.kick.color",
+            // v7 and v8 already nested, so only the v10 move applies.
+            "embeds.colors.player.teleport,      7, log.player.teleport.color",
+            "embeds.colors.moderation.deop,      8, log.moderation.deop.color",
+            "embeds.colors.player.gamemode,      8, log.player.gamemode.color",
+            // v9 is the single-step case.
+            "embeds.colors.player.join,          9, log.player.join.color",
+            "log.player.join,                    9, log.player.join.enabled",
+            "log.server.explosion,               9, log.server.explosion.enabled",
+    })
+    void renamesCompose(String oldPath, int from, String expected) {
+        assertEquals(expected, ConfigMigrator.resolvePath(oldPath, defaults, from, current));
+    }
+
+    @Test
+    @DisplayName("v9's 'whitelist' colour belongs to the whitelist_edit toggle")
+    void whitelistColourFindsItsRenamedToggle() {
+        // The colour key and the toggle key never matched: v9 had a colour called
+        // "whitelist" but a toggle called "whitelist_edit". v10 merged them.
+        assertEquals("log.moderation.whitelist_edit.color",
+                ConfigMigrator.resolvePath("embeds.colors.moderation.whitelist", defaults, 9, current));
+    }
+
+    @Test
+    @DisplayName("every v9 event toggle survives the upgrade")
+    void allV9TogglesResolve() {
+        String[][] groups = {
+                {"player", "join", "quit", "chat", "command", "death", "advancement", "teleport", "gamemode"},
+                {"server", "command", "start", "stop", "explosion"},
+                {"moderation", "ban", "unban", "kick", "op", "deop", "whitelist_toggle", "whitelist_edit"},
+        };
+        for (String[] group : groups) {
+            for (int i = 1; i < group.length; i++) {
+                String path = "log." + group[0] + "." + group[i];
+                assertEquals(path + ".enabled",
+                        ConfigMigrator.resolvePath(path, defaults, 9, current),
+                        path + " must carry over; if it does not, that user's setting is lost");
+            }
+        }
+    }
+
+    @ParameterizedTest(name = "{0} is untouched by any step")
+    @ValueSource(strings = {"webhook.url", "format.time", "format.name", "format.nicknames",
+            "embeds.enabled", "embeds.author"})
+    void keysThatNeverMovedPassStraightThrough(String path) {
+        // From the oldest schema on record, so every intermediate step is exercised.
+        assertEquals(path, ConfigMigrator.resolvePath(path, defaults, 2, current));
+    }
+
+    @Test
+    @DisplayName("a key that genuinely no longer exists resolves to nothing")
+    void removedKeysAreNotForcedSomewhere() {
+        // v6's embeds.colors.server was a single fallback colour; v7 turned that
+        // same name into a section, so the scalar has no successor. Inventing a
+        // destination would be worse than dropping it.
+        assertNull(ConfigMigrator.resolvePath("embeds.colors.server", defaults, 6, current));
+        assertNull(ConfigMigrator.resolvePath("log.player.nonsense", defaults, 9, current));
+        assertNull(ConfigMigrator.resolvePath("embeds.colors.nope.nope", defaults, 9, current));
+    }
+
+    @Test
+    @DisplayName("every resolved path actually exists in the shipped defaults")
+    void resolvedPathsAreReal() {
+        for (String flat : new String[]{"player_join", "player_quit", "player_chat",
+                "player_command", "player_death", "server_command", "ban", "unban", "kick"}) {
+            String resolved = ConfigMigrator.resolvePath("embeds.colors." + flat, defaults, 6, current);
+            assertNotNull(resolved, flat + " (a v6 colour) must land somewhere");
+            // resolvePath only returns paths present in defMap, so this is belt and
+            // braces against a future change loosening that.
+            org.junit.jupiter.api.Assertions.assertTrue(defaults.containsKey(resolved),
+                    resolved + " is not a real key in the shipped config");
+        }
+    }
+}

--- a/src/test/java/com/discordlogger/config/ConfigMigratorSetScalarTest.java
+++ b/src/test/java/com/discordlogger/config/ConfigMigratorSetScalarTest.java
@@ -1,0 +1,106 @@
+package com.discordlogger.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Writing a single value back into config.yml without wrecking the file.
+ *
+ * <p>{@code /discordlogger webhook} needs this. The obvious implementation —
+ * {@code getConfig().set()} then {@code saveConfig()} — re-serialises the whole
+ * file through Bukkit's YAML writer and drops every comment, including the
+ * {@code CONFIG VERSION V<n>} trailer. A config saved that way looks like it has
+ * no schema at all, which breaks migration for that user permanently.
+ */
+class ConfigMigratorSetScalarTest {
+
+    @TempDir
+    Path dir;
+
+    private Path config;
+    private String before;
+
+    @BeforeEach
+    void copyShippedConfig() throws Exception {
+        before = Files.readString(Path.of("src/main/resources/config.yml"));
+        config = dir.resolve("config.yml");
+        Files.writeString(config, before);
+    }
+
+    @Test
+    @DisplayName("the value is written and the file still parses")
+    void writesTheValue() throws Exception {
+        String url = "https://discord.com/api/webhooks/123456789/TOKEN";
+        assertTrue(ConfigMigrator.setScalar(config.toFile(), "webhook.url", url));
+
+        Map<?, ?> parsed = (Map<?, ?>) new Yaml().load(Files.readString(config));
+        assertEquals(url, ((Map<?, ?>) parsed.get("webhook")).get("url"));
+    }
+
+    @Test
+    @DisplayName("exactly one line changes — nothing else in the file is touched")
+    void changesOnlyTheTargetLine() throws Exception {
+        ConfigMigrator.setScalar(config.toFile(), "webhook.url", "https://discord.com/api/webhooks/1/T");
+
+        List<String> was = List.of(before.split("\n", -1));
+        List<String> now = List.of(Files.readString(config).split("\n", -1));
+
+        assertEquals(was.size(), now.size(), "line count must not change");
+        long differing = java.util.stream.IntStream.range(0, was.size())
+                .filter(i -> !was.get(i).equals(now.get(i)))
+                .count();
+        assertEquals(1, differing, "only webhook.url's line should differ");
+    }
+
+    @Test
+    @DisplayName("comments, banners and the schema trailer all survive")
+    void preservesEverythingElse() throws Exception {
+        ConfigMigrator.setScalar(config.toFile(), "webhook.url", "https://discord.com/api/webhooks/1/T");
+        String after = Files.readString(config);
+
+        assertEquals(before.lines().filter(l -> l.strip().startsWith("#")).count(),
+                after.lines().filter(l -> l.strip().startsWith("#")).count(),
+                "comments are the documentation; losing them makes the file unusable by hand");
+        assertTrue(after.strip().endsWith("(x-release-please-version)"),
+                "the trailer must survive or ConfigMigrator can no longer detect the schema");
+        assertEquals(ConfigMigrator.extractVersion(before), ConfigMigrator.extractVersion(after));
+    }
+
+    @Test
+    @DisplayName("an unknown key reports failure instead of corrupting the file")
+    void unknownKeyIsRejected() throws Exception {
+        assertFalse(ConfigMigrator.setScalar(config.toFile(), "webhook.does_not_exist", "x"));
+        assertEquals(before, Files.readString(config), "a failed write must leave the file alone");
+    }
+
+    @Test
+    @DisplayName("a missing file fails rather than throwing")
+    void missingFileIsHandled() {
+        assertFalse(ConfigMigrator.setScalar(new File(dir.toFile(), "nope.yml"), "webhook.url", "x"));
+    }
+
+    @Test
+    @DisplayName("a nested key deeper than the old schema's maximum still resolves")
+    void writesDeeplyNestedKeys() throws Exception {
+        // v10 toggles sit four levels down; the line finder predates that depth.
+        assertTrue(ConfigMigrator.setScalar(config.toFile(), "log.player.join.enabled", false));
+
+        Map<?, ?> parsed = (Map<?, ?>) new Yaml().load(Files.readString(config));
+        Map<?, ?> log = (Map<?, ?>) parsed.get("log");
+        Map<?, ?> player = (Map<?, ?>) log.get("player");
+        assertEquals(false, ((Map<?, ?>) player.get("join")).get("enabled"));
+    }
+}

--- a/src/test/java/com/discordlogger/config/ConfigMigratorUpgradeTest.java
+++ b/src/test/java/com/discordlogger/config/ConfigMigratorUpgradeTest.java
@@ -1,0 +1,147 @@
+package com.discordlogger.config;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A real upgrade, end to end: a customised old config in, the new schema out.
+ *
+ * <p>This is the test that would catch the failure that actually matters — an
+ * upgrade that quietly discards what someone configured and replaces it with
+ * defaults. It runs against the genuinely shipped {@code config.yml}, so it keeps
+ * testing the real thing as the schema moves.
+ */
+class ConfigMigratorUpgradeTest {
+
+    private static String shipped;
+    private static int current;
+
+    @BeforeAll
+    static void loadShippedConfig() throws Exception {
+        shipped = Files.readString(Path.of("src/main/resources/config.yml"));
+        current = ConfigMigrator.extractVersion(shipped);
+    }
+
+    /** A v9 config someone actually customised — the point is that none of this is default. */
+    private static final String CUSTOMISED_V9 = String.join("\n",
+            "webhook:", "  url: \"https://discord.com/api/webhooks/123/SECRET\"",
+            "format:", "  time: \"[HH:mm]\"", "  name: \"Survival\"", "  nicknames: false",
+            "embeds:", "  enabled: true", "  author: \"My Server\"",
+            "  colors:",
+            "    player:", "      join: \"#123456\"", "      chat: \"#654321\"",
+            "    moderation:", "      whitelist: \"#ABCDEF\"",
+            "log:",
+            "  player:", "    join: true", "    quit: false", "    chat: false",
+            "    command: true", "    death: true", "    advancement: true",
+            "    teleport: true", "    gamemode: true",
+            "  server:", "    command: true", "    start: true", "    stop: true",
+            "    explosion: false",
+            "  moderation:", "    ban: true", "    unban: true", "    kick: true",
+            "    op: true", "    deop: true", "    whitelist_toggle: true",
+            "    whitelist_edit: true",
+            "# CONFIG VERSION V9, SHIPPED WITH v2.1.6", "");
+
+    private Map<?, ?> upgradeFromV9() {
+        String out = ConfigMigrator.migrateText(shipped, CUSTOMISED_V9, 9, current);
+        return (Map<?, ?>) new Yaml().load(out);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> event(Map<?, ?> root, String group, String name) {
+        Map<?, ?> log = (Map<?, ?>) root.get("log");
+        Map<?, ?> section = (Map<?, ?>) log.get(group);
+        return (Map<String, Object>) section.get(name);
+    }
+
+    @Test
+    @DisplayName("disabled events stay disabled through the shape change")
+    void togglesSurvive() {
+        Map<?, ?> r = upgradeFromV9();
+        assertEquals(false, event(r, "player", "quit").get("enabled"));
+        assertEquals(false, event(r, "player", "chat").get("enabled"));
+        assertEquals(false, event(r, "server", "explosion").get("enabled"));
+        assertEquals(true, event(r, "player", "join").get("enabled"));
+        assertEquals(true, event(r, "moderation", "ban").get("enabled"));
+    }
+
+    @Test
+    @DisplayName("customised colours move to their event; untouched ones take the new default")
+    void coloursMoveBesideTheirToggle() {
+        Map<?, ?> r = upgradeFromV9();
+        assertEquals("#123456", event(r, "player", "join").get("color"));
+        assertEquals("#654321", event(r, "player", "chat").get("color"));
+        // v9's "whitelist" colour belongs to the whitelist_edit toggle.
+        assertEquals("#ABCDEF", event(r, "moderation", "whitelist_edit").get("color"));
+        // Not customised in the v9 file, so it must come from the new defaults.
+        assertEquals("#ED4245", event(r, "player", "quit").get("color"));
+    }
+
+    @Test
+    @DisplayName("settings outside the log tree survive untouched")
+    void unrelatedSettingsSurvive() {
+        Map<?, ?> r = upgradeFromV9();
+        assertEquals("https://discord.com/api/webhooks/123/SECRET",
+                ((Map<?, ?>) r.get("webhook")).get("url"));
+        assertEquals("My Server", ((Map<?, ?>) r.get("embeds")).get("author"));
+        assertEquals(false, ((Map<?, ?>) r.get("format")).get("nicknames"));
+        assertEquals("Survival", ((Map<?, ?>) r.get("format")).get("name"));
+    }
+
+    @Test
+    @DisplayName("the old colours tree is gone, not left behind alongside the new one")
+    void oldStructureIsNotCarriedOver() {
+        assertFalse(((Map<?, ?>) upgradeFromV9().get("embeds")).containsKey("colors"));
+    }
+
+    @Test
+    @DisplayName("the result is the new schema's file, comments and all")
+    void outputKeepsTheShippedFileIntact() {
+        String out = ConfigMigrator.migrateText(shipped, CUSTOMISED_V9, 9, current);
+
+        assertTrue(out.strip().endsWith("(x-release-please-version)"),
+                "the schema trailer must survive, or the next upgrade cannot detect the version");
+        assertEquals(commentLines(shipped), commentLines(out),
+                "migration must not drop comments — the file is documentation as much as config");
+        assertEquals(shipped.split("\n", -1).length, out.split("\n", -1).length,
+                "migration rewrites values in place; it must not add or remove lines");
+    }
+
+    @Test
+    @DisplayName("a config that changed nothing round-trips to the shipped file exactly")
+    void defaultConfigIsUnchangedByMigration() {
+        // Same schema in and out, no customisation: the only difference should be
+        // none at all. Guards against a rename rule firing when it should not.
+        String out = ConfigMigrator.migrateText(shipped, shipped, current, current);
+        assertEquals(shipped.stripTrailing(), out.stripTrailing());
+    }
+
+    @Test
+    @DisplayName("every customised value in the old config lands somewhere")
+    void nothingIsSilentlyDropped() {
+        Map<String, Object> user = ConfigMigrator.flattenYaml(new Yaml().load(CUSTOMISED_V9));
+        Map<String, Object> defaults = ConfigMigrator.flattenYaml(new Yaml().load(shipped));
+
+        List<String> lost = user.keySet().stream()
+                .filter(k -> ConfigMigrator.resolvePath(k, defaults, 9, current) == null)
+                .toList();
+
+        assertEquals(List.of(), lost,
+                "these v9 keys have nowhere to go in the current schema, so the user's "
+                        + "choices for them would be replaced by defaults");
+    }
+
+    private static long commentLines(String text) {
+        return text.lines().filter(l -> l.strip().startsWith("#")).count();
+    }
+}

--- a/src/test/java/com/discordlogger/log/LogRedactionTest.java
+++ b/src/test/java/com/discordlogger/log/LogRedactionTest.java
@@ -1,0 +1,76 @@
+package com.discordlogger.log;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Keeping webhook URLs out of Discord.
+ *
+ * <p>A webhook URL is a bearer credential — anyone holding it can post to that
+ * channel. Command logging echoes whatever was typed, so without redaction,
+ * {@code /discordlogger webhook <url>} would publish the new URL to the channel
+ * the plugin is currently posting to, which when changing webhooks is the old one.
+ */
+class LogRedactionTest {
+
+    private static final String ID = "123456789012345678";
+    private static final String TOKEN = "AbCdEf-gH1jK_lMnOpQrStUvWxYz";
+
+    @ParameterizedTest(name = "{0} is treated as a webhook host")
+    @ValueSource(strings = {
+            "https://discord.com",
+            "https://discordapp.com",
+            "https://ptb.discord.com",
+            "https://canary.discord.com",
+    })
+    void masksEveryDiscordHost(String host) {
+        String url = host + "/api/webhooks/" + ID + "/" + TOKEN;
+        assertEquals(host + "/api/webhooks/" + ID + "/***", Log.redactWebhooks(url));
+    }
+
+    @Test
+    @DisplayName("the id survives so the channel is still identifiable")
+    void keepsTheIdDropsTheToken() {
+        String out = Log.redactWebhooks("/discordlogger webhook https://discord.com/api/webhooks/"
+                + ID + "/" + TOKEN);
+        assertTrue(out.contains(ID), "the channel id is not a secret and is useful in an audit trail");
+        assertFalse(out.contains(TOKEN), "the token is the credential and must never be logged");
+    }
+
+    @Test
+    @DisplayName("a URL embedded in a longer message is still masked")
+    void masksUrlsMidSentence() {
+        assertEquals("set it to https://discord.com/api/webhooks/" + ID + "/*** just now",
+                Log.redactWebhooks("set it to https://discord.com/api/webhooks/"
+                        + ID + "/" + TOKEN + " just now"));
+    }
+
+    @Test
+    @DisplayName("ordinary commands pass through untouched")
+    void leavesEverythingElseAlone() {
+        assertEquals("/gamemode creative Steve", Log.redactWebhooks("/gamemode creative Steve"));
+        assertEquals("/say hello #general", Log.redactWebhooks("/say hello #general"));
+        assertEquals("", Log.redactWebhooks(""));
+        assertEquals(null, Log.redactWebhooks(null));
+    }
+
+    @Test
+    @DisplayName("only real Discord webhook URLs are accepted")
+    void validatesWebhookUrls() {
+        assertTrue(Log.isValidWebhookUrl("https://discord.com/api/webhooks/" + ID + "/" + TOKEN));
+        assertTrue(Log.isValidWebhookUrl("https://canary.discord.com/api/webhooks/1/x"));
+
+        assertFalse(Log.isValidWebhookUrl("https://evil.example/api/webhooks/1/x"),
+                "a lookalike host must not be accepted — it would send every log off-site");
+        assertFalse(Log.isValidWebhookUrl("http://discord.com/api/webhooks/1/x"),
+                "plain HTTP would put the token on the wire in clear");
+        assertFalse(Log.isValidWebhookUrl(""));
+        assertFalse(Log.isValidWebhookUrl(null));
+    }
+}


### PR DESCRIPTION
The repo had no test framework, so `ConfigMigrator` was unprotected while growing into five schema versions of branching logic. A silent break there resets or destroys settings on upgrade — the worst failure this plugin has, and one that shows up on users' servers rather than in CI.

**53 tests**, ~10s:

| Suite | Covers |
|---|---|
| `ConfigMigratorDecisionTest` | forward-only rule, `AHEAD`, unreadable trailers, numeric vs lexicographic ordering |
| `ConfigMigratorPathTest` | the rename chain — v6/v7/v8/v9 → current, all 19 toggles, keys that legitimately vanish |
| `ConfigMigratorUpgradeTest` | a full upgrade of a *customised* v9 config, end to end |
| `ConfigMigratorSetScalarTest` | one line changes, comments/banners/trailer intact, unknown keys rejected |
| `LogRedactionTest` | every Discord host, URLs mid-sentence, lookalike hosts and plain HTTP rejected |

## Proven to fail, not just to pass

A test that cannot fail is worthless, so I broke the code four ways and confirmed each is caught:

| Mutation | Result |
|---|---|
| Migrate in both directions again (the original bug) | 3 failures |
| Drop the v6→v7 rename step | 7 failures |
| Let the config writer strip comments (the `saveConfig()` failure mode) | 2 failures — *"expected 142 lines but was 86"*, *"expected 56 comments but was 0"* |
| Stop redacting webhook URLs | 6 failures |

## One refactor

`migrateIfVersionChanged` is split so `migrateText(defaultText, userText, from, to)` is a pure function of two strings. The part that can lose someone's settings is now testable without a running server, and what surrounds it is only file I/O and rotation. `flattenYaml` and `extractVersion` drop to package-private for the same reason — no public API grows.

Every suite reads the shipped `config.yml` and takes the schema number from its own trailer, so they keep testing the real file across schema bumps rather than drifting into asserting a stale snapshot.

Supersedes #131, carrying over its whitespace fix.
