### PR TITLE
feat(webhook): route individual events to their own Discord channel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,8 +217,14 @@ Path-filtered (`dorny/paths-filter`): `build` runs on `src/**`/`pom.xml` changes
 - `dispatch()` hands off to `WebhookQueue` and returns immediately — callers may be on the main thread and must never block on HTTP.
 - `post()` performs one request and **returns a `Response`** (status + rate-limit headers) rather than logging; the queue owns retry/wait/give-up decisions.
 
+### Per-event webhook routing
+
+Every event takes an optional `log.<group>.<event>.webhook`. Empty means the main `webhook.url`, which is the overwhelmingly common case. `Log.webhookFor(category)` resolves it from a map built alongside `colorMap` — same walk, same key normalisation, same atomic swap. An invalid URL is rejected at load with a console warning and that event falls back, rather than posting into the void.
+
+`Log.plain` and the update notices deliberately stay on the main webhook: they belong to no event.
+
 ### `WebhookQueue` (rate limiting)
-- **One worker thread**, which is also the ordering guarantee — logs are a narrative, so out-of-order delivery is its own bug.
+- **One worker per destination**, which is also the ordering guarantee — logs are a narrative, so out-of-order delivery is its own bug.
 - **Proactive pacing:** reads `X-RateLimit-Remaining` / `X-RateLimit-Reset-After` from each response and waits out a spent budget *before* sending, so 429s are usually avoided rather than handled. A 429 is still handled (honours `Retry-After`, retries the same payload without consuming an attempt).
 - Transient failures (5xx, network — status `0`) retry with exponential backoff, max 4 attempts. Other 4xx aren't retried; a 404 says the webhook URL is gone.
 - **Not a Bukkit scheduler task** — it must keep draining during `onDisable`, and the scheduler refuses tasks once disabled.

--- a/docs/assets/configs/v10/config.template.yml
+++ b/docs/assets/configs/v10/config.template.yml
@@ -81,31 +81,38 @@ log:
       color: "{{COLOR_player.join}}" # green
       webhook: "{{HOOK_player.join}}" # Send just this event elsewhere. Empty = use webhook.url above
       show_platform: {{EXTRA_player.join.show_platform}} # Flags players who joined from Bedrock (needs Geyser + Floodgate)
+
     quit: # Player Quit
       enabled: {{LOG_player.quit.enabled}}
       color: "{{COLOR_player.quit}}" # red
       webhook: "{{HOOK_player.quit}}" # Send just this event elsewhere. Empty = use webhook.url above
+
     chat: # Player Chat
       enabled: {{LOG_player.chat.enabled}}
       color: "{{COLOR_player.chat}}" # blurple
       webhook: "{{HOOK_player.chat}}" # Send just this event elsewhere. Empty = use webhook.url above
+
     command: # Commands executed by a player in-game
       enabled: {{LOG_player.command.enabled}}
       color: "{{COLOR_player.command}}" # yellow
       webhook: "{{HOOK_player.command}}" # Send just this event elsewhere. Empty = use webhook.url above
+
     death: # Player Death (with death message)
       enabled: {{LOG_player.death.enabled}}
       color: "{{COLOR_player.death}}" # red
       webhook: "{{HOOK_player.death}}" # Send just this event elsewhere. Empty = use webhook.url above
       show_coords: {{EXTRA_player.death.show_coords}} # Adds where the player died. Anyone who can see the channel can find the body
+
     advancement: # Logs when a player gets an advancement
       enabled: {{LOG_player.advancement.enabled}}
       color: "{{COLOR_player.advancement}}" # green
       webhook: "{{HOOK_player.advancement}}" # Send just this event elsewhere. Empty = use webhook.url above
+
     teleport: # Logs when a player teleports
       enabled: {{LOG_player.teleport.enabled}}
       color: "{{COLOR_player.teleport}}" # blue
       webhook: "{{HOOK_player.teleport}}" # Send just this event elsewhere. Empty = use webhook.url above
+
     gamemode: # Logs when a players gamemode changes
       enabled: {{LOG_player.gamemode.enabled}}
       color: "{{COLOR_player.gamemode}}" # purple
@@ -116,14 +123,17 @@ log:
       enabled: {{LOG_server.command.enabled}}
       color: "{{COLOR_server.command}}" # pink
       webhook: "{{HOOK_server.command}}" # Send just this event elsewhere. Empty = use webhook.url above
+
     start: # Logged when the plugin/server starts
       enabled: {{LOG_server.start.enabled}}
       color: "{{COLOR_server.start}}" # green
       webhook: "{{HOOK_server.start}}" # Send just this event elsewhere. Empty = use webhook.url above
+
     stop: # Logged on /stop / clean shutdown
       enabled: {{LOG_server.stop.enabled}}
       color: "{{COLOR_server.stop}}" # red
       webhook: "{{HOOK_server.stop}}" # Send just this event elsewhere. Empty = use webhook.url above
+
     explosion: # Log when an explosion occurs
       enabled: {{LOG_server.explosion.enabled}}
       color: "{{COLOR_server.explosion}}" # red
@@ -134,29 +144,34 @@ log:
       enabled: {{LOG_moderation.ban.enabled}}
       color: "{{COLOR_moderation.ban}}" # red
       webhook: "{{HOOK_moderation.ban}}" # Send just this event elsewhere. Empty = use webhook.url above
+
     unban: # Logs when a player has been unbanned
       enabled: {{LOG_moderation.unban.enabled}}
       color: "{{COLOR_moderation.unban}}" # red
       webhook: "{{HOOK_moderation.unban}}" # Send just this event elsewhere. Empty = use webhook.url above
+
     kick: # Logs when a player has been kicked
       enabled: {{LOG_moderation.kick.enabled}}
       color: "{{COLOR_moderation.kick}}" # red
       webhook: "{{HOOK_moderation.kick}}" # Send just this event elsewhere. Empty = use webhook.url above
+
     op: # Logs when a player is granted op premissions
       enabled: {{LOG_moderation.op.enabled}}
       color: "{{COLOR_moderation.op}}" # red
       webhook: "{{HOOK_moderation.op}}" # Send just this event elsewhere. Empty = use webhook.url above
+
     deop: # Logs when a players op permissions are revoked
       enabled: {{LOG_moderation.deop.enabled}}
       color: "{{COLOR_moderation.deop}}" # red
       webhook: "{{HOOK_moderation.deop}}" # Send just this event elsewhere. Empty = use webhook.url above
+
     whitelist_toggle: # Logs when the whitelist is enabled/disabled
       enabled: {{LOG_moderation.whitelist_toggle.enabled}}
       color: "{{COLOR_moderation.whitelist_toggle}}" # teal
       webhook: "{{HOOK_moderation.whitelist_toggle}}" # Send just this event elsewhere. Empty = use webhook.url above
+
     whitelist_edit: # Logs when players are added/removed from the whitelist
       enabled: {{LOG_moderation.whitelist_edit.enabled}}
       color: "{{COLOR_moderation.whitelist_edit}}" # dark teal
       webhook: "{{HOOK_moderation.whitelist_edit}}" # Send just this event elsewhere. Empty = use webhook.url above
-
 # CONFIG VERSION V10, GENERATED ON WEBSITE ON {{GENERATED_AT}}

--- a/docs/assets/configs/v10/config.template.yml
+++ b/docs/assets/configs/v10/config.template.yml
@@ -79,65 +79,84 @@ log:
     join: # Player Join
       enabled: {{LOG_player.join.enabled}}
       color: "{{COLOR_player.join}}" # green
+      webhook: "{{HOOK_player.join}}" # Send just this event elsewhere. Empty = use webhook.url above
       show_platform: {{EXTRA_player.join.show_platform}} # Flags players who joined from Bedrock (needs Geyser + Floodgate)
     quit: # Player Quit
       enabled: {{LOG_player.quit.enabled}}
       color: "{{COLOR_player.quit}}" # red
+      webhook: "{{HOOK_player.quit}}" # Send just this event elsewhere. Empty = use webhook.url above
     chat: # Player Chat
       enabled: {{LOG_player.chat.enabled}}
       color: "{{COLOR_player.chat}}" # blurple
+      webhook: "{{HOOK_player.chat}}" # Send just this event elsewhere. Empty = use webhook.url above
     command: # Commands executed by a player in-game
       enabled: {{LOG_player.command.enabled}}
       color: "{{COLOR_player.command}}" # yellow
+      webhook: "{{HOOK_player.command}}" # Send just this event elsewhere. Empty = use webhook.url above
     death: # Player Death (with death message)
       enabled: {{LOG_player.death.enabled}}
       color: "{{COLOR_player.death}}" # red
+      webhook: "{{HOOK_player.death}}" # Send just this event elsewhere. Empty = use webhook.url above
       show_coords: {{EXTRA_player.death.show_coords}} # Adds where the player died. Anyone who can see the channel can find the body
     advancement: # Logs when a player gets an advancement
       enabled: {{LOG_player.advancement.enabled}}
       color: "{{COLOR_player.advancement}}" # green
+      webhook: "{{HOOK_player.advancement}}" # Send just this event elsewhere. Empty = use webhook.url above
     teleport: # Logs when a player teleports
       enabled: {{LOG_player.teleport.enabled}}
       color: "{{COLOR_player.teleport}}" # blue
+      webhook: "{{HOOK_player.teleport}}" # Send just this event elsewhere. Empty = use webhook.url above
     gamemode: # Logs when a players gamemode changes
       enabled: {{LOG_player.gamemode.enabled}}
       color: "{{COLOR_player.gamemode}}" # purple
+      webhook: "{{HOOK_player.gamemode}}" # Send just this event elsewhere. Empty = use webhook.url above
 
   server:
     command: # Commands executed via the server console/terminal
       enabled: {{LOG_server.command.enabled}}
       color: "{{COLOR_server.command}}" # pink
+      webhook: "{{HOOK_server.command}}" # Send just this event elsewhere. Empty = use webhook.url above
     start: # Logged when the plugin/server starts
       enabled: {{LOG_server.start.enabled}}
       color: "{{COLOR_server.start}}" # green
+      webhook: "{{HOOK_server.start}}" # Send just this event elsewhere. Empty = use webhook.url above
     stop: # Logged on /stop / clean shutdown
       enabled: {{LOG_server.stop.enabled}}
       color: "{{COLOR_server.stop}}" # red
+      webhook: "{{HOOK_server.stop}}" # Send just this event elsewhere. Empty = use webhook.url above
     explosion: # Log when an explosion occurs
       enabled: {{LOG_server.explosion.enabled}}
       color: "{{COLOR_server.explosion}}" # red
+      webhook: "{{HOOK_server.explosion}}" # Send just this event elsewhere. Empty = use webhook.url above
 
   moderation:
     ban: # Logs when a player has been banned
       enabled: {{LOG_moderation.ban.enabled}}
       color: "{{COLOR_moderation.ban}}" # red
+      webhook: "{{HOOK_moderation.ban}}" # Send just this event elsewhere. Empty = use webhook.url above
     unban: # Logs when a player has been unbanned
       enabled: {{LOG_moderation.unban.enabled}}
       color: "{{COLOR_moderation.unban}}" # red
+      webhook: "{{HOOK_moderation.unban}}" # Send just this event elsewhere. Empty = use webhook.url above
     kick: # Logs when a player has been kicked
       enabled: {{LOG_moderation.kick.enabled}}
       color: "{{COLOR_moderation.kick}}" # red
+      webhook: "{{HOOK_moderation.kick}}" # Send just this event elsewhere. Empty = use webhook.url above
     op: # Logs when a player is granted op premissions
       enabled: {{LOG_moderation.op.enabled}}
       color: "{{COLOR_moderation.op}}" # red
+      webhook: "{{HOOK_moderation.op}}" # Send just this event elsewhere. Empty = use webhook.url above
     deop: # Logs when a players op permissions are revoked
       enabled: {{LOG_moderation.deop.enabled}}
       color: "{{COLOR_moderation.deop}}" # red
+      webhook: "{{HOOK_moderation.deop}}" # Send just this event elsewhere. Empty = use webhook.url above
     whitelist_toggle: # Logs when the whitelist is enabled/disabled
       enabled: {{LOG_moderation.whitelist_toggle.enabled}}
       color: "{{COLOR_moderation.whitelist_toggle}}" # teal
+      webhook: "{{HOOK_moderation.whitelist_toggle}}" # Send just this event elsewhere. Empty = use webhook.url above
     whitelist_edit: # Logs when players are added/removed from the whitelist
       enabled: {{LOG_moderation.whitelist_edit.enabled}}
       color: "{{COLOR_moderation.whitelist_edit}}" # dark teal
+      webhook: "{{HOOK_moderation.whitelist_edit}}" # Send just this event elsewhere. Empty = use webhook.url above
 
 # CONFIG VERSION V10, GENERATED ON WEBSITE ON {{GENERATED_AT}}

--- a/docs/assets/configs/v10/config.yml
+++ b/docs/assets/configs/v10/config.yml
@@ -79,65 +79,84 @@ log:
     join: # Player Join
       enabled: true
       color: "#57F287" # green
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
       show_platform: true # Flags players who joined from Bedrock (needs Geyser + Floodgate)
     quit: # Player Quit
       enabled: true
       color: "#ED4245" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     chat: # Player Chat
       enabled: true
       color: "#5865F2" # blurple
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     command: # Commands executed by a player in-game
       enabled: true
       color: "#FEE75C" # yellow
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     death: # Player Death (with death message)
       enabled: true
       color: "#ED4245" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
       show_coords: false # Adds where the player died. Anyone who can see the channel can find the body
     advancement: # Logs when a player gets an advancement
       enabled: true
       color: "#2ECC71" # green
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     teleport: # Logs when a player teleports
       enabled: true
       color: "#3498DB" # blue
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     gamemode: # Logs when a players gamemode changes
       enabled: true
       color: "#9B59B6" # purple
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
 
   server:
     command: # Commands executed via the server console/terminal
       enabled: true
       color: "#EB459E" # pink
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     start: # Logged when the plugin/server starts
       enabled: true
       color: "#43B581" # green
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     stop: # Logged on /stop / clean shutdown
       enabled: true
       color: "#ED4245" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     explosion: # Log when an explosion occurs
       enabled: true
       color: "#E74C3C" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
 
   moderation:
     ban: # Logs when a player has been banned
       enabled: true
       color: "#FF0000" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     unban: # Logs when a player has been unbanned
       enabled: true
       color: "#FF0000" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     kick: # Logs when a player has been kicked
       enabled: true
       color: "#FF0000" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     op: # Logs when a player is granted op premissions
       enabled: true
       color: "#FF0000" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     deop: # Logs when a players op permissions are revoked
       enabled: true
       color: "#FF0000" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     whitelist_toggle: # Logs when the whitelist is enabled/disabled
       enabled: true
       color: "#1ABC9C" # teal
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     whitelist_edit: # Logs when players are added/removed from the whitelist
       enabled: true
       color: "#16A085" # dark teal
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
 
 # CONFIG VERSION V10, DOWNLOADED FROM WEBSITE

--- a/docs/assets/configs/v10/config.yml
+++ b/docs/assets/configs/v10/config.yml
@@ -81,31 +81,38 @@ log:
       color: "#57F287" # green
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
       show_platform: true # Flags players who joined from Bedrock (needs Geyser + Floodgate)
+
     quit: # Player Quit
       enabled: true
       color: "#ED4245" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     chat: # Player Chat
       enabled: true
       color: "#5865F2" # blurple
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     command: # Commands executed by a player in-game
       enabled: true
       color: "#FEE75C" # yellow
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     death: # Player Death (with death message)
       enabled: true
       color: "#ED4245" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
       show_coords: false # Adds where the player died. Anyone who can see the channel can find the body
+
     advancement: # Logs when a player gets an advancement
       enabled: true
       color: "#2ECC71" # green
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     teleport: # Logs when a player teleports
       enabled: true
       color: "#3498DB" # blue
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     gamemode: # Logs when a players gamemode changes
       enabled: true
       color: "#9B59B6" # purple
@@ -116,14 +123,17 @@ log:
       enabled: true
       color: "#EB459E" # pink
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     start: # Logged when the plugin/server starts
       enabled: true
       color: "#43B581" # green
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     stop: # Logged on /stop / clean shutdown
       enabled: true
       color: "#ED4245" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     explosion: # Log when an explosion occurs
       enabled: true
       color: "#E74C3C" # red
@@ -134,29 +144,34 @@ log:
       enabled: true
       color: "#FF0000" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     unban: # Logs when a player has been unbanned
       enabled: true
       color: "#FF0000" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     kick: # Logs when a player has been kicked
       enabled: true
       color: "#FF0000" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     op: # Logs when a player is granted op premissions
       enabled: true
       color: "#FF0000" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     deop: # Logs when a players op permissions are revoked
       enabled: true
       color: "#FF0000" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     whitelist_toggle: # Logs when the whitelist is enabled/disabled
       enabled: true
       color: "#1ABC9C" # teal
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     whitelist_edit: # Logs when players are added/removed from the whitelist
       enabled: true
       color: "#16A085" # dark teal
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
-
 # CONFIG VERSION V10, DOWNLOADED FROM WEBSITE

--- a/docs/assets/configs/v10/generator.js
+++ b/docs/assets/configs/v10/generator.js
@@ -116,6 +116,7 @@
             template: null,
             toggles: {},
             extras: {},
+            hooks: {},
             colors: {},
         };
 
@@ -125,6 +126,7 @@
             { id: 'style',   title: 'Log style' },
             { id: 'events',  title: 'Events to log' },
             { id: 'colors',  title: 'Embed colors' },
+            { id: 'routing', title: 'Per-event channels' },
             { id: 'result',  title: 'Your config.yml' },
         ];
 
@@ -164,6 +166,8 @@
                 for (const extra of (item.extras || [])) {
                     state.extras[extra.key] = !!extra.default;
                 }
+                // Empty means "use the main webhook", which is what almost everyone wants.
+                if (item.webhookKey) state.hooks[item.webhookKey] = '';
             }
         }
 
@@ -460,6 +464,55 @@
                 h('h2', { class: 'cfg-title' }, '5) Embed colors'),
                 h('p', { class: 'cfg-note' }, 'These default to the plugin\'s own colors — adjust any you like.'),
                 wrap,
+                actions('Back', h('button', { class: 'cfg-btn cfg-btn--primary', type: 'button', onclick: next }, 'Next')),
+            ]);
+        };
+
+        renderers.routing = () => {
+            const wrap = h('div', {});
+            let any = false;
+
+            for (const cat of (state.options.categories || [])) {
+                const rows = (cat.items || []).filter(item => {
+                    const k = toggleKey(item.configKey);
+                    // Only offer routing for events actually being logged — a channel
+                    // for an event you turned off is a setting that does nothing.
+                    return item.webhookKey && k && state.toggles[k];
+                });
+                if (!rows.length) continue;
+                any = true;
+
+                const box = h('div', { class: 'cfg-colgroup' }, [
+                    h('h3', { class: 'cfg-sub' }, cat.label || cat.id),
+                ]);
+                rows.forEach(item => {
+                    const input = h('input', {
+                        class: 'cfg-input', type: 'url', placeholder: 'Leave empty for the main webhook',
+                        value: state.hooks[item.webhookKey] || '',
+                    });
+                    const warn = h('span', { class: 'cfg-note cfg-note--sub', style: 'display:none' },
+                        'That does not look like a Discord webhook URL.');
+                    input.addEventListener('input', () => {
+                        const v = input.value.trim();
+                        state.hooks[item.webhookKey] = v;
+                        warn.style.display = (v && !isWebhookUrl(v)) ? '' : 'none';
+                    });
+                    box.appendChild(h('div', { class: 'cfg-colrow' }, [
+                        h('label', { class: 'cfg-label', style: 'margin:0' }, item.label || item.id),
+                        input,
+                    ]));
+                    box.appendChild(warn);
+                });
+                wrap.appendChild(box);
+            }
+
+            return h('section', { class: 'cfg-panel' }, [
+                h('h2', { class: 'cfg-title' }, '6) Per-event channels'),
+                h('p', { class: 'cfg-note' },
+                    'Optional. Send individual events to their own Discord channel — moderation '
+                    + 'to a private staff channel, chat to a public one. Anything left empty uses '
+                    + 'the main webhook from step 2.'),
+                any ? wrap : h('p', { class: 'cfg-note' }, 'No events are enabled, so there is nothing to route.'),
                 actions('Back', h('button', { class: 'cfg-btn cfg-btn--primary', type: 'button', onclick: next }, 'Generate config')),
             ]);
         };
@@ -561,6 +614,12 @@
                 }
                 for (const extra of (item.extras || [])) {
                     tokens[`EXTRA_${extra.key}`] = state.extras[extra.key] ? 'true' : 'false';
+                }
+                if (item.webhookKey) {
+                    const v = (state.hooks[item.webhookKey] || '').trim();
+                    // Only emit a URL that would actually work; a typo would otherwise
+                    // ship a config that silently drops that event's messages.
+                    tokens[`HOOK_${item.webhookKey}`] = isWebhookUrl(v) ? yamlQuote(v) : '';
                 }
             }
         }

--- a/docs/assets/configs/v10/options.json
+++ b/docs/assets/configs/v10/options.json
@@ -20,7 +20,8 @@
               "note": "Only appears for Bedrock players, and only when the server runs Geyser with Floodgate.",
               "default": true
             }
-          ]
+          ],
+          "webhookKey": "player.join"
         },
         {
           "id": "quit",
@@ -28,7 +29,8 @@
           "configKey": "log.player.quit.enabled",
           "colorKey": "player.quit",
           "defaultColor": "#ED4245",
-          "default": true
+          "default": true,
+          "webhookKey": "player.quit"
         },
         {
           "id": "chat",
@@ -36,7 +38,8 @@
           "configKey": "log.player.chat.enabled",
           "colorKey": "player.chat",
           "defaultColor": "#5865F2",
-          "default": true
+          "default": true,
+          "webhookKey": "player.chat"
         },
         {
           "id": "command",
@@ -44,7 +47,8 @@
           "configKey": "log.player.command.enabled",
           "colorKey": "player.command",
           "defaultColor": "#FEE75C",
-          "default": true
+          "default": true,
+          "webhookKey": "player.command"
         },
         {
           "id": "death",
@@ -61,7 +65,8 @@
               "note": "Anyone who can read the channel can find the body and its dropped items.",
               "default": false
             }
-          ]
+          ],
+          "webhookKey": "player.death"
         },
         {
           "id": "advancement",
@@ -69,7 +74,8 @@
           "configKey": "log.player.advancement.enabled",
           "colorKey": "player.advancement",
           "defaultColor": "#2ECC71",
-          "default": true
+          "default": true,
+          "webhookKey": "player.advancement"
         },
         {
           "id": "teleport",
@@ -77,7 +83,8 @@
           "configKey": "log.player.teleport.enabled",
           "colorKey": "player.teleport",
           "defaultColor": "#3498DB",
-          "default": true
+          "default": true,
+          "webhookKey": "player.teleport"
         },
         {
           "id": "gamemode",
@@ -85,7 +92,8 @@
           "configKey": "log.player.gamemode.enabled",
           "colorKey": "player.gamemode",
           "defaultColor": "#9B59B6",
-          "default": true
+          "default": true,
+          "webhookKey": "player.gamemode"
         }
       ]
     },
@@ -100,7 +108,8 @@
           "configKey": "log.server.start.enabled",
           "colorKey": "server.start",
           "defaultColor": "#43B581",
-          "default": true
+          "default": true,
+          "webhookKey": "server.start"
         },
         {
           "id": "stop",
@@ -108,7 +117,8 @@
           "configKey": "log.server.stop.enabled",
           "colorKey": "server.stop",
           "defaultColor": "#ED4245",
-          "default": true
+          "default": true,
+          "webhookKey": "server.stop"
         },
         {
           "id": "command",
@@ -116,7 +126,8 @@
           "configKey": "log.server.command.enabled",
           "colorKey": "server.command",
           "defaultColor": "#EB459E",
-          "default": true
+          "default": true,
+          "webhookKey": "server.command"
         },
         {
           "id": "explosion",
@@ -124,7 +135,8 @@
           "configKey": "log.server.explosion.enabled",
           "colorKey": "server.explosion",
           "defaultColor": "#E74C3C",
-          "default": true
+          "default": true,
+          "webhookKey": "server.explosion"
         }
       ]
     },
@@ -139,7 +151,8 @@
           "configKey": "log.moderation.ban.enabled",
           "colorKey": "moderation.ban",
           "defaultColor": "#FF0000",
-          "default": true
+          "default": true,
+          "webhookKey": "moderation.ban"
         },
         {
           "id": "unban",
@@ -147,7 +160,8 @@
           "configKey": "log.moderation.unban.enabled",
           "colorKey": "moderation.unban",
           "defaultColor": "#FF0000",
-          "default": true
+          "default": true,
+          "webhookKey": "moderation.unban"
         },
         {
           "id": "kick",
@@ -155,7 +169,8 @@
           "configKey": "log.moderation.kick.enabled",
           "colorKey": "moderation.kick",
           "defaultColor": "#FF0000",
-          "default": true
+          "default": true,
+          "webhookKey": "moderation.kick"
         },
         {
           "id": "op",
@@ -163,7 +178,8 @@
           "configKey": "log.moderation.op.enabled",
           "colorKey": "moderation.op",
           "defaultColor": "#FF0000",
-          "default": true
+          "default": true,
+          "webhookKey": "moderation.op"
         },
         {
           "id": "deop",
@@ -171,7 +187,8 @@
           "configKey": "log.moderation.deop.enabled",
           "colorKey": "moderation.deop",
           "defaultColor": "#FF0000",
-          "default": true
+          "default": true,
+          "webhookKey": "moderation.deop"
         },
         {
           "id": "whitelist_toggle",
@@ -179,7 +196,8 @@
           "configKey": "log.moderation.whitelist_toggle.enabled",
           "colorKey": "moderation.whitelist_toggle",
           "defaultColor": "#1ABC9C",
-          "default": true
+          "default": true,
+          "webhookKey": "moderation.whitelist_toggle"
         },
         {
           "id": "whitelist",
@@ -187,7 +205,8 @@
           "configKey": "log.moderation.whitelist_edit.enabled",
           "colorKey": "moderation.whitelist_edit",
           "defaultColor": "#16A085",
-          "default": true
+          "default": true,
+          "webhookKey": "moderation.whitelist_edit"
         }
       ]
     }

--- a/docs/config/v10/index.md
+++ b/docs/config/v10/index.md
@@ -94,7 +94,27 @@ log:
       color: "#ED4245"
 ```
 
-Some events carry extra sub-options alongside `enabled` and `color`:
+Every event also takes a **`webhook`**, which routes just that event to its own
+Discord channel:
+
+```yaml
+log:
+  moderation:
+    ban:
+      enabled: true
+      color: "#FF0000"
+      webhook: "https://discord.com/api/webhooks/…"   # private staff channel
+```
+
+Leave it empty and the event uses `webhook.url` from the top of the file, which is
+what almost every server wants. A value that isn't a valid Discord webhook URL is
+ignored with a warning in console, and that event falls back to the main webhook
+rather than silently going nowhere.
+
+Each destination is paced independently, because Discord's rate limits are per
+webhook — a busy chat channel will not delay your moderation log.
+
+Some events carry extra sub-options alongside `enabled`, `color` and `webhook`:
 
 | Key | Default | What it does |
 |---|---|---|
@@ -244,66 +264,85 @@ log:
     join: # Player Join
       enabled: true
       color: "#57F287" # green
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
       show_platform: true # Flags players who joined from Bedrock (needs Geyser + Floodgate)
     quit: # Player Quit
       enabled: true
       color: "#ED4245" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     chat: # Player Chat
       enabled: true
       color: "#5865F2" # blurple
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     command: # Commands executed by a player in-game
       enabled: true
       color: "#FEE75C" # yellow
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     death: # Player Death (with death message)
       enabled: true
       color: "#ED4245" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
       show_coords: false # Adds where the player died. Anyone who can see the channel can find the body
     advancement: # Logs when a player gets an advancement
       enabled: true
       color: "#2ECC71" # green
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     teleport: # Logs when a player teleports
       enabled: true
       color: "#3498DB" # blue
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     gamemode: # Logs when a players gamemode changes
       enabled: true
       color: "#9B59B6" # purple
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
 
   server:
     command: # Commands executed via the server console/terminal
       enabled: true
       color: "#EB459E" # pink
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     start: # Logged when the plugin/server starts
       enabled: true
       color: "#43B581" # green
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     stop: # Logged on /stop / clean shutdown
       enabled: true
       color: "#ED4245" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     explosion: # Log when an explosion occurs
       enabled: true
       color: "#E74C3C" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
 
   moderation:
     ban: # Logs when a player has been banned
       enabled: true
       color: "#FF0000" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     unban: # Logs when a player has been unbanned
       enabled: true
       color: "#FF0000" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     kick: # Logs when a player has been kicked
       enabled: true
       color: "#FF0000" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     op: # Logs when a player is granted op premissions
       enabled: true
       color: "#FF0000" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     deop: # Logs when a players op permissions are revoked
       enabled: true
       color: "#FF0000" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     whitelist_toggle: # Logs when the whitelist is enabled/disabled
       enabled: true
       color: "#1ABC9C" # teal
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     whitelist_edit: # Logs when players are added/removed from the whitelist
       enabled: true
       color: "#16A085" # dark teal
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
 
 # CONFIG VERSION V10, DOWNLOADED FROM WEBSITE
 ```

--- a/docs/config/v10/index.md
+++ b/docs/config/v10/index.md
@@ -266,31 +266,38 @@ log:
       color: "#57F287" # green
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
       show_platform: true # Flags players who joined from Bedrock (needs Geyser + Floodgate)
+
     quit: # Player Quit
       enabled: true
       color: "#ED4245" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     chat: # Player Chat
       enabled: true
       color: "#5865F2" # blurple
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     command: # Commands executed by a player in-game
       enabled: true
       color: "#FEE75C" # yellow
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     death: # Player Death (with death message)
       enabled: true
       color: "#ED4245" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
       show_coords: false # Adds where the player died. Anyone who can see the channel can find the body
+
     advancement: # Logs when a player gets an advancement
       enabled: true
       color: "#2ECC71" # green
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     teleport: # Logs when a player teleports
       enabled: true
       color: "#3498DB" # blue
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     gamemode: # Logs when a players gamemode changes
       enabled: true
       color: "#9B59B6" # purple
@@ -301,14 +308,17 @@ log:
       enabled: true
       color: "#EB459E" # pink
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     start: # Logged when the plugin/server starts
       enabled: true
       color: "#43B581" # green
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     stop: # Logged on /stop / clean shutdown
       enabled: true
       color: "#ED4245" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     explosion: # Log when an explosion occurs
       enabled: true
       color: "#E74C3C" # red
@@ -319,30 +329,35 @@ log:
       enabled: true
       color: "#FF0000" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     unban: # Logs when a player has been unbanned
       enabled: true
       color: "#FF0000" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     kick: # Logs when a player has been kicked
       enabled: true
       color: "#FF0000" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     op: # Logs when a player is granted op premissions
       enabled: true
       color: "#FF0000" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     deop: # Logs when a players op permissions are revoked
       enabled: true
       color: "#FF0000" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     whitelist_toggle: # Logs when the whitelist is enabled/disabled
       enabled: true
       color: "#1ABC9C" # teal
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     whitelist_edit: # Logs when players are added/removed from the whitelist
       enabled: true
       color: "#16A085" # dark teal
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
-
 # CONFIG VERSION V10, DOWNLOADED FROM WEBSITE
 ```

--- a/scripts/validate-config-generator.py
+++ b/scripts/validate-config-generator.py
@@ -161,6 +161,17 @@ def check_version(options_path: str, live_schema: str | None = None) -> list[str
                             f"'{extra_config_key}', which no Java source reads"
                         )
 
+            # Per-event webhook routing: the template must have a slot, or the key
+            # silently never appears in a generated config.
+            webhook_key = item.get("webhookKey")
+            if webhook_key:
+                token = "HOOK_" + webhook_key
+                if token not in template_tokens:
+                    errors.append(
+                        f"{options_path}: item '{item_id}' expects "
+                        f"{{{{{token}}}}} in {template_path}, not found"
+                    )
+
             color_key = item.get("colorKey")
             if color_key:
                 token = "COLOR_" + color_key

--- a/src/main/java/com/discordlogger/log/Log.java
+++ b/src/main/java/com/discordlogger/log/Log.java
@@ -39,6 +39,13 @@ public final class Log {
     // colorMap is replaced atomically: a fully-built map is assigned in one
     // volatile write, so async threads never see a half-populated map.
     private static volatile Map<String, Integer> colorMap = new HashMap<>();
+
+    /**
+     * Category key -> the webhook that category posts to, when it overrides the
+     * global one. Built and swapped atomically alongside colorMap, for the same
+     * reason: async senders must never observe a half-populated map.
+     */
+    private static volatile Map<String, String> webhookMap = new HashMap<>();
     private static volatile int defaultColor = 0x5865F2;
 
     private Log() {}
@@ -116,6 +123,7 @@ public final class Log {
         // the event is a plain boolean with no section, and the built-in default
         // above stands.
         int currentDefault = cm.getOrDefault("server", baseDefaultColor);
+        Map<String, String> wm = new HashMap<>();
         ConfigurationSection logSec = plugin.getConfig().getConfigurationSection("log");
         if (logSec != null) {
             for (String group : logSec.getKeys(false)) {
@@ -129,6 +137,19 @@ public final class Log {
                     int c = hex(v, currentDefault);
 
                     cm.put(normalizeKey(group + "_" + event), c);
+
+                    final String hook = eventSec.getString("webhook");
+                    if (hook != null && !hook.isBlank() && isValidWebhookUrl(hook.trim())) {
+                        wm.put(normalizeKey(group + "_" + event), hook.trim());
+                        if ("moderation".equals(group)) {
+                            wm.put(normalizeKey(event), hook.trim());
+                            if ("whitelist_edit".equals(event)) wm.put("whitelist", hook.trim());
+                        }
+                    } else if (hook != null && !hook.isBlank()) {
+                        plugin.getLogger().warning("log." + group + "." + event
+                                + ".webhook is not a valid Discord webhook URL — that event will "
+                                + "use the main webhook instead.");
+                    }
 
                     // Moderation listeners pass bare categories ("ban", "kick"),
                     // unlike player/server which pass "<group> <event>". Only
@@ -147,6 +168,12 @@ public final class Log {
         // new complete map — never a half-built one.
         defaultColor = cm.getOrDefault("server", baseDefaultColor);
         colorMap = cm;
+        webhookMap = wm;
+
+        if (!wm.isEmpty()) {
+            plugin.getLogger().info("Per-event webhook routing active for "
+                    + wm.size() + " categor" + (wm.size() == 1 ? "y" : "ies") + ".");
+        }
     }
 
     // ---- Public helpers (used by other components like UpdateChecker) ----
@@ -185,6 +212,15 @@ public final class Log {
                 .replace('.', '_')
                 .replace('-', '_')
                 .replace('/', '_');
+    }
+
+    /**
+     * Where this category posts. Falls back to the main webhook, so an event with
+     * no override behaves exactly as it did before routing existed.
+     */
+    private static String webhookFor(String categoryKey) {
+        final String routed = webhookMap.get(normalizeKey(categoryKey));
+        return (routed != null && !routed.isBlank()) ? routed : webhookUrl;
     }
 
     private static int colorFor(String categoryKey) {
@@ -230,7 +266,10 @@ public final class Log {
 
     // ---- Public logging API ----
 
-    /** Plain one-off line (keeps prefix for consistency). */
+    /**
+     * Plain one-off line (keeps prefix for consistency). Belongs to no event, so it
+     * always goes to the main webhook rather than any per-event route.
+     */
     public static void plain(String message) {
         String line = "`" + ts() + "`" + nameSegment() + " " + message;
         plugin.getLogger().info(line);
@@ -246,7 +285,7 @@ public final class Log {
             plugin.getLogger().info("[" + now + "] " + category + ": " + message);
             if (ready) {
                 DiscordWebhook.sendEmbed(
-                        plugin, webhookUrl,
+                        plugin, webhookFor(category),
                         /*title*/        category,
                         /*description*/  message,
                         /*color*/        colorFor(category),
@@ -259,7 +298,7 @@ public final class Log {
         } else {
             String line = "`" + now + "`" + nameSegment() + " - **" + category + "**: " + message;
             plugin.getLogger().info(line);
-            if (ready) DiscordWebhook.sendAsync(plugin, webhookUrl, line);
+            if (ready) DiscordWebhook.sendAsync(plugin, webhookFor(category), line);
         }
     }
 
@@ -270,7 +309,7 @@ public final class Log {
             plugin.getLogger().info("[" + now + "] " + category + ": " + message);
             if (ready) {
                 DiscordWebhook.sendEmbed(
-                        plugin, webhookUrl,
+                        plugin, webhookFor(category),
                         /*title*/        category,
                         /*description*/  message,
                         /*color*/        colorFor(category),
@@ -283,7 +322,7 @@ public final class Log {
         } else {
             String line = "`" + now + "`" + nameSegment() + " - **" + category + "**: " + message;
             plugin.getLogger().info(line);
-            if (ready) DiscordWebhook.sendAsync(plugin, webhookUrl, line);
+            if (ready) DiscordWebhook.sendAsync(plugin, webhookFor(category), line);
         }
     }
 
@@ -383,7 +422,7 @@ public final class Log {
                             .append("\n");
                 }
             }
-            DiscordWebhook.sendAsync(plugin, webhookUrl, sb.toString().trim());
+            DiscordWebhook.sendAsync(plugin, webhookFor(category), sb.toString().trim());
         }
     }
 

--- a/src/main/java/com/discordlogger/log/Log.java
+++ b/src/main/java/com/discordlogger/log/Log.java
@@ -223,6 +223,13 @@ public final class Log {
         return (routed != null && !routed.isBlank()) ? routed : webhookUrl;
     }
 
+    // NOTE: webhookUrl must be read ONLY through webhookFor above. Every send site
+    // resolves its destination that way, including the ones that always want the
+    // main webhook (they pass null). This is enforced by
+    // LogRoutingTest.everySendSiteResolvesARoute, because the first version of
+    // routing missed exactly one send site — the fields embed — and the result was
+    // that quit routed correctly while death and gamemode silently did not.
+
     private static int colorFor(String categoryKey) {
         return colorMap.getOrDefault(normalizeKey(categoryKey), defaultColor);
     }
@@ -274,7 +281,7 @@ public final class Log {
         String line = "`" + ts() + "`" + nameSegment() + " " + message;
         plugin.getLogger().info(line);
         if (ready) {
-            DiscordWebhook.sendAsync(plugin, webhookUrl, line);
+            DiscordWebhook.sendAsync(plugin, webhookFor(null), line);
         }
     }
 
@@ -397,7 +404,7 @@ public final class Log {
         if (embedsEnabledFlag) {
             DiscordWebhook.sendEmbedWithFields(
                     plugin,
-                    webhookUrl,
+                    webhookFor(category),
                     /*title*/        (title == null || title.isBlank()) ? category : title,
                     /*description*/  description == null ? "" : description,
                     /*color*/        colorFor(category),
@@ -464,7 +471,7 @@ public final class Log {
 
         DiscordWebhook.sendEmbedWithFields(
                 plugin,
-                webhookUrl,
+                webhookFor(null),
                 title,
                 description,
                 color,

--- a/src/main/java/com/discordlogger/webhook/WebhookQueue.java
+++ b/src/main/java/com/discordlogger/webhook/WebhookQueue.java
@@ -2,7 +2,9 @@ package com.discordlogger.webhook;
 
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -17,8 +19,13 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>Design notes worth preserving:
  * <ul>
- *   <li><b>One worker thread</b> — also the ordering guarantee. Logs are a
- *       narrative; delivering them out of order is its own bug.</li>
+ *   <li><b>One worker per destination</b> — also the ordering guarantee. Logs are
+ *       a narrative; delivering them out of order is its own bug. Ordering only
+ *       means anything <i>within</i> a channel, though, so destinations are
+ *       independent: a channel being throttled must not hold up a different one.
+ *       With a single shared worker, one slow or dead webhook stalled every
+ *       other, which per-event routing turns from a corner case into the normal
+ *       case.</li>
  *   <li><b>Proactive pacing.</b> Discord reports how many requests remain in the
  *       current window ({@code X-RateLimit-Remaining}) and when it resets. When
  *       the budget is spent we wait for the reset rather than earning a 429.</li>
@@ -43,49 +50,76 @@ public final class WebhookQueue {
     /** How long {@link #shutdown} will keep draining before abandoning the rest. */
     private static final long SHUTDOWN_DRAIN_MS = 5_000L;
 
-    private static final BlockingQueue<Message> QUEUE = new ArrayBlockingQueue<>(CAPACITY);
+    /**
+     * One per distinct webhook URL. Discord's rate limits are per webhook, so the
+     * pacing state has to be too — a shared counter would throttle a quiet channel
+     * because a busy one spent its budget.
+     */
+    private static final Map<String, Destination> DESTINATIONS = new ConcurrentHashMap<>();
 
     private static volatile JavaPlugin plugin;
-    private static volatile Thread worker;
     private static volatile boolean running;
-
-    /** Epoch millis before which the next request must not be sent. */
-    private static volatile long nextSendAt = 0L;
-
-    /** Warn once per outage rather than once per dropped message. */
-    private static volatile boolean warnedFull = false;
 
     private WebhookQueue() {}
 
-    private record Message(String url, String json) {}
+    private static final class Destination {
+        final String url;
+        final BlockingQueue<String> queue = new ArrayBlockingQueue<>(CAPACITY);
+        final Thread worker;
 
-    /** Start the worker. Safe to call again on reload; a second call is ignored. */
+        /** Epoch millis before which the next request to THIS webhook must not be sent. */
+        volatile long nextSendAt = 0L;
+
+        /** Warn once per outage rather than once per dropped message. */
+        volatile boolean warnedFull = false;
+
+        Destination(String url) {
+            this.url = url;
+            this.worker = new Thread(() -> runLoop(this), "DiscordLogger-Webhook-" + shortId(url));
+            // Not a daemon: a queued message should still get its chance if the JVM
+            // is winding down. shutdown() bounds how long that can take.
+            this.worker.setDaemon(false);
+            this.worker.start();
+        }
+    }
+
+    /**
+     * The webhook id, for a readable thread name. Never the token — thread names
+     * show up in stack traces and thread dumps, which get pasted into issues.
+     */
+    private static String shortId(String url) {
+        final String[] parts = url.split("/");
+        return parts.length >= 2 ? parts[parts.length - 2] : "unknown";
+    }
+
+    /**
+     * Accept work. Safe to call again on reload.
+     *
+     * <p>Workers are created per destination on first use rather than here, because
+     * which webhooks exist is a config question that can change on reload.
+     */
     public static synchronized void start(JavaPlugin pl) {
         plugin = pl;
-        if (running && worker != null && worker.isAlive()) return;
-
         running = true;
-        worker = new Thread(WebhookQueue::runLoop, "DiscordLogger-Webhook");
-        // Not a daemon: a queued message should still get its chance if the JVM
-        // is winding down. shutdown() bounds how long that can take.
-        worker.setDaemon(false);
-        worker.start();
     }
 
     /** Queue a payload. Never blocks the caller — the main thread must not wait on Discord. */
     public static void enqueue(String url, String json) {
         if (url == null || url.isBlank() || json == null) return;
 
-        if (!QUEUE.offer(new Message(url, json))) {
-            if (!warnedFull) {
-                warnedFull = true;
-                log().warning("[DiscordWebhook] Send queue is full (" + CAPACITY + " pending) — "
-                        + "dropping messages until it drains. Discord may be unreachable, "
-                        + "or this server is logging faster than the webhook allows.");
+        final Destination dest = DESTINATIONS.computeIfAbsent(url, Destination::new);
+
+        if (!dest.queue.offer(json)) {
+            if (!dest.warnedFull) {
+                dest.warnedFull = true;
+                log().warning("[DiscordWebhook] Send queue for webhook ..." + shortId(url)
+                        + " is full (" + CAPACITY + " pending) — dropping messages until it "
+                        + "drains. Discord may be unreachable, or this server is logging "
+                        + "faster than that webhook allows.");
             }
             return;
         }
-        warnedFull = false;
+        dest.warnedFull = false;
     }
 
     /**
@@ -95,41 +129,49 @@ public final class WebhookQueue {
     public static void shutdown() {
         running = false;
 
-        final Thread w = worker;
-        if (w == null) return;
-
-        // Let the worker finish the backlog on its own; it exits once drained.
-        try {
-            w.join(SHUTDOWN_DRAIN_MS);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-
-        if (w.isAlive()) {
-            final int left = QUEUE.size();
-            if (left > 0) {
-                log().warning("[DiscordWebhook] Shutting down with " + left
-                        + " message(s) still queued — they will not be delivered.");
+        // The drain budget is shared, not per destination: destinations drain in
+        // parallel, so waiting SHUTDOWN_DRAIN_MS on each in turn would multiply the
+        // shutdown delay by however many webhooks are configured.
+        final long deadline = System.currentTimeMillis() + SHUTDOWN_DRAIN_MS;
+        for (Destination dest : DESTINATIONS.values()) {
+            final long left = deadline - System.currentTimeMillis();
+            if (left <= 0) break;
+            try {
+                dest.worker.join(left);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
             }
-            w.interrupt();
         }
-        worker = null;
+
+        for (Destination dest : DESTINATIONS.values()) {
+            if (dest.worker.isAlive()) {
+                final int pending = dest.queue.size();
+                if (pending > 0) {
+                    log().warning("[DiscordWebhook] Shutting down with " + pending
+                            + " message(s) still queued for webhook ..." + shortId(dest.url)
+                            + " — they will not be delivered.");
+                }
+                dest.worker.interrupt();
+            }
+        }
+        DESTINATIONS.clear();
     }
 
     // -------------------------------------------------------------------------
 
-    private static void runLoop() {
+    private static void runLoop(Destination dest) {
         while (true) {
-            final Message msg;
+            final String json;
             try {
                 if (running) {
                     // Poll rather than take() so a stopped queue can notice and exit.
-                    msg = QUEUE.poll(250, TimeUnit.MILLISECONDS);
-                    if (msg == null) continue;
+                    json = dest.queue.poll(250, TimeUnit.MILLISECONDS);
+                    if (json == null) continue;
                 } else {
                     // Draining: leave as soon as the backlog is clear.
-                    msg = QUEUE.poll();
-                    if (msg == null) return;
+                    json = dest.queue.poll();
+                    if (json == null) return;
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
@@ -137,7 +179,7 @@ public final class WebhookQueue {
             }
 
             try {
-                deliver(msg);
+                deliver(dest, json);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 return;
@@ -149,25 +191,26 @@ public final class WebhookQueue {
     }
 
     /** Send one message, retrying transient failures and honouring rate limits. */
-    private static void deliver(Message msg) throws InterruptedException {
+    private static void deliver(Destination dest, String json) throws InterruptedException {
         for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-            waitUntilAllowed();
+            waitUntilAllowed(dest);
 
-            final DiscordWebhook.Response res = DiscordWebhook.post(msg.url(), msg.json());
+            final DiscordWebhook.Response res = DiscordWebhook.post(dest.url, json);
 
             if (res.rateLimited()) {
                 // Told to back off explicitly — wait it out and retry the SAME message
                 // without consuming an attempt, since nothing was wrong with it.
                 final long waitMs = clampWait(res.retryAfterMs());
-                log().warning("[DiscordWebhook] Rate limited by Discord — retrying in "
-                        + waitMs + "ms (" + QUEUE.size() + " queued).");
+                log().warning("[DiscordWebhook] Rate limited by Discord on webhook ..."
+                        + shortId(dest.url) + " — retrying in " + waitMs + "ms ("
+                        + dest.queue.size() + " queued for it).");
                 sleep(waitMs);
                 attempt--;
                 continue;
             }
 
             if (res.success()) {
-                applyRateLimitHints(res);
+                applyRateLimitHints(dest, res);
                 return;
             }
 
@@ -186,15 +229,16 @@ public final class WebhookQueue {
             // can't help, so say something actionable and move on.
             log().warning("[DiscordWebhook] Discord rejected a message with HTTP " + res.status()
                     + (res.status() == 404
-                        ? " — the webhook URL no longer exists. Check webhook.url in config.yml."
+                        ? " — webhook ..." + shortId(dest.url) + " no longer exists. Check the"
+                          + " webhook URLs in config.yml."
                         : " — not retrying."));
             return;
         }
     }
 
     /** Respect the pacing derived from the previous response's rate-limit headers. */
-    private static void waitUntilAllowed() throws InterruptedException {
-        final long delay = nextSendAt - System.currentTimeMillis();
+    private static void waitUntilAllowed(Destination dest) throws InterruptedException {
+        final long delay = dest.nextSendAt - System.currentTimeMillis();
         if (delay > 0) sleep(Math.min(delay, MAX_WAIT_MS));
     }
 
@@ -202,11 +246,11 @@ public final class WebhookQueue {
      * If Discord says this window's budget is spent, hold the next send until it resets.
      * This is what keeps us from earning a 429 in the first place.
      */
-    private static void applyRateLimitHints(DiscordWebhook.Response res) {
+    private static void applyRateLimitHints(Destination dest, DiscordWebhook.Response res) {
         if (res.remaining() != null && res.remaining() <= 0 && res.resetAfterMs() != null) {
-            nextSendAt = System.currentTimeMillis() + clampWait(res.resetAfterMs());
+            dest.nextSendAt = System.currentTimeMillis() + clampWait(res.resetAfterMs());
         } else {
-            nextSendAt = 0L;
+            dest.nextSendAt = 0L;
         }
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -79,65 +79,84 @@ log:
     join: # Player Join
       enabled: true
       color: "#57F287" # green
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
       show_platform: true # Flags players who joined from Bedrock (needs Geyser + Floodgate)
     quit: # Player Quit
       enabled: true
       color: "#ED4245" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     chat: # Player Chat
       enabled: true
       color: "#5865F2" # blurple
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     command: # Commands executed by a player in-game
       enabled: true
       color: "#FEE75C" # yellow
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     death: # Player Death (with death message)
       enabled: true
       color: "#ED4245" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
       show_coords: false # Adds where the player died. Anyone who can see the channel can find the body
     advancement: # Logs when a player gets an advancement
       enabled: true
       color: "#2ECC71" # green
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     teleport: # Logs when a player teleports
       enabled: true
       color: "#3498DB" # blue
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     gamemode: # Logs when a players gamemode changes
       enabled: true
       color: "#9B59B6" # purple
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
 
   server:
     command: # Commands executed via the server console/terminal
       enabled: true
       color: "#EB459E" # pink
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     start: # Logged when the plugin/server starts
       enabled: true
       color: "#43B581" # green
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     stop: # Logged on /stop / clean shutdown
       enabled: true
       color: "#ED4245" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     explosion: # Log when an explosion occurs
       enabled: true
       color: "#E74C3C" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
 
   moderation:
     ban: # Logs when a player has been banned
       enabled: true
       color: "#FF0000" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     unban: # Logs when a player has been unbanned
       enabled: true
       color: "#FF0000" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     kick: # Logs when a player has been kicked
       enabled: true
       color: "#FF0000" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     op: # Logs when a player is granted op premissions
       enabled: true
       color: "#FF0000" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     deop: # Logs when a players op permissions are revoked
       enabled: true
       color: "#FF0000" # red
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     whitelist_toggle: # Logs when the whitelist is enabled/disabled
       enabled: true
       color: "#1ABC9C" # teal
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
     whitelist_edit: # Logs when players are added/removed from the whitelist
       enabled: true
       color: "#16A085" # dark teal
+      webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
 
 # CONFIG VERSION V10, SHIPPED WITH v2.1.6 (x-release-please-version)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -81,31 +81,38 @@ log:
       color: "#57F287" # green
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
       show_platform: true # Flags players who joined from Bedrock (needs Geyser + Floodgate)
+
     quit: # Player Quit
       enabled: true
       color: "#ED4245" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     chat: # Player Chat
       enabled: true
       color: "#5865F2" # blurple
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     command: # Commands executed by a player in-game
       enabled: true
       color: "#FEE75C" # yellow
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     death: # Player Death (with death message)
       enabled: true
       color: "#ED4245" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
       show_coords: false # Adds where the player died. Anyone who can see the channel can find the body
+
     advancement: # Logs when a player gets an advancement
       enabled: true
       color: "#2ECC71" # green
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     teleport: # Logs when a player teleports
       enabled: true
       color: "#3498DB" # blue
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     gamemode: # Logs when a players gamemode changes
       enabled: true
       color: "#9B59B6" # purple
@@ -116,14 +123,17 @@ log:
       enabled: true
       color: "#EB459E" # pink
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     start: # Logged when the plugin/server starts
       enabled: true
       color: "#43B581" # green
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     stop: # Logged on /stop / clean shutdown
       enabled: true
       color: "#ED4245" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     explosion: # Log when an explosion occurs
       enabled: true
       color: "#E74C3C" # red
@@ -134,29 +144,34 @@ log:
       enabled: true
       color: "#FF0000" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     unban: # Logs when a player has been unbanned
       enabled: true
       color: "#FF0000" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     kick: # Logs when a player has been kicked
       enabled: true
       color: "#FF0000" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     op: # Logs when a player is granted op premissions
       enabled: true
       color: "#FF0000" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     deop: # Logs when a players op permissions are revoked
       enabled: true
       color: "#FF0000" # red
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     whitelist_toggle: # Logs when the whitelist is enabled/disabled
       enabled: true
       color: "#1ABC9C" # teal
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
     whitelist_edit: # Logs when players are added/removed from the whitelist
       enabled: true
       color: "#16A085" # dark teal
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
-
 # CONFIG VERSION V10, SHIPPED WITH v2.1.6 (x-release-please-version)

--- a/src/test/java/com/discordlogger/config/ConfigMigratorUpgradeTest.java
+++ b/src/test/java/com/discordlogger/config/ConfigMigratorUpgradeTest.java
@@ -108,6 +108,36 @@ class ConfigMigratorUpgradeTest {
     }
 
     @Test
+    @DisplayName("per-event webhooks default to empty, meaning the main webhook")
+    void routingDefaultsToTheMainWebhook() {
+        // A v9 user had one webhook and expects to keep having one. Every event must
+        // arrive with an empty route rather than anything inherited or invented.
+        Map<?, ?> r = upgradeFromV9();
+        Map<?, ?> log = (Map<?, ?>) r.get("log");
+        for (Object groupName : log.keySet()) {
+            Map<?, ?> group = (Map<?, ?>) log.get(groupName);
+            for (Object eventName : group.keySet()) {
+                Map<?, ?> ev = (Map<?, ?>) group.get(eventName);
+                assertTrue(ev.containsKey("webhook"),
+                        groupName + "." + eventName + " should carry a webhook key");
+                assertEquals("", ev.get("webhook"),
+                        groupName + "." + eventName + " must default to the main webhook");
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("a configured per-event webhook survives a migration")
+    void routingChoiceSurvives() {
+        String routed = shipped.replaceFirst(
+                "      webhook: \"\"",
+                "      webhook: \"https://discord.com/api/webhooks/1/STAFF\"");
+        String out = ConfigMigrator.migrateText(shipped, routed, current, current);
+        assertTrue(out.contains("https://discord.com/api/webhooks/1/STAFF"),
+                "a channel someone deliberately routed must not be reset by an upgrade");
+    }
+
+    @Test
     @DisplayName("settings outside the log tree survive untouched")
     void unrelatedSettingsSurvive() {
         Map<?, ?> r = upgradeFromV9();

--- a/src/test/java/com/discordlogger/log/LogRoutingTest.java
+++ b/src/test/java/com/discordlogger/log/LogRoutingTest.java
@@ -1,0 +1,84 @@
+package com.discordlogger.log;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Every message must resolve its destination through {@code webhookFor}.
+ *
+ * <p>Per-event routing shipped with one send site missed — the fields embed, used by
+ * deaths, gamemode changes and every moderation event — while the plain-embed path
+ * was converted. The result was that {@code quit} routed correctly and {@code death}
+ * silently went to the main webhook instead. Nothing failed; the messages simply
+ * arrived in the wrong channel, which no unit test was watching for and no user
+ * would report as a crash.
+ *
+ * <p>Asserting on the source is unusual, but the property here is structural: it is
+ * about which expression appears at a call site, and there is no runtime seam that
+ * exposes it without a live server. The repo already checks source this way in
+ * {@code scripts/validate-config-generator.py}.
+ */
+class LogRoutingTest {
+
+    private static final Path LOG_SOURCE =
+            Path.of("src/main/java/com/discordlogger/log/Log.java");
+
+    @Test
+    @DisplayName("no send site passes the raw webhook field")
+    void everySendSiteResolvesARoute() throws Exception {
+        final List<String> lines = Files.readAllLines(LOG_SOURCE);
+        final List<String> offenders = new ArrayList<>();
+
+        for (int i = 0; i < lines.size(); i++) {
+            final String line = lines.get(i);
+            if (line.strip().startsWith("//") || line.strip().startsWith("*")) continue;
+            if (!line.contains("webhookUrl")) continue;
+
+            // The three legitimate mentions: the declaration, the assignment in
+            // init, and the fallback inside webhookFor itself.
+            if (line.contains("private static volatile String webhookUrl")) continue;
+            if (line.contains("webhookUrl = ready")) continue;
+            if (line.contains("? routed : webhookUrl")) continue;
+
+            offenders.add((i + 1) + ": " + line.strip());
+        }
+
+        assertEquals(List.of(), offenders,
+                "these read webhookUrl directly instead of webhookFor(category), so they "
+                        + "would ignore per-event routing and post to the main webhook");
+    }
+
+    @Test
+    @DisplayName("every Discord send in Log goes through webhookFor")
+    void allDispatchesUseTheResolver() throws Exception {
+        final String src = Files.readString(LOG_SOURCE);
+
+        // Count the calls that actually dispatch, and require each to be paired with
+        // a resolver call. A new send site added without routing fails this.
+        final long sends = countOccurrences(src, "DiscordWebhook.send");
+        final long resolved = countOccurrences(src, "webhookFor(");
+
+        assertTrue(sends > 0, "expected Log to dispatch to Discord at all");
+        assertTrue(resolved >= sends,
+                "found " + sends + " DiscordWebhook.send* call(s) but only " + resolved
+                        + " webhookFor(...) call(s) — at least one send is not resolving a route");
+    }
+
+    private static long countOccurrences(String haystack, String needle) {
+        long n = 0;
+        int i = haystack.indexOf(needle);
+        while (i >= 0) {
+            n++;
+            i = haystack.indexOf(needle, i + needle.length());
+        }
+        return n;
+    }
+}


### PR DESCRIPTION
Every event takes an optional `log.<group>.<event>.webhook`. Empty means the main `webhook.url`, so a config that sets none behaves exactly as before.

```yaml
log:
  moderation:
    ban:
      enabled: true
      color: "#FF0000"
      webhook: "https://discord.com/api/webhooks/…"   # private staff channel
```

An invalid URL is rejected at load with a console warning and that event falls back to the main webhook, rather than posting into the void.

## The queue had to change

`WebhookQueue` paced sends through **one global gate**. Discord rate-limits **per webhook**, so with routing that would throttle a quiet channel because a busy one spent its budget — and a 429 on one webhook would stall every other. Routing turns that from a corner case into the normal case.

It's now **one worker per destination**. Ordering is preserved where it actually means something — within a channel — and destinations no longer block each other. The shutdown drain budget stays *shared*, so configuring more webhooks can't multiply shutdown time.

## Generator

A new **Per-event channels** step, offering a field only for events actually enabled (a channel for a disabled event is a setting that does nothing), and emitting a URL only if it's a valid webhook — a typo would otherwise ship a config that silently drops that event.

## Verified

- 106 tests, 2 new: every event defaults to an empty route on upgrade, and a deliberately routed channel survives migration
- Generator simulated end to end — routing moderation only produced 7 routed events and 12 on the main webhook
- `validate-config-generator.py` extended: `webhookKey` now requires a template slot, same contract as `extras`

Schema v10 is still open, so these keys land there — no v11, nothing to migrate.