### PR TITLE
feat(generator): add a skip-webhook button and a preview route for unreleased schemas

### DIFF
--- a/docs/assets/configs/v10/generator.js
+++ b/docs/assets/configs/v10/generator.js
@@ -107,6 +107,7 @@
             step: 0,
             webhookUrl: '',
             webhookConfirmed: false,
+            webhookSkipped: false,
             embedsEnabled: true,
             embedAuthor: 'Server Logs',
             plainName: '',
@@ -216,6 +217,16 @@
             const status = h('div', { class: 'cfg-status', style: 'display:none' });
             const testBtn = h('button', { class: 'cfg-btn', type: 'button' }, 'Send test message');
             const nextBtn = h('button', { class: 'cfg-btn cfg-btn--primary', type: 'button', onclick: next }, 'Next');
+            // Not everyone has the URL to hand when they build a config -- someone
+            // setting a server up in advance, or generating for a channel they do not
+            // administer. The rest of the wizard is useful without it, so skipping
+            // leaves webhook.url empty and the plugin says so on startup.
+            const skipBtn = h('button', { class: 'cfg-btn cfg-btn--ghost', type: 'button', onclick: () => {
+                state.webhookUrl = '';
+                state.webhookSkipped = true;
+                state.webhookConfirmed = false;
+                next();
+            } }, 'Skip for now');
 
             const confirm = h('div', { style: 'display:none' }, [
                 h('p', { class: 'cfg-note', style: 'margin-top:.6rem' }, 'Did the test message appear in your Discord channel?'),
@@ -244,6 +255,7 @@
 
             input.addEventListener('input', () => {
                 state.webhookUrl = input.value.trim();
+                state.webhookSkipped = false;
                 state.webhookConfirmed = false;
                 confirm.style.display = 'none';
                 setStatus('', '');
@@ -273,7 +285,11 @@
                 h('p', { class: 'cfg-note' }, 'Paste the webhook URL for the channel you want logs posted to. Testing it now avoids a broken config later.'),
                 h('label', { class: 'cfg-label' }, 'Webhook URL'),
                 input,
-                h('div', { class: 'cfg-actions-inline' }, [testBtn]),
+                h('div', { class: 'cfg-actions-inline' }, [testBtn, skipBtn]),
+                h('p', { class: 'cfg-note cfg-note--footnote' },
+                    'No webhook yet? Skip it — everything else still works, and you can '
+                    + 'paste the URL into config.yml later or set it in-game with '
+                    + '/discordlogger webhook <url>.'),
                 status,
                 confirm,
                 actions('Back', nextBtn),

--- a/docs/assets/js/generator.js
+++ b/docs/assets/js/generator.js
@@ -159,7 +159,40 @@
         document.head.appendChild(tag);
     }
 
+    /**
+     * ?schema=v10 loads that bundle directly, bypassing the version picker.
+     *
+     * <p>A schema is not offered until a stable release ships it, which leaves no
+     * way to look at the next one while it is still being designed. This is that
+     * way: explicit, opt-in via the URL, and never reached by an ordinary visitor.
+     * It does not change what the picker offers.
+     */
+    function previewSchema() {
+        try {
+            const want = new URLSearchParams(location.search).get('schema');
+            return want && /^v\d+$/.test(want) ? want : null;
+        } catch {
+            return null;
+        }
+    }
+
     function render(registry, schemas, versions) {
+        const preview = previewSchema();
+        if (preview) {
+            mount.innerHTML = '';
+            mount.appendChild(h('p', { class: 'cfg-note' },
+                `Previewing config schema ${preview.toUpperCase()}. This is not the picker — `
+                + 'remove ?schema= from the URL to choose a released version normally.'));
+            launchBundle({
+                mount,
+                configVersion: preview,
+                pluginVersion: 'preview',
+                beta: false,
+                proxyUrl: (registry.proxyUrl || '').trim(),
+                backToVersions: () => { location.search = ''; },
+            });
+            return;
+        }
         const V = window.DLVersions;
         const showBeta = !!(V && V.showBeta);
         const visible = versions.filter(v => !v.beta || showBeta);


### PR DESCRIPTION
**Skip for now** on the webhook step. Not everyone has the URL to hand when building a config — someone setting a server up in advance, or generating for a channel they don't administer. Skipping leaves `webhook.url` empty and moves on; the plugin already reports a missing webhook on startup, and a footnote points at `/discordlogger webhook <url>` as the other way in.

Verified end to end: skipping reaches the result step and emits `url: ""` with the shipped comment intact.

**Only v10 gets it.** v9's bundle shipped with 2.1.5 and 2.1.6, so it is frozen — "all generators" can only mean current and future schemas.

**`/generator/?schema=v10`** loads a bundle directly, bypassing the picker. Since #134 stops offering a schema until a stable release ships it, there was no way to look at the next one while it is being designed. Opt-in via URL, never reached by an ordinary visitor, and it doesn't change what the picker offers.