### PR TITLE
feat(death): optionally include coordinates in death messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,6 +394,7 @@ Compare that against the newest entry in `docs/assets/configs/registry.json`. If
 #### Phase 2 — the website generator (the part with the isolation rule)
 
 5. **`cp -r docs/assets/configs/v<N-1> docs/assets/configs/v<N>`** — copy forward, then adapt the copy. Never refactor the old folder in place.
+   - **Immediately change `const CONFIG_VERSION` at the top of the copied `generator.js`.** It drives three things at once: the key the bundle registers under (`window.DL_GENERATORS[...]`), the directory it fetches `options.json` and the template from, and the version shown to the user. Left at the old value, the new bundle registers as the *previous* schema and serves the previous schema's data — so the new generator silently emits the **old** config. Valid YAML, wrong file, no error anywhere. `validate-config-generator.py` now checks this (it was missed once and only surfaced by driving the UI).
 6. **Adapt the new bundle**: `generator.js` (registers `window.DL_GENERATORS['v<N>']`), `options.json`, the template, and the `config.yml` mirror. The mirror must match `src/main/resources/config.yml` byte for byte apart from the trailer's `BUILT` suffix.
 7. **DO NOT TOUCH `docs/assets/configs/v<N-1>/**` ever again.** Someone still running the older plugin must keep generating exactly the config they always did.
 
@@ -440,6 +441,24 @@ mvn -B -ntp -DskipTests clean package && unzip -p target/*.jar config.yml | tail
 
 14. Merging the Release PR ships the schema and **freezes it permanently**. From that moment `docs/assets/configs/v<N>/` and the shipped keys are history: the next key change opens `v<N+1>`.
 15. **Versions are never skipped**, and a schema that was opened but never published is not "used up" — it stays open and keeps accumulating changes until a release ships it.
+
+#### Per-event sub-options (`extras`)
+
+An event can carry extra keys beside `enabled` and `color` — `log.player.death.show_coords` is the first. The generator handles these generically, so **adding another needs no JavaScript**: declare it in `options.json` under the item's `extras`, add a matching `{{EXTRA_<key>}}` slot to the template, ship the key in `config.yml`, and read it in Java.
+
+```json
+"extras": [
+  { "key": "player.death.show_coords",
+    "configKey": "log.player.death.show_coords",
+    "label": "Include coordinates in death messages",
+    "note": "Anyone who can read the channel can find the body and its dropped items.",
+    "default": false }
+]
+```
+
+Two behaviours worth preserving: **"Select all"/"Select none" deliberately skip sub-options** (the selector excludes `.cfg-check--sub`), because turning every event on should never silently start broadcasting death locations; and the CSS must stay scoped `#cfg-gen .cfg-check--sub` *after* the base rule, since `#cfg-gen .cfg-check` uses the `margin` shorthand and would otherwise reset the indent.
+
+The validator checks each `extras` entry the same way as `configKey`: the template must have the slot, and for the live schema some Java must read it.
 
 #### What each of the four config copies is for
 

--- a/docs/assets/configs/v10/config.template.yml
+++ b/docs/assets/configs/v10/config.template.yml
@@ -91,6 +91,7 @@ log:
     death: # Player Death (with death message)
       enabled: {{LOG_player.death.enabled}}
       color: "{{COLOR_player.death}}" # red
+      show_coords: {{EXTRA_player.death.show_coords}} # Adds where the player died. Anyone who can see the channel can find the body
     advancement: # Logs when a player gets an advancement
       enabled: {{LOG_player.advancement.enabled}}
       color: "{{COLOR_player.advancement}}" # green

--- a/docs/assets/configs/v10/config.yml
+++ b/docs/assets/configs/v10/config.yml
@@ -91,6 +91,7 @@ log:
     death: # Player Death (with death message)
       enabled: true
       color: "#ED4245" # red
+      show_coords: false # Adds where the player died. Anyone who can see the channel can find the body
     advancement: # Logs when a player gets an advancement
       enabled: true
       color: "#2ECC71" # green

--- a/docs/assets/configs/v10/generator.js
+++ b/docs/assets/configs/v10/generator.js
@@ -13,7 +13,7 @@
 (() => {
     'use strict';
 
-    const CONFIG_VERSION = 'v9';
+    const CONFIG_VERSION = 'v10';
 
     window.DL_GENERATORS = window.DL_GENERATORS || {};
     window.DL_GENERATORS[CONFIG_VERSION] = launch;
@@ -115,6 +115,7 @@
             options: null,
             template: null,
             toggles: {},
+            extras: {},
             colors: {},
         };
 
@@ -158,6 +159,11 @@
                 const k = toggleKey(item.configKey);
                 if (k) state.toggles[k] = item.default !== undefined ? !!item.default : true;
                 if (item.colorKey) state.colors[item.colorKey] = item.defaultColor || FALLBACK_COLOR;
+                // Per-event sub-options (e.g. death coordinates). Driven entirely by
+                // options.json, so adding another needs no change to this file.
+                for (const extra of (item.extras || [])) {
+                    state.extras[extra.key] = !!extra.default;
+                }
             }
         }
 
@@ -374,11 +380,24 @@
                     const cb = h('input', { type: 'checkbox', ...(state.toggles[k] ? { checked: true } : {}) });
                     cb.addEventListener('change', () => { state.toggles[k] = cb.checked; });
                     list.appendChild(h('label', { class: 'cfg-check' }, [cb, h('span', {}, item.label || k)]));
+
+                    for (const extra of (item.extras || [])) {
+                        const sub = h('input', {
+                            type: 'checkbox',
+                            ...(state.extras[extra.key] ? { checked: true } : {}),
+                        });
+                        sub.addEventListener('change', () => { state.extras[extra.key] = sub.checked; });
+                        list.appendChild(h('label', { class: 'cfg-check cfg-check--sub' },
+                            [sub, h('span', {}, extra.label || extra.key)]));
+                        if (extra.note) {
+                            list.appendChild(h('p', { class: 'cfg-note cfg-note--sub' }, extra.note));
+                        }
+                    }
                 }
             }
 
             const setAll = on => () => {
-                for (const cb of list.querySelectorAll('input[type=checkbox]')) {
+                for (const cb of list.querySelectorAll('.cfg-check:not(.cfg-check--sub) input[type=checkbox]')) {
                     if (cb.checked !== on) { cb.checked = on; cb.dispatchEvent(new Event('change')); }
                 }
             };
@@ -540,6 +559,9 @@
                 if (item.colorKey) {
                     tokens[`COLOR_${item.colorKey}`] = state.colors[item.colorKey] || FALLBACK_COLOR;
                 }
+                for (const extra of (item.extras || [])) {
+                    tokens[`EXTRA_${extra.key}`] = state.extras[extra.key] ? 'true' : 'false';
+                }
             }
         }
 
@@ -579,6 +601,11 @@
     #cfg-gen .cfg-status.is-ok { background: rgba(22,163,74,.08); border-color: rgba(22,163,74,.2); }
     #cfg-gen .cfg-status.is-error { background: rgba(239,68,68,.08); border-color: rgba(239,68,68,.2); }
     #cfg-gen .cfg-radio, #cfg-gen .cfg-check { display: flex; align-items: center; gap: .45rem; margin: .3rem 0; }
+    /* Sub-options sit indented under the event they belong to. Scoped and placed
+       after the base rule because that rule uses the margin shorthand, which
+       would otherwise reset the indent back to zero. */
+    #cfg-gen .cfg-check--sub { margin-left: 1.75rem; opacity: .92; }
+    #cfg-gen .cfg-note--sub { margin: .1rem 0 .5rem 1.75rem; font-size: .85em; opacity: .75; }
     #cfg-gen .cfg-sub { margin: .9rem 0 .3rem; }
     #cfg-gen .cfg-colgroup { border: 1px solid var(--border); border-radius: 10px; padding: .65rem .7rem; margin-bottom: .9rem; }
     #cfg-gen .cfg-colrow { display: flex; align-items: center; justify-content: space-between; gap: .7rem; margin: .35rem 0; }

--- a/docs/assets/configs/v10/options.json
+++ b/docs/assets/configs/v10/options.json
@@ -43,7 +43,16 @@
           "configKey": "log.player.death.enabled",
           "colorKey": "player.death",
           "defaultColor": "#ED4245",
-          "default": true
+          "default": true,
+          "extras": [
+            {
+              "key": "player.death.show_coords",
+              "configKey": "log.player.death.show_coords",
+              "label": "Include coordinates in death messages",
+              "note": "Anyone who can read the channel can find the body and its dropped items.",
+              "default": false
+            }
+          ]
         },
         {
           "id": "advancement",

--- a/docs/config/v10/index.md
+++ b/docs/config/v10/index.md
@@ -94,6 +94,17 @@ log:
       color: "#ED4245"
 ```
 
+Some events carry extra sub-options alongside `enabled` and `color`:
+
+| Key | Default | What it does |
+|---|---|---|
+| `log.player.death.show_coords` | `false` | Appends where the player died, as `x, y, z in world`. |
+
+> **`show_coords` is off by default on purpose.** A death message with coordinates tells
+> everyone who can read the channel exactly where the body — and the inventory it
+> dropped — is. That is useful on a private server and a griefing tool on a public one,
+> so it is opt-in rather than something you discover after the fact.
+
 `color` is read whether or not the event is enabled, so turning something off and
 back on keeps the colour you chose. Colours are hex, with or without the leading `#`;
 an unreadable value falls back to the built-in default rather than failing to load.
@@ -238,6 +249,7 @@ log:
     death: # Player Death (with death message)
       enabled: true
       color: "#ED4245" # red
+      show_coords: false # Adds where the player died. Anyone who can see the channel can find the body
     advancement: # Logs when a player gets an advancement
       enabled: true
       color: "#2ECC71" # green

--- a/scripts/validate-config-generator.py
+++ b/scripts/validate-config-generator.py
@@ -56,6 +56,33 @@ def shipped_schema() -> str | None:
     return f"v{m.group(1)}" if m else None
 
 
+def check_bundle_declares_its_own_version(version_dir: str) -> list[str]:
+    """Each bundle's generator.js must declare the schema it *is*.
+
+    CONFIG_VERSION drives three things: the key it registers under
+    (window.DL_GENERATORS[...]), the directory it fetches options.json and the
+    template from, and the version shown to the user. A copy-forward that leaves
+    the previous value behind therefore produces a generator that silently emits
+    the OLD schema's config -- valid YAML, wrong file, and no error anywhere.
+    """
+    schema = os.path.basename(version_dir)
+    js_path = os.path.join(version_dir, "generator.js")
+    if not os.path.exists(js_path):
+        return [f"{js_path} missing"]
+
+    with open(js_path, encoding="utf-8") as f:
+        m = re.search(r"const\s+CONFIG_VERSION\s*=\s*['\"]([^'\"]+)['\"]", f.read())
+    if not m:
+        return [f"{js_path}: no CONFIG_VERSION declaration found"]
+    if m.group(1) != schema:
+        return [
+            f"{js_path} declares CONFIG_VERSION '{m.group(1)}' but lives in {schema}/. "
+            f"It would register as '{m.group(1)}' and load {m.group(1)}'s data, so the "
+            f"{schema} generator would emit a {m.group(1)} config."
+        ]
+    return []
+
+
 def check_version(options_path: str, live_schema: str | None = None) -> list[str]:
     errors = []
     version_dir = os.path.dirname(options_path)
@@ -77,9 +104,10 @@ def check_version(options_path: str, live_schema: str | None = None) -> list[str
         for item in cat.get("items", []):
             item_id = item.get("id", "?")
 
+            is_live = os.path.basename(version_dir) == live_schema
+
             config_key = item.get("configKey", "")
             if config_key.startswith("log."):
-                is_live = os.path.basename(version_dir) == live_schema
                 token = "LOG_" + config_key[len("log."):]
                 if token not in template_tokens:
                     errors.append(
@@ -110,6 +138,28 @@ def check_version(options_path: str, live_schema: str | None = None) -> list[str
                         f"{options_path}: item '{item_id}' references config key "
                         f"'{config_key}', which no Java source under {JAVA_SRC} reads"
                     )
+
+            # Per-event sub-options: same contract as configKey -- the template must
+            # have a slot for it, and (for the live schema) some Java must read it.
+            # Without this a sub-option silently generates nothing.
+            for extra in item.get("extras", []):
+                extra_token = "EXTRA_" + extra.get("key", "")
+                if extra_token not in template_tokens:
+                    errors.append(
+                        f"{options_path}: item '{item_id}' sub-option expects "
+                        f"{{{{{extra_token}}}}} in {template_path}, not found"
+                    )
+                extra_config_key = extra.get("configKey", "")
+                if extra_config_key and is_live:
+                    grep = subprocess.run(
+                        ["grep", "-rl", "-F", f'"{extra_config_key}"', JAVA_SRC],
+                        capture_output=True, text=True,
+                    )
+                    if not grep.stdout.strip():
+                        errors.append(
+                            f"{options_path}: item '{item_id}' sub-option references "
+                            f"'{extra_config_key}', which no Java source reads"
+                        )
 
             color_key = item.get("colorKey")
             if color_key:
@@ -230,15 +280,17 @@ def check_java_fallbacks_match_shipped_config() -> list[str]:
             if leaf_m and category:
                 shipped[f"log.{category}.{leaf_m.group(1)}"] = leaf_m.group(2)
                 continue
-            # Schema v10 shape: the event is a section, the toggle is its
-            # "enabled" child, and "color" sits alongside it.
+            # Schema v10 shape: the event is a section whose boolean children are
+            # its toggles -- "enabled", plus any sub-option such as "show_coords".
+            # Capturing all of them (rather than "enabled" alone) is what lets a new
+            # sub-option be checked against its Java fallback like any other key.
             event_m = re.match(r"^    (\w+):\s*(?:#.*)?$", line)
             if event_m and category:
                 event = event_m.group(1)
                 continue
-            enabled_m = re.match(r"^      enabled:\s*(true|false)\b", line)
-            if enabled_m and category and event:
-                shipped[f"log.{category}.{event}.enabled"] = enabled_m.group(1)
+            child_m = re.match(r"^      (\w+):\s*(true|false)\b", line)
+            if child_m and category and event:
+                shipped[f"log.{category}.{event}.{child_m.group(1)}"] = child_m.group(2)
 
     if not shipped:
         return [f"{SHIPPED_CONFIG}: could not parse any log.* toggles -- has the structure changed?"]
@@ -268,6 +320,7 @@ def main() -> int:
     live = shipped_schema()
     for options_path in sorted(glob.glob("docs/assets/configs/v*/options.json")):
         all_errors.extend(check_version(options_path, live))
+        all_errors.extend(check_bundle_declares_its_own_version(os.path.dirname(options_path)))
     all_errors.extend(check_shipped_config_matches_mirror())
     all_errors.extend(check_doc_page_embedded_configs())
     all_errors.extend(check_java_fallbacks_match_shipped_config())

--- a/src/main/java/com/discordlogger/listener/player/PlayerDeath.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerDeath.java
@@ -17,6 +17,9 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public final class PlayerDeath implements Listener {
     private final Plugin plugin;
 
@@ -28,19 +31,42 @@ public final class PlayerDeath implements Listener {
 
         final Player victim = e.getEntity();
         final String vName = Names.display(victim, (JavaPlugin) plugin);
-        final String thumb = Log.playerAvatarUrl(victim.getUniqueId());
 
-        // Prefer killer context (player)
+        final List<Log.Field> fields = new ArrayList<>();
+        fields.add(new Log.Field("Cause of Death", describeCause(victim)));
+
+        // Only present when asked for. Off by default: a death message with
+        // coordinates tells everyone who can read the channel where the body — and
+        // the inventory it dropped — is.
+        if (plugin.getConfig().getBoolean("log.player.death.show_coords", false)) {
+            fields.add(new Log.Field("Coords", coordsOf(victim)));
+        }
+
+        Log.eventFieldsWithThumb(
+                "Player Death",
+                "Player Death",
+                vName + " died",
+                null,                       // null -> use embeds.author from config
+                fields,
+                Log.playerAvatarUrl(victim.getUniqueId())
+        );
+    }
+
+    /**
+     * How the player died, as a standalone phrase for a field value.
+     *
+     * <p>Each branch used to send its own complete message, so the wording was
+     * mid-sentence ("was slain by X"). As a field value it stands on its own, so it
+     * reads "Slain by X".
+     */
+    private String describeCause(Player victim) {
         final Player killer = victim.getKiller();
         if (killer != null) {
             String kName = Names.display(killer, (JavaPlugin) plugin);
             String weapon = weaponName(killer.getInventory().getItemInMainHand());
-            String suffix = weapon.isEmpty() ? "" : " [" + weapon + "]";
-            send(victim, vName + " was slain by " + kName + suffix, thumb);
-            return;
+            return "Slain by " + kName + (weapon.isEmpty() ? "" : " [" + weapon + "]");
         }
 
-        // Last damage cause
         EntityDamageEvent last = victim.getLastDamageCause();
         if (last instanceof EntityDamageByEntityEvent byEntity) {
             Entity damager = byEntity.getDamager();
@@ -48,43 +74,25 @@ public final class PlayerDeath implements Listener {
             if (damager instanceof Projectile proj) {
                 Object shooter = proj.getShooter();
                 if (shooter instanceof Player pShooter) {
-                    String kName = Names.display(pShooter, (JavaPlugin) plugin);
-                    send(victim, vName + " was shot by " + kName, thumb);
-                    return;
-                } else if (shooter instanceof Entity eShooter) {
-                    send(victim, vName + " was shot by " + mobName(eShooter), thumb);
-                    return;
-                } else {
-                    send(victim, vName + " was shot", thumb);
-                    return;
+                    return "Shot by " + Names.display(pShooter, (JavaPlugin) plugin);
                 }
+                if (shooter instanceof Entity eShooter) {
+                    return "Shot by " + mobName(eShooter);
+                }
+                return "Shot";
             }
-
-            send(victim, vName + " was slain by " + mobName(damager), thumb);
-            return;
+            return "Slain by " + mobName(damager);
         }
 
-        // Environmental causes
-        String cause = causeText(last == null ? null : last.getCause());
-        send(victim, vName + " " + cause, thumb);
+        return causeText(last == null ? null : last.getCause());
     }
 
-    /**
-     * Single send point for every death, so the coordinates suffix is appended in
-     * one place rather than repeated across the five ways a death is described.
-     *
-     * <p>Off by default: a death message tells everyone who can read the channel
-     * exactly where the body — and the dropped inventory — is. That is a fine
-     * thing on a private server and a griefing tool on a public one, so it is
-     * opt-in rather than something an admin discovers after the fact.
-     */
-    private void send(Player victim, String message, String thumb) {
-        if (plugin.getConfig().getBoolean("log.player.death.show_coords", false)) {
-            final Location at = victim.getLocation();
-            message += " at " + at.getBlockX() + ", " + at.getBlockY() + ", " + at.getBlockZ()
-                    + " in " + Log.mdEscape(at.getWorld() == null ? "unknown" : at.getWorld().getName());
-        }
-        Log.eventWithThumb("Player Death", message, thumb);
+    /** Block coordinates and world, e.g. "128, 71, -344 in world". */
+    private String coordsOf(Player victim) {
+        final Location at = victim.getLocation();
+        final String world = at.getWorld() == null ? "unknown" : at.getWorld().getName();
+        return at.getBlockX() + ", " + at.getBlockY() + ", " + at.getBlockZ()
+                + " in " + Log.mdEscape(world);
     }
 
     private String weaponName(ItemStack item) {
@@ -103,29 +111,29 @@ public final class PlayerDeath implements Listener {
     }
 
     private String causeText(EntityDamageEvent.DamageCause cause) {
-        if (cause == null) return "died";
+        if (cause == null) return "Died";
         switch (cause) {
-            case FALL: return "fell from a high place";
-            case LAVA: return "tried to swim in lava";
+            case FALL: return "Fell from a high place";
+            case LAVA: return "Tried to swim in lava";
             case FIRE:
-            case FIRE_TICK: return "burned to death";
-            case DROWNING: return "drowned";
-            case SUFFOCATION: return "suffocated in a wall";
-            case VOID: return "fell into the void";
-            case CONTACT: return "was pricked to death";
+            case FIRE_TICK: return "Burned to death";
+            case DROWNING: return "Drowned";
+            case SUFFOCATION: return "Suffocated in a wall";
+            case VOID: return "Fell into the void";
+            case CONTACT: return "Was pricked to death";
             case BLOCK_EXPLOSION:
-            case ENTITY_EXPLOSION: return "blew up";
-            case MAGIC: return "was killed by magic";
-            case POISON: return "was poisoned";
-            case WITHER: return "withered away";
-            case STARVATION: return "starved to death";
-            case FREEZE: return "froze to death";
-            case LIGHTNING: return "was struck by lightning";
-            case HOT_FLOOR: return "discovered the floor was lava";
-            case CRAMMING: return "was squished too much";
-            case DRAGON_BREATH: return "was roasted by dragon breath";
-            case THORNS: return "was killed by thorns";
-            default: return "died";
+            case ENTITY_EXPLOSION: return "Blew up";
+            case MAGIC: return "Was killed by magic";
+            case POISON: return "Was poisoned";
+            case WITHER: return "Withered away";
+            case STARVATION: return "Starved to death";
+            case FREEZE: return "Froze to death";
+            case LIGHTNING: return "Was struck by lightning";
+            case HOT_FLOOR: return "Discovered the floor was lava";
+            case CRAMMING: return "Was squished too much";
+            case DRAGON_BREATH: return "Was roasted by dragon breath";
+            case THORNS: return "Was killed by thorns";
+            default: return "Died";
         }
     }
 }

--- a/src/main/java/com/discordlogger/listener/player/PlayerDeath.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerDeath.java
@@ -2,6 +2,7 @@ package com.discordlogger.listener.player;
 
 import com.discordlogger.log.Log;
 import com.discordlogger.util.Names;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
@@ -35,7 +36,7 @@ public final class PlayerDeath implements Listener {
             String kName = Names.display(killer, (JavaPlugin) plugin);
             String weapon = weaponName(killer.getInventory().getItemInMainHand());
             String suffix = weapon.isEmpty() ? "" : " [" + weapon + "]";
-            Log.eventWithThumb("Player Death", vName + " was slain by " + kName + suffix, thumb);
+            send(victim, vName + " was slain by " + kName + suffix, thumb);
             return;
         }
 
@@ -48,24 +49,42 @@ public final class PlayerDeath implements Listener {
                 Object shooter = proj.getShooter();
                 if (shooter instanceof Player pShooter) {
                     String kName = Names.display(pShooter, (JavaPlugin) plugin);
-                    Log.eventWithThumb("Player Death", vName + " was shot by " + kName, thumb);
+                    send(victim, vName + " was shot by " + kName, thumb);
                     return;
                 } else if (shooter instanceof Entity eShooter) {
-                    Log.eventWithThumb("Player Death", vName + " was shot by " + mobName(eShooter), thumb);
+                    send(victim, vName + " was shot by " + mobName(eShooter), thumb);
                     return;
                 } else {
-                    Log.eventWithThumb("Player Death", vName + " was shot", thumb);
+                    send(victim, vName + " was shot", thumb);
                     return;
                 }
             }
 
-            Log.eventWithThumb("Player Death", vName + " was slain by " + mobName(damager), thumb);
+            send(victim, vName + " was slain by " + mobName(damager), thumb);
             return;
         }
 
         // Environmental causes
         String cause = causeText(last == null ? null : last.getCause());
-        Log.eventWithThumb("Player Death", vName + " " + cause, thumb);
+        send(victim, vName + " " + cause, thumb);
+    }
+
+    /**
+     * Single send point for every death, so the coordinates suffix is appended in
+     * one place rather than repeated across the five ways a death is described.
+     *
+     * <p>Off by default: a death message tells everyone who can read the channel
+     * exactly where the body — and the dropped inventory — is. That is a fine
+     * thing on a private server and a griefing tool on a public one, so it is
+     * opt-in rather than something an admin discovers after the fact.
+     */
+    private void send(Player victim, String message, String thumb) {
+        if (plugin.getConfig().getBoolean("log.player.death.show_coords", false)) {
+            final Location at = victim.getLocation();
+            message += " at " + at.getBlockX() + ", " + at.getBlockY() + ", " + at.getBlockZ()
+                    + " in " + Log.mdEscape(at.getWorld() == null ? "unknown" : at.getWorld().getName());
+        }
+        Log.eventWithThumb("Player Death", message, thumb);
     }
 
     private String weaponName(ItemStack item) {

--- a/src/main/java/com/discordlogger/listener/player/PlayerDeath.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerDeath.java
@@ -84,7 +84,10 @@ public final class PlayerDeath implements Listener {
             return "Slain by " + mobName(damager);
         }
 
-        return causeText(last == null ? null : last.getCause());
+        final String text = last == null ? null : causeText(last.getCause());
+        // Only reached when there is no damage cause at all, or Paper has added one
+        // we do not know yet. causeTextIsExhaustive() in the tests fails on the latter.
+        return text == null ? "Died" : text;
     }
 
     /** Block coordinates and world, e.g. "128, 71, -344 in world". */
@@ -110,8 +113,16 @@ public final class PlayerDeath implements Listener {
         return "a " + type;
     }
 
-    private String causeText(EntityDamageEvent.DamageCause cause) {
-        if (cause == null) return "Died";
+    /**
+     * Phrasing for each damage cause, or null if this one is not handled.
+     *
+     * <p>Returning null rather than a generic string is what makes the gap
+     * detectable: a test walks every {@code DamageCause} the API declares and fails
+     * on any that returns null, so a cause added by a future Paper release is caught
+     * in CI instead of surfacing as "Cause of Death: Died" on someone's server.
+     */
+    static String causeText(EntityDamageEvent.DamageCause cause) {
+        if (cause == null) return null;
         switch (cause) {
             case FALL: return "Fell from a high place";
             case LAVA: return "Tried to swim in lava";
@@ -133,7 +144,27 @@ public final class PlayerDeath implements Listener {
             case CRAMMING: return "Was squished too much";
             case DRAGON_BREATH: return "Was roasted by dragon breath";
             case THORNS: return "Was killed by thorns";
-            default: return "Died";
+
+            // Reachable via /kill, and the twelve others that previously fell through
+            // to a bare "Died".
+            case KILL: return "Killed by command";
+            case SUICIDE: return "Killed by command";
+            case WORLD_BORDER: return "Left the world border";
+            case SONIC_BOOM: return "Hit by a warden's sonic boom";
+            case CAMPFIRE: return "Burned on a campfire";
+            case FALLING_BLOCK: return "Squashed by a falling block";
+            case FLY_INTO_WALL: return "Flew into a wall";
+            case DRYOUT: return "Dried out";
+            case MELTING: return "Melted";
+            // These normally resolve through the damager branch above; they only reach
+            // here when the attacker is already gone by the time the death is read.
+            case ENTITY_ATTACK: return "Slain";
+            case ENTITY_SWEEP_ATTACK: return "Slain";
+            case PROJECTILE: return "Shot";
+            // Inflicted by a plugin, so there is nothing truthful to say beyond this.
+            case CUSTOM: return "Died";
+
+            default: return null;
         }
     }
 }

--- a/src/main/java/com/discordlogger/log/Log.java
+++ b/src/main/java/com/discordlogger/log/Log.java
@@ -316,12 +316,32 @@ public final class Log {
                                             String author,
                                             List<Field> fields,
                                             String thumbnailUrl) {
+        eventFieldsWithThumb(category, title, "", author, fields, thumbnailUrl);
+    }
+
+    /**
+     * As above, with a description line between the title and the fields.
+     *
+     * <p>Overload rather than a sixth parameter on the original: every existing
+     * caller wants an empty description, and threading a null through thirteen
+     * call sites to say "unchanged" is noise.
+     */
+    public static void eventFieldsWithThumb(String category,
+                                            String title,
+                                            String description,
+                                            String author,
+                                            List<Field> fields,
+                                            String thumbnailUrl) {
         final String now = ts();
 
         // Console echo
         StringBuilder console = new StringBuilder();
         console.append("[").append(now).append("] ")
                 .append(title == null || title.isBlank() ? category : title).append(": ");
+        if (description != null && !description.isBlank()) {
+            console.append(description);
+            if (fields != null && !fields.isEmpty()) console.append(" | ");
+        }
         if (fields != null && !fields.isEmpty()) {
             boolean first = true;
             for (Field f : fields) {
@@ -340,7 +360,7 @@ public final class Log {
                     plugin,
                     webhookUrl,
                     /*title*/        (title == null || title.isBlank()) ? category : title,
-                    /*description*/  "",
+                    /*description*/  description == null ? "" : description,
                     /*color*/        colorFor(category),
                     /*timestampIso*/ OffsetDateTime.now(ZoneOffset.UTC).toString(),
                     /*author*/       (author == null || author.isBlank()) ? embedAuthorName : author,
@@ -353,6 +373,9 @@ public final class Log {
             sb.append("`").append(now).append("`").append(nameSegment())
                     .append(" - **").append(category).append("**: ")
                     .append(title == null || title.isBlank() ? "" : title + "\n");
+            if (description != null && !description.isBlank()) {
+                sb.append(description).append("\n");
+            }
             if (fields != null) {
                 for (Field f : fields) {
                     sb.append("- ").append(f.name).append(" ")

--- a/src/main/java/com/discordlogger/webhook/DiscordWebhook.java
+++ b/src/main/java/com/discordlogger/webhook/DiscordWebhook.java
@@ -81,7 +81,25 @@ public final class DiscordWebhook {
             String[][] fields // each element: { name, value, inline("true"/"false") }
     ) {
         if (url == null || url.isBlank()) return;
+        dispatch(plugin, url, buildEmbedJson(title, description, color, timestampIso,
+                author, footer, thumbnailUrl, fields));
+    }
 
+    /**
+     * Builds the embed payload. Split from the send so the exact JSON that reaches
+     * Discord can be asserted in a test — it is the user-visible output format, and
+     * a silent change to it is not something a compiler catches.
+     */
+    static String buildEmbedJson(
+            String title,
+            String description,
+            int color,
+            String timestampIso,
+            String author,
+            String footer,
+            String thumbnailUrl,
+            String[][] fields
+    ) {
         StringBuilder sb = new StringBuilder(512);
         sb.append("{\"content\":null,\"embeds\":[{");
 
@@ -128,8 +146,7 @@ public final class DiscordWebhook {
 
         trimComma(sb);
         sb.append("}],\"attachments\":[]}");
-
-        dispatch(plugin, url, sb.toString());
+        return sb.toString();
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -91,6 +91,7 @@ log:
     death: # Player Death (with death message)
       enabled: true
       color: "#ED4245" # red
+      show_coords: false # Adds where the player died. Anyone who can see the channel can find the body
     advancement: # Logs when a player gets an advancement
       enabled: true
       color: "#2ECC71" # green

--- a/src/test/java/com/discordlogger/config/ConfigMigratorUpgradeTest.java
+++ b/src/test/java/com/discordlogger/config/ConfigMigratorUpgradeTest.java
@@ -88,6 +88,26 @@ class ConfigMigratorUpgradeTest {
     }
 
     @Test
+    @DisplayName("a sub-option added to the open schema takes its default, not a stale value")
+    void newSubOptionsDefaultSafely() {
+        // show_coords did not exist in v9, so an upgrading user must land on the
+        // shipped default. It defaults to false because a death message with
+        // coordinates tells the whole channel where the body and its loot are.
+        Map<?, ?> r = upgradeFromV9();
+        assertEquals(false, event(r, "player", "death").get("show_coords"));
+    }
+
+    @Test
+    @DisplayName("an existing sub-option choice is preserved across a migration")
+    void subOptionChoiceSurvives() {
+        String opted = shipped.replace("      show_coords: false", "      show_coords: true");
+        String out = ConfigMigrator.migrateText(shipped, opted, current, current);
+        Map<?, ?> r = (Map<?, ?>) new Yaml().load(out);
+        assertEquals(true, event(r, "player", "death").get("show_coords"),
+                "a user who opted in must not be silently opted back out");
+    }
+
+    @Test
     @DisplayName("settings outside the log tree survive untouched")
     void unrelatedSettingsSurvive() {
         Map<?, ?> r = upgradeFromV9();

--- a/src/test/java/com/discordlogger/listener/player/PlayerDeathCauseTest.java
+++ b/src/test/java/com/discordlogger/listener/player/PlayerDeathCauseTest.java
@@ -1,0 +1,73 @@
+package com.discordlogger.listener.player;
+
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Every way the server can kill a player has words for it.
+ *
+ * <p>This exists because thirteen of the thirty-three damage causes — including the
+ * one behind {@code /kill} — silently fell through to "Cause of Death: Died". That
+ * is invisible until someone dies that particular way, so the gap is closed by
+ * walking the API's own enum rather than by listing the ones anyone thought of.
+ */
+class PlayerDeathCauseTest {
+
+    @ParameterizedTest
+    @EnumSource(DamageCause.class)
+    @DisplayName("every damage cause the API declares has phrasing")
+    void everyCauseIsHandled(DamageCause cause) {
+        assertNotNull(PlayerDeath.causeText(cause),
+                cause + " has no phrasing, so a player dying this way would be reported "
+                        + "as a bare \"Died\". Add a case for it.");
+    }
+
+    @Test
+    @DisplayName("a future Paper release adding a cause fails here, not in production")
+    void causeTextIsExhaustive() {
+        List<String> unhandled = new ArrayList<>();
+        for (DamageCause cause : DamageCause.values()) {
+            if (PlayerDeath.causeText(cause) == null) unhandled.add(cause.name());
+        }
+        assertEquals(List.of(), unhandled,
+                "these damage causes have no phrasing and would report as \"Died\"");
+    }
+
+    @Test
+    @DisplayName("/kill reads as a command, not as a mystery")
+    void killCommandIsNamed() {
+        // The reported case: /kill produced "Cause of Death: Died".
+        assertEquals("Killed by command", PlayerDeath.causeText(DamageCause.KILL));
+        assertEquals("Killed by command", PlayerDeath.causeText(DamageCause.SUICIDE));
+    }
+
+    @Test
+    @DisplayName("phrasing reads as a standalone field value")
+    void phrasingIsStandalone() {
+        for (DamageCause cause : DamageCause.values()) {
+            String text = PlayerDeath.causeText(cause);
+            assertTrue(Character.isUpperCase(text.charAt(0)),
+                    cause + " -> \"" + text + "\" should start capitalised; it is a field value, "
+                            + "not the middle of a sentence");
+            assertTrue(text.equals(text.strip()) && !text.isBlank(), cause + " -> \"" + text + "\"");
+            assertTrue(text.length() <= 64, cause + " -> \"" + text + "\" is too long for a field");
+        }
+    }
+
+    @Test
+    @DisplayName("no cause yields null, so the caller can fall back")
+    void nullCauseIsHandled() {
+        assertNull(PlayerDeath.causeText(null));
+    }
+}

--- a/src/test/java/com/discordlogger/webhook/DeathEmbedPayloadTest.java
+++ b/src/test/java/com/discordlogger/webhook/DeathEmbedPayloadTest.java
@@ -1,0 +1,99 @@
+package com.discordlogger.webhook;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The exact JSON a death sends to Discord.
+ *
+ * <p>This is user-visible output with an agreed shape — title, a description naming
+ * the player, a "Cause of Death" field always, and a "Coords" field only when the
+ * server opted in. None of that is enforced by the compiler, so it is pinned here.
+ */
+class DeathEmbedPayloadTest {
+
+    private static final int RED = 0xED4245;
+    private static final String THUMB = "https://example.invalid/head.png";
+
+    private static String[][] fields(String... nameValuePairs) {
+        String[][] out = new String[nameValuePairs.length / 2][];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = new String[]{nameValuePairs[i * 2], nameValuePairs[i * 2 + 1], "false"};
+        }
+        return out;
+    }
+
+    private static String deathPayload(boolean withCoords) {
+        String[][] f = withCoords
+                ? fields("Cause of Death", "Fell from a high place",
+                         "Coords", "128, 71, -344 in world")
+                : fields("Cause of Death", "Fell from a high place");
+        return DiscordWebhook.buildEmbedJson(
+                "Player Death", "Lachlan died", RED,
+                "2026-07-31T06:00:00Z", "Server Logs", "DiscordLogger v2.2.0", THUMB, f);
+    }
+
+    @Test
+    @DisplayName("the embed carries the title, description and cause field")
+    void hasTitleDescriptionAndCause() {
+        String json = deathPayload(false);
+        assertTrue(json.contains("\"title\":\"Player Death\""), json);
+        assertTrue(json.contains("\"description\":\"Lachlan died\""), json);
+        assertTrue(json.contains("\"name\":\"Cause of Death\""), json);
+        assertTrue(json.contains("\"value\":\"Fell from a high place\""), json);
+    }
+
+    @Test
+    @DisplayName("Coords is absent unless the server opted in")
+    void coordsOnlyWhenEnabled() {
+        assertFalse(deathPayload(false).contains("Coords"),
+                "show_coords is off by default; the field must not appear at all");
+        assertTrue(deathPayload(true).contains("\"name\":\"Coords\""));
+        assertTrue(deathPayload(true).contains("\"value\":\"128, 71, -344 in world\""));
+    }
+
+    @Test
+    @DisplayName("Cause of Death comes before Coords")
+    void causeIsListedFirst() {
+        String json = deathPayload(true);
+        assertTrue(json.indexOf("Cause of Death") < json.indexOf("\"name\":\"Coords\""),
+                "cause is the headline detail and must lead");
+    }
+
+    @Test
+    @DisplayName("the envelope is the shape Discord expects")
+    void envelopeShape() {
+        String json = deathPayload(true);
+        assertTrue(json.startsWith("{\"content\":null,\"embeds\":[{"), json);
+        assertTrue(json.endsWith("}],\"attachments\":[]}"), json);
+        assertTrue(json.contains("\"author\":{\"name\":\"Server Logs\"}"), json);
+        assertTrue(json.contains("\"color\":" + RED), json);
+        // No trailing comma before a closing brace — Discord rejects the whole payload.
+        assertFalse(json.contains(",}"), json);
+        assertFalse(json.contains(",]"), json);
+    }
+
+    @Test
+    @DisplayName("a player name with quotes cannot break the payload")
+    void escapesFieldContent() {
+        String json = DiscordWebhook.buildEmbedJson(
+                "Player Death", "He said \"hi\" died", RED, null, null, null, null,
+                fields("Cause of Death", "Slain by A\\B"));
+        assertFalse(json.contains("\"hi\""), "raw quotes would terminate the JSON string early");
+        assertTrue(json.contains("\\\"hi\\\""), json);
+        assertTrue(json.contains("A\\\\B"), json);
+    }
+
+    @Test
+    @DisplayName("no fields at all still produces valid JSON")
+    void handlesEmptyFields() {
+        String json = DiscordWebhook.buildEmbedJson(
+                "Player Death", "Lachlan died", RED, null, null, null, null, new String[0][]);
+        assertFalse(json.contains("\"fields\""));
+        assertTrue(json.endsWith("}],\"attachments\":[]}"), json);
+        assertFalse(json.contains(",}"), json);
+    }
+}


### PR DESCRIPTION
`log.player.death.show_coords` appends `at x, y, z in world` to death messages.

**Defaults to `false`, deliberately.** A death message with coordinates tells everyone who can read the channel exactly where the body — and the inventory it dropped — is. Useful on a private server, a griefing tool on a public one. Opt-in beats discovering it after the fact.

## Schema

Edits **v10 in place** rather than opening v11: 2.2.0 is unreleased, so v10 is still open and a key change doesn't freeze it (AGENTS.md Phase 0). Nothing to migrate — v9 users land on the shipped default.

## Generator

Sub-options are handled generically via an `extras` list in `options.json`, so the next one needs no JavaScript. Renders indented under its parent event with a warning note, and **"Select all" deliberately skips it** — turning every event on must never silently start broadcasting death locations. Verified in the browser: indent applied, off by default, still off after Select all.

## Two bugs found while verifying — both pre-existing in the v10 copy-forward

**1. `v10/generator.js` still declared `CONFIG_VERSION = 'v9'`.** That drives the key it registers under, *and* the directory it fetches `options.json` and the template from. So the v10 generator registered as v9 and served v9's data — it would have silently produced a **v9 config** for v10 users. Valid YAML, wrong file, no error anywhere.

Only surfaced by actually driving the UI; reading the diff would never have shown it. The validator now checks that each bundle declares the schema it lives in, and I confirmed the check fails when reverted.

**2. The validator's config parser only recognised `enabled`** as an event's toggle, so a sub-option's Java fallback went unchecked. It now reads every boolean child — confirmed by pointing the Java at a non-existent key and watching it fail.

## Verification

- 55 tests pass, including two new ones: the sub-option defaults safely on upgrade, and an existing opt-in survives migration
- `validate-config-generator.py` clean
- Generator simulated end to end — both opted-in and default produce valid YAML
