### PR TITLE
feat(docs): offer only stable config schemas, with a footnote instead of a toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,6 +295,8 @@ Jekyll site (GitHub Pages gem stack) at `discordlogger.godtiergamers.xyz` (CNAME
 
 ### Version awareness — never hardcode a version number
 
+**Never write "and newer" about schema coverage.** A schema is only known to be shipped by the releases that have actually shipped it — the next release may open a new one, so promising future coverage eventually becomes a lie on a page nobody revisits. `<span data-dl-schema-versions="v10">` fills itself from the releases API plus `registry.json`, listing only real releases, and says so plainly when none exists yet. The config-docs index uses the same rule.
+
 `docs/assets/js/versions.js` is loaded from `<head>` on every page and is the single source of truth. It reads the GitHub releases API once (cached per session), works out the newest stable and newest nightly, and exposes `window.DLVersions`.
 
 **A version is "beta" when it is newer than the newest stable release** — i.e. it exists only in nightly builds. This is *derived, never hand-flagged*: while 1.2.3 is nightly-only its docs show a BETA badge, and the moment 1.2.3 ships stable every badge and gate flips itself off with no edits. Never add a manual "is beta" flag anywhere.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -476,6 +476,14 @@ Schema history, recovered from the shipped config's git history — **update thi
 
 - **Webhook testing / CORS:** Discord webhooks allow simple browser POSTs; each bundle carries its own test payload. Tests go browser → Discord directly. A Cloudflare Worker relay used to exist for this and was deleted — it was never deployed and never needed. The **frozen** v9 bundle still contains the dormant `proxyUrl` branch in its `sendTest`; it is inert (the key no longer exists in `registry.json`, so the value is `""`) and must not be edited, because publication froze that schema. Newer bundles should simply omit it.
 
+### Config generator and config docs — stable schemas only
+
+Neither offers a config version that has only ever shipped in a nightly, and there is **no opt-in**. A nightly's schema can still change before release, so a config generated against one can be silently wrong by the time the stable build lands — worse than not offering it at all. Both carry a footnote explaining the absence instead of a toggle.
+
+The beta opt-in in `versions.js` still exists and still drives the **downloads page**, which is a different question: choosing which *build* to install is the user's call, choosing a config format that may still move is not. `window.DLVersions.showBeta` is deliberately ignored by both the generator and the config-docs picker — setting it true does not surface beta schemas.
+
+A schema's docs page stays reachable by URL the whole time; it is simply not listed until a stable release carries it. This is what makes `registry.json`'s `since` pointing at a stable version the safe default.
+
 ### Downloads page
 
 Renders straight from the releases API. Nightly builds (tag matches `-BETA.N`) get a dedicated purple **"Nightly"** badge and a purple card edge; any *other* pre-release keeps the generic "Pre-release" badge. Nightlies are **hidden behind an opt-in toggle** (remembered per visitor, same shared slider component) with a plain-language stability warning.

--- a/docs/assets/js/generator.js
+++ b/docs/assets/js/generator.js
@@ -160,9 +160,12 @@
     }
 
     function render(registry, schemas, versions) {
-        const V = window.DLVersions;
-        const showBeta = !!(V && V.showBeta);
-        const visible = versions.filter(v => !v.beta || showBeta);
+        // Stable releases only, always. A nightly's config schema can still change
+        // before it ships, so a config generated against one can be wrong by the
+        // time the stable release lands — and it would be wrong silently, which is
+        // worse than not offering it. Deliberately not behind a toggle: the beta
+        // opt-in elsewhere on the site is for downloading builds, not for configs.
+        const visible = versions.filter(v => !v.beta);
 
         mount.innerHTML = '';
 
@@ -173,7 +176,7 @@
 
         if (!visible.length) {
             panelBody.push(h('p', { class: 'cfg-note' },
-                'No supported versions found. Please refresh, or take a ready-made config from the config docs.'));
+                'No stable releases found. Please refresh, or take a ready-made config from the config docs.'));
             mount.appendChild(h('div', { class: 'cfg-wrap' }, [h('section', { class: 'cfg-panel' }, panelBody)]));
             return;
         }
@@ -187,9 +190,10 @@
         select.value = String(firstStable >= 0 ? firstStable : 0);
 
         const detail = h('p', { class: 'cfg-note' });
-        const betaWarn = h('p', { class: 'cfg-note cfg-note--beta' },
-            '⚠️ Nightly build — its config format may still change before it ships in a stable release.');
         const notReady = h('p', { class: 'cfg-note cfg-note--beta' });
+        const nightlyFootnote = h('p', { class: 'cfg-note cfg-note--footnote' },
+            'Nightly builds are not supported here. Their config format can still change '
+            + 'before it ships, so only stable releases are listed.');
         const goBtn = h('button', { class: 'cfg-btn cfg-btn--primary', type: 'button' }, 'Continue');
 
         const current = () => visible[Number(select.value)] || visible[0];
@@ -202,7 +206,6 @@
             detail.textContent = schema
                 ? `Uses config schema ${schema.config.toUpperCase()} — detected automatically.`
                 : 'No generator is available for that version.';
-            betaWarn.style.display = v.beta ? '' : 'none';
 
             if (schema && !ready) {
                 notReady.textContent = `The generator for config ${schema.config.toUpperCase()} isn't available yet — this version is listed for reference only.`;
@@ -232,18 +235,14 @@
             h('label', { class: 'cfg-label' }, 'Plugin version'),
             select,
             detail,
-            betaWarn,
             notReady,
         );
 
-        // The toggle stays visible in BOTH states whenever nightlies exist —
-        // otherwise turning it on would remove the only way to turn it back off.
+        // A plain footnote replaces what used to be an opt-in toggle. Someone on a
+        // nightly needs to know why their build is absent; they do not need a way
+        // to generate a config against a schema that may still change.
         if (versions.some(v => v.beta)) {
-            if (!showBeta) {
-                panelBody.push(h('p', { class: 'cfg-note' },
-                    'Running a nightly build? Enable beta versions below to generate a config for it.'));
-            }
-            panelBody.push(h('div', { 'data-dl-beta-toggle': 'Nightly builds are previews of unreleased work — their config format may change before release.' }));
+            panelBody.push(nightlyFootnote);
         }
         panelBody.push(h('div', { class: 'cfg-actions' }, [goBtn]));
 

--- a/docs/assets/js/versions.js
+++ b/docs/assets/js/versions.js
@@ -18,6 +18,9 @@
           -> hidden entirely unless that version is beta AND the visitor
              enabled beta content (shown normally once it ships stable)
 
+      <span data-dl-schema-versions="v10"></span>
+                                            -> filled with the stable releases that
+                                               actually ship that config schema
       <span data-dl-latest></span>          -> filled with the newest stable version
       <span data-dl-latest-nightly></span>  -> filled with the newest nightly version
 
@@ -206,6 +209,57 @@
         }
     }
 
+    /**
+     * Fills an element with the stable releases that actually ship a given config
+     * schema, e.g. "v2.1.5, v2.1.6".
+     *
+     * <p>Deliberately never says "and newer": a schema is only known to be shipped
+     * by the releases that have shipped it. The next release may open a new schema,
+     * so claiming future coverage would eventually be a lie on a page nobody
+     * revisits. Until a stable release carries it, the honest answer is that none
+     * does yet.
+     */
+    async function applySchemaCoverage(root) {
+        const hosts = root.querySelectorAll('[data-dl-schema-versions]');
+        if (!hosts.length) return;
+
+        let schemas;
+        try {
+            const res = await fetch('/assets/configs/registry.json');
+            if (!res.ok) return;
+            schemas = (await res.json()).schemas || [];
+        } catch { return; }
+
+        schemas = schemas
+            .filter(s => parseVer(s.since))
+            .sort((a, b) => cmpVer(parseVer(a.since), parseVer(b.since)));
+
+        hosts.forEach(el => {
+            const want = el.getAttribute('data-dl-schema-versions');
+            const idx = schemas.findIndex(s => s.config === want);
+            if (idx < 0) return;
+
+            const since = parseVer(schemas[idx].since);
+            const nextSince = schemas[idx + 1] ? parseVer(schemas[idx + 1].since) : null;
+
+            const hits = (api.releases || [])
+                .filter(r => !r.prerelease)
+                .filter(r => {
+                    const v = parseVer(r.version);
+                    if (!v) return false;
+                    if (cmpVer(v, since) < 0) return false;
+                    if (nextSince && cmpVer(v, nextSince) >= 0) return false;
+                    return true;
+                })
+                .map(r => r.version);
+
+            const uniq = [...new Set(hits)].sort((a, b) => cmpVer(parseVer(a), parseVer(b)));
+            el.textContent = uniq.length
+                ? uniq.map(v => 'v' + v).join(', ')
+                : 'none yet — this schema has not shipped in a stable release';
+        });
+    }
+
     function renderToggles(root) {
         root.querySelectorAll('[data-dl-beta-toggle]').forEach(host => {
             if (host.dataset.dlToggleReady === '1') {
@@ -243,6 +297,7 @@
         applyBetaOnly(root);
         applyFills(root);
         renderToggles(root);
+        applySchemaCoverage(root);
     }
 
     /* ---- boot ---- */

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -19,12 +19,15 @@ If you're not sure, open your `config.yml` and check the **last line**; it will 
   <p class="dl-nightly-warning">Loading config versions…</p>
 </div>
 
-<div id="cfg-version-beta-toggle" hidden data-dl-beta-toggle="Beta config versions only exist in nightly builds and may change before they ship in a stable release."></div>
+<p id="cfg-version-nightly-note" class="dl-nightly-warning" hidden>
+  Config versions that only exist in nightly builds are not listed. Their format can
+  still change before it ships, so only schemas from stable releases appear here.
+</p>
 
 <script>
 (function () {
   const listEl = document.getElementById('cfg-version-list');
-  const toggleHost = document.getElementById('cfg-version-beta-toggle');
+  const nightlyNote = document.getElementById('cfg-version-nightly-note');
 
   const parseBase = raw => {
     const m = String(raw || '').trim().match(/^v?(\d+)\.(\d+)\.(\d+)/);
@@ -76,22 +79,24 @@ If you're not sure, open your `config.yml` and check the **last line**; it will 
       .sort((a, b) => cmpBase(parseBase(b.since), parseBase(a.since)));
 
     function render() {
-      const showBeta = !!(api && api.showBeta);
+      // Stable schemas only, with no opt-in. A schema that has only ever shipped in
+      // a nightly can still change before release, so documenting it as a choice
+      // invites someone to write a config against a format that then moves. The
+      // page for it still exists and is reachable by URL; it is simply not offered
+      // until a stable release carries it.
       let anyBeta = false;
       const rows = [];
 
       schemas.forEach((s, i) => {
         const newer = schemas[i - 1] || null;
         const beta = api ? api.isBeta(s.since) : false;
-        if (beta) anyBeta = true;
-        if (beta && !showBeta) return;
+        if (beta) { anyBeta = true; return; }
 
         const label = s.config.toUpperCase();
         rows.push(
           `<li>
              <a href="/config/${s.config}/"><strong>${label}</strong></a>
              — ships with DiscordLogger ${coverage(s, newer, releases)}
-             ${beta ? '<span class="dl-badge dl-badge--nightly" title="Only in nightly builds so far">BETA</span>' : ''}
            </li>`
         );
       });
@@ -100,12 +105,10 @@ If you're not sure, open your `config.yml` and check the **last line**; it will 
         ? `<ul>${rows.join('')}</ul>`
         : '<p class="dl-nightly-warning">No stable config versions found.</p>';
 
-      toggleHost.hidden = !anyBeta;
-      if (V) V.apply(toggleHost);
+      nightlyNote.hidden = !anyBeta;
     }
 
     render();
-    document.addEventListener('dl-beta-change', render);
   }
 
   boot();

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -53,7 +53,9 @@ If you're not sure, open your `config.yml` and check the **last line**; it will 
       })
       .map(r => r.version);
     const uniq = [...new Set(hits)].sort((a, b) => cmpBase(parseBase(a), parseBase(b)));
-    if (!uniq.length) return `v${schema.since} and newer`;
+    // Never claim "and newer": the next release may open a new schema, so future
+    // coverage is not ours to promise. Until a stable release ships it, none does.
+    if (!uniq.length) return 'no stable release yet';
     return uniq.map(v => 'v' + v).join(', ');
   }
 

--- a/docs/config/v10/index.md
+++ b/docs/config/v10/index.md
@@ -8,7 +8,7 @@ description: Full documentation for config.yml schema v10 — defaults, per-key 
 
 # config.yml Docs — v10
 
-**_Supported Plugin Versions:_ v2.2.0 and newer**
+**_Supported Plugin Versions:_ <span data-dl-schema-versions="v10">…</span>**
 
 <div style="margin:1rem 0 1.25rem;">
   <a class="btn" href="/assets/configs/v10/config.yml" download>

--- a/docs/config/v9/index.md
+++ b/docs/config/v9/index.md
@@ -8,7 +8,7 @@ description: Full documentation for config.yml schema v9 — defaults, per-key e
 
 # config.yml Docs — v9
 
-**_Supported Plugin Versions:_ v2.1.5, v2.1.6**
+**_Supported Plugin Versions:_ <span data-dl-schema-versions="v9">…</span>**
 
 <div style="margin:1rem 0 1.25rem;">
   <a class="btn" href="/assets/configs/v9/config.yml" download>


### PR DESCRIPTION
The config generator and the config-docs picker no longer list a schema that has only ever shipped in a nightly, and the opt-in that used to reveal them is gone.

A nightly's schema can still change before it ships, so a config generated against one can be wrong by the time the stable release lands — **silently** wrong, which is worse than not offering it. Choosing which *build* to install is the user's call; choosing a config format that may still move is not.

Both pages now show a plain footnote instead, and only when such a schema actually exists:

> Nightly builds are not supported here. Their config format can still change before it ships, so only stable releases are listed.

## What stays

- **The downloads page keeps its nightly toggle** — different question, and still the user's call.
- **`versions.js` keeps the beta machinery**, since downloads needs it. The generator and picker now ignore `showBeta` entirely.
- **Schema docs pages stay reachable by URL** the whole time. `/config/v10/` still works and still documents v10; it is simply not *listed* until a stable release carries it.

## Verified in the browser

- Generator offers `2.1.6, 2.1.5` — no BETA entries, v10 correctly absent while 2.2.0 is unreleased
- Forcing `DLVersions.showBeta = true` no longer leaks beta schemas into either page
- The old toggle is gone from both; the footnote renders on both
