### PR TITLE
docs: remove the completed Bedrock indicator from TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,6 @@ Got an idea that isn't here? Open a [feature request](https://github.com/GodTier
 - **Per-category webhook routing** — send different log categories to different Discord channels (e.g. moderation to a private staff channel, chat to a public one).
 - **Deeper logging modes** — option to relay the full server console rather than only the specific events currently supported.
 - **Log filtering (allow/deny lists)** — exclude specific entries within a category: e.g. don't log `/whisper` when command logging is on, or ignore a particular player by UUID.
-- **Bedrock vs Java indicator** — show which platform a player connected from.
 - **`lang.yml` with MiniMessage** — move every user-facing string into a language file so wording and formatting can be fully rewritten without touching code.
 
 ## Website & docs


### PR DESCRIPTION
Shipped in #136 and should have been removed with that merge. The protocol is that an item is deleted the moment it's done, so the list stays trustworthy as a picture of what's actually outstanding.