### PR TITLE
docs: remove the completed webhook routing item from TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,6 @@ Got an idea that isn't here? Open a [feature request](https://github.com/GodTier
 
 ## Plugin
 
-- **Per-category webhook routing** — send different log categories to different Discord channels (e.g. moderation to a private staff channel, chat to a public one).
 - **Deeper logging modes** — option to relay the full server console rather than only the specific events currently supported.
 - **Log filtering (allow/deny lists)** — exclude specific entries within a category: e.g. don't log `/whisper` when command logging is on, or ignore a particular player by UUID.
 - **`lang.yml` with MiniMessage** — move every user-facing string into a language file so wording and formatting can be fully rewritten without touching code.


### PR DESCRIPTION
Shipped in #138 — per event rather than per category, which is what was actually built.