### PR TITLE
feat(filters): skip specific commands, players, worlds and chat content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,16 @@ Path-filtered (`dorny/paths-filter`): `build` runs on `src/**`/`pom.xml` changes
 - `dispatch()` hands off to `WebhookQueue` and returns immediately — callers may be on the main thread and must never block on HTTP.
 - `post()` performs one request and **returns a `Response`** (status + rate-limit headers) rather than logging; the queue owns retry/wait/give-up decisions.
 
+### Log filtering (`filters:`)
+
+Applied in the **listener**, not in `Log` — that is where the player, world and raw command still exist; by the time a message reaches `Log` it is rendered prose. `Filters` holds an immutable snapshot swapped atomically on reload, and `applyRuntimeConfig` reloads it *before* `Log.init` so a reload cannot briefly log something the new config filters.
+
+`filters.ignored_commands` **ships non-empty**, which is unusual for this project and deliberate: command logging posts the line as typed, so `/login` published passwords in plain text and `/msg` published private messages. Matching is on the command word after stripping the slash, arguments and any plugin qualifier — without that last step `/essentials:msg` would bypass an entry of `msg`, which would make a security-flavoured filter worthless.
+
+**Moderation events are deliberately not filtered by player.** `ignored_players` means "this account's own activity", not "everything mentioning this account"; a ban is a record of staff action and hiding it guts the audit trail.
+
+**Lists in config are a migration hazard.** `ConfigMigrator` replaced scalars only, and every value was a scalar until `filters:` existed. A list hitting that path wrote `key:"[a, b]"` — invalid YAML, original items orphaned. It now splices list blocks bottom-up (top-down would invalidate later indices) and quotes an item only when YAML would otherwise read it as a boolean or number. `ConfigMigratorListTest` pins this.
+
 ### Per-event webhook routing
 
 Every event takes an optional `log.<group>.<event>.webhook`. Empty means the main `webhook.url`, which is the overwhelmingly common case. `Log.webhookFor(category)` resolves it from a map built alongside `colorMap` — same walk, same key normalisation, same atomic swap. An invalid URL is rejected at load with a console warning and that event falls back, rather than posting into the void.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -482,6 +482,18 @@ The validator checks each `extras` entry the same way as `configKey`: the templa
 
 Phases 1–3 touch three different files that all look like "the config". They are not interchangeable — see *Config file dictionary* above for the full breakdown, and check all four before claiming a schema change is done.
 
+### How a config's schema is identified
+
+Three sources, in decreasing durability, resolved by `ConfigMigrator.detectVersion`:
+
+1. **Its shape** — which keys exist (`SchemaDetector.infer`). The arbiter. A file's schema is not a claim it makes, it is what the file *is*; a config declaring v10 while lacking every v10 key is a v9 file with a bad label.
+2. **The `config-version` key** at the top of the file. Replaced a comment on the *last* line, which was the least durable thing in a config — editors strip comments, formatters move them, and tidying the end of a file removes one without anyone noticing. When it vanished, migration was skipped and every option silently fell back to its default.
+3. **The trailer comment**. Retained because every v9-and-earlier config in existence has one and no key — the files that most need upgrading are exactly the ones with only this.
+
+On disagreement the **shape wins** and the mismatch is logged. `config-version` is excluded from the transplant in `resolvePath`: the newly written file already declares its own schema, and copying the old number forward would relabel a v10 file as v9 and make the next start migrate it again.
+
+Each version's marker is the first key that appeared in it, so deleting an unrelated option cannot drop a file a version. **v4 and v5 have identical key sets** and are genuinely indistinguishable; reporting the newer is safe because nothing changed between them.
+
 ### Config version enforcement (plugin side)
 
 `ConfigMigrator` compares the trailer in the user's `config.yml` against the one baked into the running JAR and returns a `Result(status, installed, shipped)`. The decision is `ConfigMigrator.decide(installed, shipped)`, deliberately split out as a pure function so it can be tested without a running server:

--- a/docs/assets/configs/v10/config.template.yml
+++ b/docs/assets/configs/v10/config.template.yml
@@ -36,6 +36,16 @@
 
 # Documentation for this config can be found at https://discordlogger.godtiergamers.xyz/config/v10/
 
+#############################
+# D O   N O T   E D I T     #
+#############################
+
+# Identifies which config format this file uses, so the plugin can upgrade it
+# correctly when you update. Changing it will not convert anything -- it only
+# misleads the upgrader. If it goes missing the plugin works it out from the keys
+# below, so deleting it is survivable, just unnecessary.
+config-version: 10
+
 ###################
 # WEBHOOK OPTIONS #
 ###################

--- a/docs/assets/configs/v10/config.template.yml
+++ b/docs/assets/configs/v10/config.template.yml
@@ -44,6 +44,7 @@
 # correctly when you update. Changing it will not convert anything -- it only
 # misleads the upgrader. If it goes missing the plugin works it out from the keys
 # below, so deleting it is survivable, just unnecessary.
+# Set automatically
 config-version: 10
 
 ###################

--- a/docs/assets/configs/v10/config.template.yml
+++ b/docs/assets/configs/v10/config.template.yml
@@ -36,9 +36,9 @@
 
 # Documentation for this config can be found at https://discordlogger.godtiergamers.xyz/config/v10/
 
-#############################
-# D O   N O T   E D I T     #
-#############################
+#########################
+# D O   N O T   E D I T #
+#########################
 
 # Identifies which config format this file uses, so the plugin can upgrade it
 # correctly when you update. Changing it will not convert anything -- it only
@@ -74,14 +74,15 @@ embeds:
   enabled: {{EMBEDS_ENABLED}}
   author: "{{EMBEDS_AUTHOR}}" # Can be modified for proxy servers (e.g. Survival, Creative)
 
-####################################################################################
-#                                                                                  #
-#     ___  _  _  _                                                                 #
-#    | __|(_)| || |_  ___  _ _  ___                                                #
-#    | _| | || ||  _|/ -_)| '_|(_-<                                                #
-#    |_|  |_||_| \__|\___||_|  /__/                                                #
-#                                                                                  #
-####################################################################################
+###################################################
+#  ______ _____ _   _______ ______ _____   _____  #
+# |  ____|_   _| | |__   __|  ____|  __ \ / ____| #
+# | |__    | | | |    | |  | |__  | |__) | (___   #
+# |  __|   | | | |    | |  |  __| |  _  / \___ \  #
+# | |     _| |_| |____| |  | |____| | \ \ ____) | #
+# |_|    |_____|______|_|  |______|_|  \_\_____/  #
+#                                                 #
+###################################################
 
 # Filters apply on top of the toggles below: an event that is enabled can still be
 # skipped if it matches something here.

--- a/docs/assets/configs/v10/config.template.yml
+++ b/docs/assets/configs/v10/config.template.yml
@@ -66,6 +66,48 @@ embeds:
 
 ####################################################################################
 #                                                                                  #
+#     ___  _  _  _                                                                 #
+#    | __|(_)| || |_  ___  _ _  ___                                                #
+#    | _| | || ||  _|/ -_)| '_|(_-<                                                #
+#    |_|  |_||_| \__|\___||_|  /__/                                                #
+#                                                                                  #
+####################################################################################
+
+# Filters apply on top of the toggles below: an event that is enabled can still be
+# skipped if it matches something here.
+
+filters:
+  # Never log these commands, whoever runs them. Matched on the command word, so
+  # arguments and a plugin prefix are ignored -- "/essentials:msg hi" matches "msg".
+  # The defaults exist because these leak: login commands carry passwords in plain
+  # text, and private messages are private.
+  ignored_commands:
+    - login
+    - register
+    - changepassword
+    - unregister
+    - msg
+    - tell
+    - whisper
+    - w
+    - r
+    - reply
+
+  # Never log anything from these players. Accepts names or UUIDs, mixed freely.
+  ignored_players: []
+
+  # Players with this permission are never logged -- useful for staff alts, or a bot
+  # account whose activity would drown everything else. Empty disables the check.
+  exempt_permission: ""
+
+  # Never log events that happen in these worlds.
+  ignored_worlds: []
+
+  # Skip chat messages containing any of these (case-insensitive).
+  ignored_chat_containing: []
+
+####################################################################################
+#                                                                                  #
 #     _                      _                ___         _    _                   #
 #    | |    ___  __ _  __ _ (_) _ _   __ _   / _ \  _ __ | |_ (_) ___  _ _   ___   #
 #    | |__ / _ \/ _` |/ _` || || ' \ / _` | | (_) || '_ \|  _|| |/ _ \| ' \ (_-<   #

--- a/docs/assets/configs/v10/config.yml
+++ b/docs/assets/configs/v10/config.yml
@@ -36,6 +36,16 @@
 
 # Documentation for this config can be found at https://discordlogger.godtiergamers.xyz/config/v10/
 
+#############################
+# D O   N O T   E D I T     #
+#############################
+
+# Identifies which config format this file uses, so the plugin can upgrade it
+# correctly when you update. Changing it will not convert anything -- it only
+# misleads the upgrader. If it goes missing the plugin works it out from the keys
+# below, so deleting it is survivable, just unnecessary.
+config-version: 10
+
 ###################
 # WEBHOOK OPTIONS #
 ###################

--- a/docs/assets/configs/v10/config.yml
+++ b/docs/assets/configs/v10/config.yml
@@ -36,14 +36,10 @@
 
 # Documentation for this config can be found at https://discordlogger.godtiergamers.xyz/config/v10/
 
-#############################
-# D O   N O T   E D I T     #
-#############################
+#########################
+# D O   N O T   E D I T #
+#########################
 
-# Identifies which config format this file uses, so the plugin can upgrade it
-# correctly when you update. Changing it will not convert anything -- it only
-# misleads the upgrader. If it goes missing the plugin works it out from the keys
-# below, so deleting it is survivable, just unnecessary.
 config-version: 10
 
 ###################
@@ -74,14 +70,15 @@ embeds:
   enabled: true
   author: "Server Logs" # Can be modified for proxy servers (e.g. Survival, Creative)
 
-####################################################################################
-#                                                                                  #
-#     ___  _  _  _                                                                 #
-#    | __|(_)| || |_  ___  _ _  ___                                                #
-#    | _| | || ||  _|/ -_)| '_|(_-<                                                #
-#    |_|  |_||_| \__|\___||_|  /__/                                                #
-#                                                                                  #
-####################################################################################
+###################################################
+#  ______ _____ _   _______ ______ _____   _____  #
+# |  ____|_   _| | |__   __|  ____|  __ \ / ____| #
+# | |__    | | | |    | |  | |__  | |__) | (___   #
+# |  __|   | | | |    | |  |  __| |  _  / \___ \  #
+# | |     _| |_| |____| |  | |____| | \ \ ____) | #
+# |_|    |_____|______|_|  |______|_|  \_\_____/  #
+#                                                 #
+###################################################
 
 # Filters apply on top of the toggles below: an event that is enabled can still be
 # skipped if it matches something here.
@@ -226,4 +223,5 @@ log:
       enabled: true
       color: "#16A085" # dark teal
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
 # CONFIG VERSION V10, DOWNLOADED FROM WEBSITE

--- a/docs/assets/configs/v10/config.yml
+++ b/docs/assets/configs/v10/config.yml
@@ -66,6 +66,48 @@ embeds:
 
 ####################################################################################
 #                                                                                  #
+#     ___  _  _  _                                                                 #
+#    | __|(_)| || |_  ___  _ _  ___                                                #
+#    | _| | || ||  _|/ -_)| '_|(_-<                                                #
+#    |_|  |_||_| \__|\___||_|  /__/                                                #
+#                                                                                  #
+####################################################################################
+
+# Filters apply on top of the toggles below: an event that is enabled can still be
+# skipped if it matches something here.
+
+filters:
+  # Never log these commands, whoever runs them. Matched on the command word, so
+  # arguments and a plugin prefix are ignored -- "/essentials:msg hi" matches "msg".
+  # The defaults exist because these leak: login commands carry passwords in plain
+  # text, and private messages are private.
+  ignored_commands:
+    - login
+    - register
+    - changepassword
+    - unregister
+    - msg
+    - tell
+    - whisper
+    - w
+    - r
+    - reply
+
+  # Never log anything from these players. Accepts names or UUIDs, mixed freely.
+  ignored_players: []
+
+  # Players with this permission are never logged -- useful for staff alts, or a bot
+  # account whose activity would drown everything else. Empty disables the check.
+  exempt_permission: ""
+
+  # Never log events that happen in these worlds.
+  ignored_worlds: []
+
+  # Skip chat messages containing any of these (case-insensitive).
+  ignored_chat_containing: []
+
+####################################################################################
+#                                                                                  #
 #     _                      _                ___         _    _                   #
 #    | |    ___  __ _  __ _ (_) _ _   __ _   / _ \  _ __ | |_ (_) ___  _ _   ___   #
 #    | |__ / _ \/ _` |/ _` || || ' \ / _` | | (_) || '_ \|  _|| |/ _ \| ' \ (_-<   #

--- a/docs/assets/configs/v10/config.yml
+++ b/docs/assets/configs/v10/config.yml
@@ -40,6 +40,7 @@
 # D O   N O T   E D I T #
 #########################
 
+# Set automatically
 config-version: 10
 
 ###################

--- a/docs/config/v10/index.md
+++ b/docs/config/v10/index.md
@@ -74,6 +74,34 @@ format:
 
 ---
 
+### `filters`
+Applied on top of the event toggles: an event that is **enabled** can still be skipped
+if it matches a filter. This is how you exclude specific things without turning a whole
+category off.
+
+| Key | What it does |
+|---|---|
+| `filters.ignored_commands` | Commands never logged, matched on the command word. Arguments and a plugin prefix are ignored, so `/essentials:msg hi` matches `msg`. |
+| `filters.ignored_players` | Players never logged. Accepts **names or UUIDs**, mixed freely. |
+| `filters.exempt_permission` | Players holding this permission are never logged. Empty disables the check. |
+| `filters.ignored_worlds` | Worlds whose events are never logged. |
+| `filters.ignored_chat_containing` | Chat messages containing any of these (case-insensitive) are skipped. |
+
+> **`ignored_commands` ships non-empty, on purpose.** Command logging posts the full
+> line as typed, so `/login` and `/register` would publish passwords in plain text and
+> `/msg` would publish private messages. The defaults cover the common auth and
+> messaging commands. Removing them is a decision, not a tidy-up.
+
+> **Moderation events are not filtered by player.** `ignored_players` means "this
+> account's own activity isn't logged" — its joins, chat, commands, deaths. A ban or
+> kick is a record of *staff* action, not that player's activity, and hiding it is how
+> an audit trail loses the entries that matter most.
+
+The command match is on the command word only, so a filter cannot be dodged by
+qualifying it: `/msg`, `/MSG` and `/essentials:msg` all match an entry of `msg`.
+
+---
+
 ### `log`
 Each event is a section with two keys: **`enabled`** (whether to log it) and
 **`color`** (the embed colour for that event). v10 supports:
@@ -248,6 +276,48 @@ format:
 embeds:
   enabled: true
   author: "Server Logs" # Can be modified for proxy servers (e.g. Survival, Creative)
+
+####################################################################################
+#                                                                                  #
+#     ___  _  _  _                                                                 #
+#    | __|(_)| || |_  ___  _ _  ___                                                #
+#    | _| | || ||  _|/ -_)| '_|(_-<                                                #
+#    |_|  |_||_| \__|\___||_|  /__/                                                #
+#                                                                                  #
+####################################################################################
+
+# Filters apply on top of the toggles below: an event that is enabled can still be
+# skipped if it matches something here.
+
+filters:
+  # Never log these commands, whoever runs them. Matched on the command word, so
+  # arguments and a plugin prefix are ignored -- "/essentials:msg hi" matches "msg".
+  # The defaults exist because these leak: login commands carry passwords in plain
+  # text, and private messages are private.
+  ignored_commands:
+    - login
+    - register
+    - changepassword
+    - unregister
+    - msg
+    - tell
+    - whisper
+    - w
+    - r
+    - reply
+
+  # Never log anything from these players. Accepts names or UUIDs, mixed freely.
+  ignored_players: []
+
+  # Players with this permission are never logged -- useful for staff alts, or a bot
+  # account whose activity would drown everything else. Empty disables the check.
+  exempt_permission: ""
+
+  # Never log events that happen in these worlds.
+  ignored_worlds: []
+
+  # Skip chat messages containing any of these (case-insensitive).
+  ignored_chat_containing: []
 
 ####################################################################################
 #                                                                                  #

--- a/docs/config/v10/index.md
+++ b/docs/config/v10/index.md
@@ -74,6 +74,21 @@ format:
 
 ---
 
+### `config-version`
+Identifies which config format the file uses, so the plugin can upgrade it correctly.
+
+- **Do not change it.** Editing the number does not convert anything; it only misleads
+  the upgrader into running the wrong migration, or none.
+- **Deleting it is survivable.** If it is missing the plugin works the schema out from
+  which keys the file contains, and says so in console. It replaces a comment on the
+  last line, which was too easy to lose to a stray edit or an editor that strips
+  comments.
+- If the number and the file's actual keys disagree, the **keys win** — they are what
+  the plugin reads — and the mismatch is logged. The usual cause is an older config
+  pasted over a newer one.
+
+---
+
 ### `filters`
 Applied on top of the event toggles: an event that is **enabled** can still be skipped
 if it matches a filter. This is how you exclude specific things without turning a whole
@@ -248,6 +263,16 @@ The defaults shipped with v10. Each is set under its own event's `color` key:
 #############################
 
 # Documentation for this config can be found at https://discordlogger.godtiergamers.xyz/config/v10/
+
+#############################
+# D O   N O T   E D I T     #
+#############################
+
+# Identifies which config format this file uses, so the plugin can upgrade it
+# correctly when you update. Changing it will not convert anything -- it only
+# misleads the upgrader. If it goes missing the plugin works it out from the keys
+# below, so deleting it is survivable, just unnecessary.
+config-version: 10
 
 ###################
 # WEBHOOK OPTIONS #

--- a/docs/config/v10/index.md
+++ b/docs/config/v10/index.md
@@ -264,14 +264,10 @@ The defaults shipped with v10. Each is set under its own event's `color` key:
 
 # Documentation for this config can be found at https://discordlogger.godtiergamers.xyz/config/v10/
 
-#############################
-# D O   N O T   E D I T     #
-#############################
+#########################
+# D O   N O T   E D I T #
+#########################
 
-# Identifies which config format this file uses, so the plugin can upgrade it
-# correctly when you update. Changing it will not convert anything -- it only
-# misleads the upgrader. If it goes missing the plugin works it out from the keys
-# below, so deleting it is survivable, just unnecessary.
 config-version: 10
 
 ###################
@@ -302,14 +298,15 @@ embeds:
   enabled: true
   author: "Server Logs" # Can be modified for proxy servers (e.g. Survival, Creative)
 
-####################################################################################
-#                                                                                  #
-#     ___  _  _  _                                                                 #
-#    | __|(_)| || |_  ___  _ _  ___                                                #
-#    | _| | || ||  _|/ -_)| '_|(_-<                                                #
-#    |_|  |_||_| \__|\___||_|  /__/                                                #
-#                                                                                  #
-####################################################################################
+###################################################
+#  ______ _____ _   _______ ______ _____   _____  #
+# |  ____|_   _| | |__   __|  ____|  __ \ / ____| #
+# | |__    | | | |    | |  | |__  | |__) | (___   #
+# |  __|   | | | |    | |  |  __| |  _  / \___ \  #
+# | |     _| |_| |____| |  | |____| | \ \ ____) | #
+# |_|    |_____|______|_|  |______|_|  \_\_____/  #
+#                                                 #
+###################################################
 
 # Filters apply on top of the toggles below: an event that is enabled can still be
 # skipped if it matches something here.
@@ -454,5 +451,6 @@ log:
       enabled: true
       color: "#16A085" # dark teal
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
 # CONFIG VERSION V10, DOWNLOADED FROM WEBSITE
 ```

--- a/docs/config/v10/index.md
+++ b/docs/config/v10/index.md
@@ -23,35 +23,69 @@ description: Full documentation for config.yml schema v10 — defaults, per-key 
 ## Top-level keys
 
 ### `webhook`
-**Required.** Discord webhook target for all logs.
+**Required.** Where logs are sent, unless an individual event overrides it.
 
-- `webhook.url` — a Discord webhook URL
-    - Must be a valid Discord endpoint (the plugin verifies formatting).
-    - If empty/invalid, logs **won’t** post to Discord.
-
-**Example:**
 ```yaml
 webhook:
-  url: "https://discord.com/api/webhooks/XXXX/XXXXXXXXXXXXXXXX"
+  url: "https://discord.com/api/webhooks/1234567890/AbCdEf-gH1jK_lMnOpQrStUvWxYz"
 ```
+
+**Getting the URL:** in Discord, right-click the channel → *Edit Channel* →
+*Integrations* → *Webhooks* → *New Webhook* → *Copy Webhook URL*. You need
+**Manage Webhooks** in that channel.
+
+Or set it in game without touching the file at all:
+
+```
+/discordlogger webhook https://discord.com/api/webhooks/1234567890/AbCdEf…
+```
+
+That writes it here and reloads. The URL is never echoed back, and command logging
+redacts it, so running it does not publish the URL to the channel you are moving away
+from.
+
+**If it is empty or malformed**, the plugin still starts and still logs to console — it
+just says so on startup and posts nothing to Discord. It is not a crash, so check the
+console if messages are not arriving.
+
+> Treat the URL like a password. Anyone who has it can post to that channel as your
+> server.
 
 ---
 
 ### `embeds`
-Controls whether logs are sent as **Discord embeds** (recommended) or as plain text, and the embed **author** label.
-
-- `embeds.enabled` — `true` to send rich embeds (defaults to **true** in the v10 shipped file).
-- `embeds.author` — Small label at the top of embeds (default: **"Server Logs"**).
-
-> **Changed in v10:** `embeds.colors` no longer exists. Each event's colour now sits
-> directly under that event, beside its toggle — see [`log`](#log) below. Upgrading from
-> v9 moves your existing colours across automatically.
+Whether logs are sent as rich **embeds** or as plain text lines.
 
 ```yaml
 embeds:
   enabled: true
-  author: "Server Logs"
+  author: "Server Logs"     # small label at the top of every embed
 ```
+
+With `enabled: true` a death arrives as a coloured embed titled **Player Death**, with
+a **Cause of Death** field and the player's head as the thumbnail.
+
+With `enabled: false` the same event is one line of text:
+
+```
+`[14:32:07, 31:07:2026]` - **Player Death**: Lachlan fell from a high place
+```
+
+Plain text is worth choosing if you pipe the channel somewhere else, or find embeds
+noisy at volume. Everything still gets logged either way — only the presentation
+changes.
+
+`embeds.author` is the small label above the title. On a network it is worth setting
+per server so you can tell them apart:
+
+```yaml
+embeds:
+  author: "Survival"        # or "Creative", "Lobby", …
+```
+
+> **Changed in v10:** `embeds.colors` no longer exists. Each event's colour now sits
+> under that event, beside its toggle — see [`log`](#log). Upgrading from v9 moves your
+> existing colours across automatically.
 
 ---
 
@@ -94,95 +128,244 @@ Applied on top of the event toggles: an event that is **enabled** can still be s
 if it matches a filter. This is how you exclude specific things without turning a whole
 category off.
 
-| Key | What it does |
+Each list is independent — use one and leave the rest empty if you like.
+
+#### `filters.ignored_commands`
+Commands that are never logged, whoever runs them.
+
+The match is on the **command word only**, so arguments and any plugin prefix are
+ignored. A single entry of `msg` blocks all three of these:
+
+```
+/msg Steve hello
+/MSG Steve hello
+/essentials:msg Steve hello
+```
+
+Write entries **without** the leading slash:
+
+```yaml
+filters:
+  ignored_commands:
+    - login
+    - register
+    - msg
+    - vanish
+    - co          # CoreProtect inspect spam
+```
+
+> **This list ships non-empty, on purpose.** Command logging posts the line exactly as
+> typed, so `/login hunter2` would publish that password to Discord, and `/msg` would
+> publish private messages. The defaults cover the usual auth and messaging commands.
+> Removing them is a decision, not a tidy-up.
+
+#### `filters.ignored_worlds`
+Worlds whose events are never logged.
+
+Use the world's **folder name**, which is what the server calls it internally — not a
+display name from a plugin. On a default server:
+
+| World | Name to put here |
 |---|---|
-| `filters.ignored_commands` | Commands never logged, matched on the command word. Arguments and a plugin prefix are ignored, so `/essentials:msg hi` matches `msg`. |
-| `filters.ignored_players` | Players never logged. Accepts **names or UUIDs**, mixed freely. |
-| `filters.exempt_permission` | Players holding this permission are never logged. Empty disables the check. |
-| `filters.ignored_worlds` | Worlds whose events are never logged. |
-| `filters.ignored_chat_containing` | Chat messages containing any of these (case-insensitive) are skipped. |
+| Overworld | `world` |
+| Nether | `world_nether` |
+| The End | `world_the_end` |
 
-> **`ignored_commands` ships non-empty, on purpose.** Command logging posts the full
-> line as typed, so `/login` and `/register` would publish passwords in plain text and
-> `/msg` would publish private messages. The defaults cover the common auth and
-> messaging commands. Removing them is a decision, not a tidy-up.
+So to stop logging anything that happens in the Nether:
 
-> **Moderation events are not filtered by player.** `ignored_players` means "this
-> account's own activity isn't logged" — its joins, chat, commands, deaths. A ban or
-> kick is a record of *staff* action, not that player's activity, and hiding it is how
-> an audit trail loses the entries that matter most.
+```yaml
+filters:
+  ignored_worlds:
+    - world_nether
+```
 
-The command match is on the command word only, so a filter cannot be dodged by
-qualifying it: `/msg`, `/MSG` and `/essentials:msg` all match an entry of `msg`.
+**If your server renames or adds worlds** — Multiverse, a custom `level-name`, minigame
+worlds — those names will differ. Two ways to find the real one:
+
+- Look in your server folder. Each world is a directory containing `level.dat`; the
+  directory name is the world name.
+- In game, type `/execute in ` and let it tab-complete — it lists every loaded world by
+  its actual name.
+
+Matching is case-insensitive, so `World_Nether` works as well as `world_nether`.
+
+```yaml
+# A creative plot world, a minigame world, and the End
+filters:
+  ignored_worlds:
+    - creative
+    - bedwars_arena
+    - world_the_end
+```
+
+#### `filters.ignored_players`
+Players whose **own activity** is never logged — their joins, quits, chat, commands and
+deaths.
+
+Accepts **names or UUIDs, mixed freely** in the same list. A UUID keeps working after a
+name change, so prefer it for anything long-lived:
+
+```yaml
+filters:
+  ignored_players:
+    - AdminAlt                                  # by name
+    - ShopBot
+    - 069a79f4-44e9-4726-a5be-fca90e38aaf5      # by UUID
+```
+
+> **Moderation events are not filtered by player.** A ban or a kick is a record of
+> *staff* action, not that player's own activity, so it is still logged even for an
+> ignored account. Otherwise you could silence a bot and then never see it being
+> banned — which is exactly the entry an audit trail exists for.
+
+#### `filters.exempt_permission`
+Any player holding this permission is never logged. Empty — the default — disables the
+check entirely.
+
+Useful when the set of people to exclude changes often, such as staff or anyone
+currently vanished, because you then manage it in your permissions plugin rather than
+by editing this file:
+
+```yaml
+filters:
+  exempt_permission: "discordlogger.exempt"
+```
+
+Grant it however your permissions plugin does. With LuckPerms:
+
+```
+/lp group staff permission set discordlogger.exempt true
+```
+
+Leave it as `""` unless you want this behaviour — a node that something else happens to
+grant would quietly suppress logging for those players.
+
+#### `filters.ignored_chat_containing`
+Chat messages containing any of these are skipped. Case-insensitive **substring** match
+— not whole words, and not a regular expression:
+
+```yaml
+filters:
+  ignored_chat_containing:
+    - "[afk]"
+    - discord.gg        # invite links
+```
+
+Because it matches inside words, keep entries distinctive: an entry of `ass` would also
+skip "password" and "grass".
+
+---
 
 ---
 
 ### `log`
-Each event is a section with two keys: **`enabled`** (whether to log it) and
-**`color`** (the embed colour for that event). v10 supports:
+Every event is a section with the same three keys, plus sub-options on a few:
+
+| Key | What it does |
+|---|---|
+| `enabled` | Whether to log this event at all. |
+| `color` | The embed's colour bar, as hex. |
+| `webhook` | Send **just this event** to a different channel. Empty = the main `webhook.url`. |
+
+The events available:
 
 - `log.player.*` — `join`, `quit`, `chat`, `command`, `death`, `advancement`, `teleport`, `gamemode`
 - `log.server.*` — `command`, `start`, `stop`, `explosion`
 - `log.moderation.*` — `ban`, `unban`, `kick`, `op`, `deop`, `whitelist_toggle`, `whitelist_edit`
 
-**Example (structure):**
+**A minimal example** — log joins, don't log quits:
+
 ```yaml
 log:
   player:
     join:
       enabled: true
       color: "#57F287"
+      webhook: ""
     quit:
-      enabled: false      # this event won't be logged
+      enabled: false           # this event is never sent
       color: "#ED4245"
+      webhook: ""
 ```
 
-Every event also takes a **`webhook`**, which routes just that event to its own
-Discord channel:
+#### `color`
+Hex, with or without the leading `#`. Both of these are the same green:
 
 ```yaml
+      color: "#57F287"
+      color: "57F287"
+```
+
+An unreadable value falls back to the built-in default rather than failing to load, and
+`color` is read whether or not the event is enabled — so turning something off and back
+on keeps the colour you chose.
+
+#### `webhook` — sending one event elsewhere
+The common case is a private staff channel for moderation while everything else goes to
+a public one:
+
+```yaml
+webhook:
+  url: "https://discord.com/api/webhooks/111/PUBLIC"    # everything, by default
+
 log:
   moderation:
     ban:
       enabled: true
       color: "#FF0000"
-      webhook: "https://discord.com/api/webhooks/…"   # private staff channel
+      webhook: "https://discord.com/api/webhooks/222/STAFF"   # …except this
+    kick:
+      enabled: true
+      color: "#FF0000"
+      webhook: "https://discord.com/api/webhooks/222/STAFF"   # …and this
 ```
 
-Leave it empty and the event uses `webhook.url` from the top of the file, which is
-what almost every server wants. A value that isn't a valid Discord webhook URL is
-ignored with a warning in console, and that event falls back to the main webhook
-rather than silently going nowhere.
+Leave it as `""` and the event uses the main webhook, which is what almost every server
+wants. A value that isn't a valid Discord webhook URL is **ignored with a warning in
+console** and that event falls back to the main webhook, rather than silently going
+nowhere.
 
-Each destination is paced independently, because Discord's rate limits are per
-webhook — a busy chat channel will not delay your moderation log.
+Each destination is paced independently, because Discord's rate limits are per webhook
+— a busy chat channel will not delay your moderation log.
 
-Some events carry extra sub-options alongside `enabled`, `color` and `webhook`:
+#### Sub-options
+A few events carry an extra key beside `enabled`, `color` and `webhook`:
 
 | Key | Default | What it does |
 |---|---|---|
 | `log.player.death.show_coords` | `false` | Appends where the player died, as `x, y, z in world`. |
 | `log.player.join.show_platform` | `true` | Adds a **Platform: Bedrock** field when the joining player came from Bedrock. |
 
-> **`show_platform` only ever flags Bedrock.** Nothing can prove a player *is* Java —
-> with Geyser standalone, Bedrock players authenticate as ordinary Java accounts and are
-> indistinguishable even to Floodgate. So the field appears only when something positively
-> indicates Bedrock, and its absence means "no indication", not "definitely Java". On a
-> server without Geyser it never appears at all.
+```yaml
+log:
+  player:
+    death:
+      enabled: true
+      color: "#ED4245"
+      webhook: ""
+      show_coords: true        # "Lachlan died … Coords: 128, 71, -344 in world"
+    join:
+      enabled: true
+      color: "#57F287"
+      webhook: ""
+      show_platform: true
+```
 
 > **`show_coords` is off by default on purpose.** A death message with coordinates tells
 > everyone who can read the channel exactly where the body — and the inventory it
 > dropped — is. That is useful on a private server and a griefing tool on a public one,
 > so it is opt-in rather than something you discover after the fact.
 
-`color` is read whether or not the event is enabled, so turning something off and
-back on keeps the colour you chose. Colours are hex, with or without the leading `#`;
-an unreadable value falls back to the built-in default rather than failing to load.
+> **`show_platform` only ever flags Bedrock.** Nothing can prove a player *is* Java —
+> with Geyser standalone, Bedrock players authenticate as ordinary Java accounts and are
+> indistinguishable even to Floodgate. So the field appears only when something
+> positively indicates Bedrock, and its absence means "no indication", not "definitely
+> Java". On a server without Geyser it never appears at all.
 
 > **Upgrading from v9:** every `log.<group>.<event>: true` becomes
-> `log.<group>.<event>.enabled: true`, and each colour moves from `embeds.colors.*`
-> to its event's `color`. The plugin does this automatically on first start and
-> keeps your previous file as `config.old.yml`.
+> `log.<group>.<event>.enabled: true`, and each colour moves from `embeds.colors.*` to
+> its event's `color`. The plugin does this automatically on first start and keeps your
+> previous file as `config.old.yml`.
 
 ---
 

--- a/docs/config/v10/index.md
+++ b/docs/config/v10/index.md
@@ -268,6 +268,7 @@ The defaults shipped with v10. Each is set under its own event's `color` key:
 # D O   N O T   E D I T #
 #########################
 
+# Set automatically
 config-version: 10
 
 ###################

--- a/src/main/java/com/discordlogger/DiscordLogger.java
+++ b/src/main/java/com/discordlogger/DiscordLogger.java
@@ -7,6 +7,7 @@ import com.discordlogger.command.Webhook;
 import com.discordlogger.config.ConfigMigrator;
 import com.discordlogger.config.ConfigVersionNotice;
 import com.discordlogger.event.EventRegistry;
+import com.discordlogger.filter.Filters;
 import com.discordlogger.log.Log;
 import com.discordlogger.metrics.PluginMetrics;
 import com.discordlogger.update.BuildInfo;
@@ -104,6 +105,10 @@ public final class DiscordLogger extends JavaPlugin {
     }
 
     public boolean applyRuntimeConfig() {
+        // Before Log.init, so a reload cannot briefly log something the new config
+        // says to filter.
+        Filters.reload(this);
+
         final String url = getConfig().getString("webhook.url", "");
         final String timePattern = getConfig().getString("format.time", "[HH:mm:ss dd:MM:yyyy]");
 

--- a/src/main/java/com/discordlogger/config/ConfigMigrator.java
+++ b/src/main/java/com/discordlogger/config/ConfigMigrator.java
@@ -252,7 +252,8 @@ public final class ConfigMigrator {
                 }
                 defaultText = new String(in.readAllBytes(), StandardCharsets.UTF_8);
             }
-            final Integer newVer = extractVersion(defaultText);
+            final Map<String, Object> defFlat = flattenYaml(new Yaml().load(defaultText));
+            final Integer newVer = detectVersion(defaultText, defFlat, m -> {});
 
             // If user file missing → write default and return (fresh install; no migration)
             if (!userFile.exists()) {
@@ -264,7 +265,14 @@ public final class ConfigMigrator {
 
             // Read user's current config (verbatim)
             final String userText = Files.readString(userFile.toPath(), StandardCharsets.UTF_8);
-            final Integer oldVer = extractVersion(userText);
+            Map<String, Object> userFlat;
+            try {
+                userFlat = flattenYaml(new Yaml().load(userText));
+            } catch (Exception malformed) {
+                plugin.getLogger().warning("config.yml could not be parsed: " + malformed.getMessage());
+                userFlat = new LinkedHashMap<>();
+            }
+            final Integer oldVer = detectVersion(userText, userFlat, plugin.getLogger()::warning);
 
             // Migrate ONLY forward. A config newer than this build is left exactly as
             // it is: rewriting it against an older shipped default would drop whatever
@@ -324,6 +332,11 @@ public final class ConfigMigrator {
      * @return the path in the target schema, or null if the key is genuinely gone
      */
     static String resolvePath(String path, Map<String, Object> defMap, int from, int to) {
+        // Never carried over. The freshly written file already declares the schema it
+        // is; transplanting the user's old number would label a v10 file as v9 and
+        // make the next start try to migrate it again.
+        if ("config-version".equals(path)) return null;
+
         String current = path;
         for (int v = from; v < to; v++) {
             current = step(v, current);
@@ -524,6 +537,57 @@ public final class ConfigMigrator {
 
     private static int leadingSpaces(String s) {
         int i = 0; while (i < s.length() && s.charAt(i) == ' ') i++; return i;
+    }
+
+    /**
+     * The schema a config file actually is.
+     *
+     * <p>Three sources, in decreasing durability:
+     *
+     * <ol>
+     *   <li><b>Its shape</b> — which keys exist. Cannot be wrong, because it is not a
+     *       claim about the file, it <i>is</i> the file. Used as the arbiter.</li>
+     *   <li>The <b>{@code config-version} key</b>. Survives comment stripping and sits
+     *       at the top of the file rather than the bottom, so it is far harder to
+     *       lose by accident than the trailer it replaces.</li>
+     *   <li>The <b>trailer comment</b>. Kept because every v9-and-earlier config in
+     *       existence has one and no key, so it is the only marker on the files that
+     *       most need upgrading.</li>
+     * </ol>
+     *
+     * <p>When a declaration disagrees with the shape, the shape wins and the mismatch
+     * is reported. The realistic cause is someone pasting an older config over a newer
+     * one, or hand-editing the number; in both cases the keys are what the plugin has
+     * to read, so they are what migration must be based on.
+     */
+    static Integer detectVersion(String text, Map<String, Object> flat, java.util.function.Consumer<String> warn) {
+        final Integer declared = declaredVersion(text, flat);
+        final int inferred = SchemaDetector.infer(flat);
+
+        if (inferred == SchemaDetector.UNKNOWN) return declared;
+        if (declared == null) return inferred;
+
+        if (declared != inferred) {
+            warn.accept("config.yml says it is schema v" + declared + ", but its keys are v"
+                    + inferred + ". Going with v" + inferred + " — the keys are what the plugin "
+                    + "actually reads. This usually means an older config was pasted over a "
+                    + "newer one, or the version was edited by hand.");
+        }
+        return inferred;
+    }
+
+    /** The version the file claims: the config-version key first, else the trailer. */
+    private static Integer declaredVersion(String text, Map<String, Object> flat) {
+        final Object key = flat == null ? null : flat.get("config-version");
+        if (key instanceof Number n) return n.intValue();
+        if (key instanceof String str) {
+            try {
+                return Integer.parseInt(str.trim());
+            } catch (NumberFormatException ignored) {
+                // Falls through to the trailer.
+            }
+        }
+        return extractVersion(text);
     }
 
     static Integer extractVersion(String text) {

--- a/src/main/java/com/discordlogger/config/ConfigMigrator.java
+++ b/src/main/java/com/discordlogger/config/ConfigMigrator.java
@@ -80,12 +80,124 @@ public final class ConfigMigrator {
         // path is absent from the new defaults, so the value is dropped and the
         // default wins — indistinguishable, to the user, from the plugin ignoring
         // their config.
+        // Two passes. Scalars are replaced in place, which keeps every line index
+        // aligned with defLines. Lists change the line count, so they are collected
+        // and spliced afterwards from the bottom up — applying them top-down would
+        // invalidate every index after the first splice.
+        record ListEdit(int from, int to, List<String> block) {}
+        final List<ListEdit> listEdits = new ArrayList<>();
+
         for (Map.Entry<String, Object> e : usrMap.entrySet()) {
             String target = resolvePath(e.getKey(), defMap, fromVersion, toVersion);
             if (target == null) continue;  // genuinely removed -> keep the default
+
+            if (e.getValue() instanceof List<?> userList) {
+                final int[] span = listSpanInDefault(defLines, target);
+                if (span != null) {
+                    listEdits.add(new ListEdit(span[0], span[1],
+                            renderList(defLines.get(span[0]), userList)));
+                }
+                continue;
+            }
             replaceLeafValueInDefault(newLines, defLines, target, e.getValue());
         }
+
+        listEdits.sort((a, b) -> Integer.compare(b.from(), a.from()));
+        for (ListEdit edit : listEdits) {
+            newLines.subList(edit.from(), edit.to()).clear();
+            newLines.addAll(edit.from(), edit.block());
+        }
+
         return String.join("\n", newLines);
+    }
+
+    /**
+     * The line range a list value occupies in the defaults, as {@code [from, toExclusive)}.
+     *
+     * <p>Handles both forms the config uses: an inline empty list ({@code key: []}),
+     * which is one line, and a block list whose items follow on their own lines.
+     *
+     * @return the span, or null if the key is not a list here
+     */
+    private static int[] listSpanInDefault(List<String> lines, String path) {
+        final LeafPos pos = findLeafLine(lines, path);
+        if (pos == null) return null;
+
+        final String keyLine = lines.get(pos.index());
+        final int colon = keyLine.indexOf(':', pos.keyIndent());
+        if (colon < 0) return null;
+
+        final String after = stripInlineComment(keyLine.substring(colon + 1)).trim();
+        if (!after.isEmpty()) {
+            // Inline: "key: []" or "key: [a, b]". One line either way.
+            return after.startsWith("[") ? new int[]{pos.index(), pos.index() + 1} : null;
+        }
+
+        int end = pos.index() + 1;
+        while (end < lines.size()) {
+            final String line = lines.get(end);
+            if (line.isBlank()) break;
+            if (leadingSpaces(line) <= pos.keyIndent()) break;
+            if (!line.strip().startsWith("-")) break;
+            end++;
+        }
+        return new int[]{pos.index(), end};
+    }
+
+    /** The user's list, written under the default's own key line and indentation. */
+    private static List<String> renderList(String keyLine, List<?> values) {
+        final int keyIndent = leadingSpaces(keyLine);
+        final int colon = keyLine.indexOf(':', keyIndent);
+        final String comment = inlineCommentOf(keyLine.substring(colon + 1));
+        final String key = keyLine.substring(0, colon + 1);
+
+        final List<String> out = new ArrayList<>();
+        if (values.isEmpty()) {
+            out.add(key + " []" + comment);
+            return out;
+        }
+        out.add(key + comment);
+        final String indent = " ".repeat(keyIndent + 2);
+        for (Object v : values) {
+            out.add(indent + "- " + renderListItem(v));
+        }
+        return out;
+    }
+
+    /**
+     * A list item, quoted only when YAML would otherwise read it as something else.
+     *
+     * <p>{@code renderScalar} quotes every string, which is right for a value being
+     * substituted into an existing line but wrong here: it would rewrite a hand-
+     * written {@code - login} as {@code - "login"} on every migration, producing a
+     * diff for a file nobody edited. Quoting stays for the cases that need it — an
+     * entry like {@code no} or {@code 3} would otherwise come back as a boolean or a
+     * number rather than the command name someone typed.
+     */
+    private static String renderListItem(Object v) {
+        if (!(v instanceof String s)) return renderScalar(v);
+        if (s.isEmpty() || !s.equals(s.strip())) return renderScalar(s);
+        if (PLAIN_SAFE.matcher(s).matches() && !YAML_RESERVED.matcher(s).matches()) return s;
+        return renderScalar(s);
+    }
+
+    /** Conservative: letters, digits and the punctuation a command or name actually uses. */
+    private static final Pattern PLAIN_SAFE = Pattern.compile("[A-Za-z0-9][A-Za-z0-9_.:@/-]*");
+
+    /** Words YAML 1.1 resolves to a boolean or null, plus anything numeric. */
+    private static final Pattern YAML_RESERVED = Pattern.compile(
+            "(?i)y|n|yes|no|true|false|on|off|null|~|[+-]?\\d+(\\.\\d+)?");
+
+    /** Everything before an unquoted '#', or the whole string when there is none. */
+    private static String stripInlineComment(String s) {
+        final int hash = findUnquotedHash(s, 0);
+        return hash < 0 ? s : s.substring(0, hash);
+    }
+
+    /** The inline comment including its leading space, or "" when absent. */
+    private static String inlineCommentOf(String s) {
+        final int hash = findUnquotedHash(s, 0);
+        return hash < 0 ? "" : " " + s.substring(hash).trim();
     }
 
     /**

--- a/src/main/java/com/discordlogger/config/SchemaDetector.java
+++ b/src/main/java/com/discordlogger/config/SchemaDetector.java
@@ -1,0 +1,67 @@
+package com.discordlogger.config;
+
+import java.util.Map;
+
+/**
+ * Works out which config schema a file actually is, from its keys.
+ *
+ * <p>The schema used to be declared only by a comment on the last line. Comments are
+ * the least durable thing in a config: editors strip them, formatters move them,
+ * and anyone tidying the bottom of a file deletes one without noticing. When that
+ * marker went missing the migrator saw {@code UNKNOWN}, skipped migration entirely,
+ * and the plugin then read a file whose shape it did not match — every option
+ * silently falling back to a default.
+ *
+ * <p>A file's schema is not really a declaration, though. It is a fact about which
+ * keys are present, and that cannot be wrong: a config claiming to be v10 while
+ * lacking every v10 key is a v9 file with a bad label. So the declaration is a hint
+ * and this is the arbiter.
+ *
+ * <p>Each version is identified by a key that first appeared in it. Deleting one
+ * unrelated option therefore cannot drop a file a version — only removing the
+ * marker itself would, and at that point the file genuinely has lost the thing that
+ * distinguishes it.
+ */
+public final class SchemaDetector {
+
+    /** Unknown, i.e. not recognisable as any schema this plugin has ever shipped. */
+    public static final int UNKNOWN = -1;
+
+    private SchemaDetector() {}
+
+    /**
+     * The newest schema whose marker is present.
+     *
+     * <p>Newest-first because schemas are additive: a v10 file also contains v9's
+     * keys, so testing oldest-first would always answer v2.
+     *
+     * @param flat the config flattened to dotted paths, as {@link ConfigMigrator#flattenYaml} produces
+     */
+    public static int infer(Map<String, Object> flat) {
+        if (flat == null || flat.isEmpty()) return UNKNOWN;
+
+        // v10 restructured events into sections and added filters. Either is decisive.
+        if (flat.containsKey("filters.exempt_permission")
+                || flat.containsKey("log.player.join.enabled")) return 10;
+
+        if (flat.containsKey("embeds.colors.server.explosion")) return 9;
+        if (flat.containsKey("embeds.colors.player.gamemode")) return 8;
+        if (flat.containsKey("embeds.colors.moderation.ban")) return 7;
+
+        // v6 introduced moderation colours as flat keys, before v7 nested them.
+        if (flat.containsKey("embeds.colors.ban")) return 6;
+
+        // v4 and v5 have identical key sets, so they are genuinely indistinguishable.
+        // Reporting the newer is safe: nothing changed between them, so the migration
+        // from either is the same, and step(4) is an identity step.
+        if (flat.containsKey("format.name")) return 5;
+
+        if (flat.containsKey("embeds.author")) return 3;
+
+        // Oldest on record. Requires the two keys that have existed since the start,
+        // so an unrelated YAML file is not mistaken for an ancient config.
+        if (flat.containsKey("webhook.url") && flat.containsKey("format.time")) return 2;
+
+        return UNKNOWN;
+    }
+}

--- a/src/main/java/com/discordlogger/filter/Filters.java
+++ b/src/main/java/com/discordlogger/filter/Filters.java
@@ -1,0 +1,169 @@
+package com.discordlogger.filter;
+
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Decides what never reaches Discord, regardless of which events are enabled.
+ *
+ * <p>Event toggles are all-or-nothing: command logging is either on or off. That is
+ * too blunt for two things a server genuinely needs. Some commands must never be
+ * logged at all — {@code /login} and {@code /register} carry passwords in plain
+ * text, and {@code /msg} is private by definition — and some accounts should be
+ * invisible, such as staff alt accounts or bots whose activity would drown the log.
+ *
+ * <p>Filtering happens in the listener rather than in {@link com.discordlogger.log.Log},
+ * because that is where the player, world and raw command still exist. By the time
+ * a message reaches {@code Log} it is a rendered string, and deciding from that
+ * would mean matching against prose.
+ *
+ * <p>The config is read into an immutable snapshot on load and swapped atomically,
+ * so a reload cannot be observed half-applied by an async sender.
+ *
+ * <p><b>Moderation events are deliberately not filtered by player.</b>
+ * {@code ignored_players} means "this account's own activity is not logged" — its
+ * joins, chat, commands, deaths. A ban or a kick is not that player's activity, it
+ * is a record of staff action, and suppressing it is how an audit trail quietly
+ * loses the entries that matter most. Someone silencing a bot account still wants
+ * to know if that account gets banned.
+ */
+public final class Filters {
+
+    private static volatile Snapshot current = Snapshot.empty();
+
+    private Filters() {}
+
+    private record Snapshot(
+            Set<String> ignoredNames,
+            Set<UUID> ignoredUuids,
+            Set<String> ignoredCommands,
+            Set<String> ignoredWorlds,
+            List<String> chatPatterns,
+            String exemptPermission
+    ) {
+        static Snapshot empty() {
+            return new Snapshot(Set.of(), Set.of(), Set.of(), Set.of(), List.of(), "");
+        }
+    }
+
+    /** Re-read the filter config. Called from applyRuntimeConfig, so /reload picks it up. */
+    public static void reload(JavaPlugin plugin) {
+        final Set<String> names = new LinkedHashSet<>();
+        final Set<UUID> uuids = new LinkedHashSet<>();
+
+        // One list accepts both names and UUIDs: asking an admin which one they have
+        // is friction, and the two are trivially distinguishable.
+        for (String entry : plugin.getConfig().getStringList("filters.ignored_players")) {
+            if (entry == null || entry.isBlank()) continue;
+            final String trimmed = entry.trim();
+            try {
+                uuids.add(UUID.fromString(trimmed));
+            } catch (IllegalArgumentException notAUuid) {
+                names.add(trimmed.toLowerCase(Locale.ROOT));
+            }
+        }
+
+        final Set<String> commands = new LinkedHashSet<>();
+        for (String entry : plugin.getConfig().getStringList("filters.ignored_commands")) {
+            if (entry == null || entry.isBlank()) continue;
+            commands.add(normaliseCommand(entry));
+        }
+
+        final Set<String> worlds = new LinkedHashSet<>();
+        for (String entry : plugin.getConfig().getStringList("filters.ignored_worlds")) {
+            if (entry == null || entry.isBlank()) continue;
+            worlds.add(entry.trim().toLowerCase(Locale.ROOT));
+        }
+
+        final List<String> patterns = plugin.getConfig()
+                .getStringList("filters.ignored_chat_containing").stream()
+                .filter(s -> s != null && !s.isBlank())
+                .map(s -> s.toLowerCase(Locale.ROOT))
+                .toList();
+
+        final String perm = plugin.getConfig().getString("filters.exempt_permission", "").trim();
+
+        current = new Snapshot(names, uuids, commands, worlds, patterns, perm);
+
+        final int total = names.size() + uuids.size() + commands.size()
+                + worlds.size() + patterns.size();
+        if (total > 0 || !perm.isEmpty()) {
+            plugin.getLogger().info("Log filters active: " + commands.size() + " command(s), "
+                    + (names.size() + uuids.size()) + " player(s), " + worlds.size() + " world(s), "
+                    + patterns.size() + " chat pattern(s)"
+                    + (perm.isEmpty() ? "" : ", exempt permission '" + perm + "'") + ".");
+        }
+    }
+
+    /**
+     * True when nothing about this player should ever be logged.
+     *
+     * <p>Covers the name list, the UUID list, and the exempt permission. The
+     * permission is checked last because it is the only one that touches the
+     * permissions plugin.
+     */
+    public static boolean blocksPlayer(Player player) {
+        if (player == null) return false;
+        final Snapshot snap = current;
+
+        if (snap.ignoredUuids().contains(player.getUniqueId())) return true;
+        if (snap.ignoredNames().contains(player.getName().toLowerCase(Locale.ROOT))) return true;
+
+        final String perm = snap.exemptPermission();
+        return !perm.isEmpty() && player.hasPermission(perm);
+    }
+
+    /** True when this world's events should never be logged. */
+    public static boolean blocksWorld(String worldName) {
+        if (worldName == null) return false;
+        return current.ignoredWorlds().contains(worldName.toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * True when this command should never be logged.
+     *
+     * @param raw the command as typed, with or without a leading slash and arguments
+     */
+    public static boolean blocksCommand(String raw) {
+        if (raw == null || raw.isBlank()) return false;
+        return current.ignoredCommands().contains(normaliseCommand(raw));
+    }
+
+    /** True when a chat line contains any configured pattern. */
+    public static boolean blocksChat(String message) {
+        if (message == null || message.isEmpty()) return false;
+        final String haystack = message.toLowerCase(Locale.ROOT);
+        for (String needle : current.chatPatterns()) {
+            if (haystack.contains(needle)) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Reduces a typed command to the word that identifies it.
+     *
+     * <p>Drops the leading slash, everything from the first space, and any plugin
+     * qualifier — {@code /essentials:msg hello} and {@code /MSG hello} both reduce to
+     * {@code msg}. Without the qualifier step, a deny-list entry of "msg" would be
+     * trivially bypassed by typing the fully-qualified form, which is exactly the
+     * kind of hole that makes a security-flavoured filter worthless.
+     */
+    static String normaliseCommand(String raw) {
+        String s = raw.trim();
+        if (s.startsWith("/")) s = s.substring(1);
+
+        final int space = s.indexOf(' ');
+        if (space >= 0) s = s.substring(0, space);
+
+        final int colon = s.indexOf(':');
+        if (colon >= 0 && colon < s.length() - 1) s = s.substring(colon + 1);
+
+        return s.toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/com/discordlogger/listener/player/PlayerAdvancement.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerAdvancement.java
@@ -1,5 +1,6 @@
 package com.discordlogger.listener.player;
 
+import com.discordlogger.filter.Filters;
 import com.discordlogger.log.Log;
 import com.discordlogger.util.Names;
 import org.bukkit.NamespacedKey;
@@ -21,6 +22,7 @@ public final class PlayerAdvancement implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onAdvancement(PlayerAdvancementDoneEvent e) {
         if (!plugin.getConfig().getBoolean("log.player.advancement.enabled", true)) return;
+        if (Filters.blocksPlayer(e.getPlayer()) || Filters.blocksWorld(e.getPlayer().getWorld().getName())) return;
 
         final NamespacedKey key = e.getAdvancement().getKey();
         final String ns = key.getNamespace();   // usually "minecraft"

--- a/src/main/java/com/discordlogger/listener/player/PlayerChat.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerChat.java
@@ -1,5 +1,6 @@
 package com.discordlogger.listener.player;
 
+import com.discordlogger.filter.Filters;
 import com.discordlogger.log.Log;
 import com.discordlogger.util.Names;
 import io.papermc.paper.event.player.AsyncChatEvent;
@@ -18,9 +19,13 @@ public final class PlayerChat implements Listener {
     @EventHandler
     public void onChat(AsyncChatEvent e) {
         if (!plugin.getConfig().getBoolean("log.player.chat.enabled", true)) return;
+        if (Filters.blocksPlayer(e.getPlayer()) || Filters.blocksWorld(e.getPlayer().getWorld().getName())) return;
 
         String who  = Names.display(e.getPlayer(), plugin);
-        String text = Log.mdEscape(PlainTextComponentSerializer.plainText().serialize(e.message()));
+        final String plain = PlainTextComponentSerializer.plainText().serialize(e.message());
+        if (Filters.blocksChat(plain)) return;
+
+        String text = Log.mdEscape(plain);
         String msg  = "**" + who + "**: " + text;
         Log.eventWithThumb("Player Chat", msg, Log.playerAvatarUrl(e.getPlayer().getUniqueId()));
     }

--- a/src/main/java/com/discordlogger/listener/player/PlayerCommand.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerCommand.java
@@ -1,5 +1,6 @@
 package com.discordlogger.listener.player;
 
+import com.discordlogger.filter.Filters;
 import com.discordlogger.log.Log;
 import com.discordlogger.util.Names;
 import org.bukkit.event.EventHandler;
@@ -17,6 +18,11 @@ public final class PlayerCommand implements Listener {
     @EventHandler
     public void onPlayerCommand(PlayerCommandPreprocessEvent e) {
         if (!plugin.getConfig().getBoolean("log.player.command.enabled", true)) return;
+        if (Filters.blocksPlayer(e.getPlayer()) || Filters.blocksWorld(e.getPlayer().getWorld().getName())) return;
+
+        // Checked before anything is rendered: /login carries a password, so it must
+        // not reach the console echo either.
+        if (Filters.blocksCommand(e.getMessage())) return;
 
         String who = Names.display(e.getPlayer(), plugin);
         String cmd = Log.mdEscape(Log.redactWebhooks(e.getMessage())); // includes leading '/'

--- a/src/main/java/com/discordlogger/listener/player/PlayerDeath.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerDeath.java
@@ -1,5 +1,6 @@
 package com.discordlogger.listener.player;
 
+import com.discordlogger.filter.Filters;
 import com.discordlogger.log.Log;
 import com.discordlogger.util.Names;
 import org.bukkit.Location;
@@ -28,6 +29,7 @@ public final class PlayerDeath implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDeath(PlayerDeathEvent e) {
         if (!plugin.getConfig().getBoolean("log.player.death.enabled", true)) return;
+        if (Filters.blocksPlayer(e.getEntity()) || Filters.blocksWorld(e.getEntity().getWorld().getName())) return;
 
         final Player victim = e.getEntity();
         final String vName = Names.display(victim, (JavaPlugin) plugin);

--- a/src/main/java/com/discordlogger/listener/player/PlayerGamemode.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerGamemode.java
@@ -1,5 +1,6 @@
 package com.discordlogger.listener.player;
 
+import com.discordlogger.filter.Filters;
 import com.discordlogger.log.Log;
 import com.discordlogger.util.Names;
 import org.bukkit.GameMode;
@@ -22,6 +23,7 @@ public final class PlayerGamemode implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onGamemodeChange(PlayerGameModeChangeEvent e) {
         if (!plugin.getConfig().getBoolean("log.player.gamemode.enabled", true)) return;
+        if (Filters.blocksPlayer(e.getPlayer()) || Filters.blocksWorld(e.getPlayer().getWorld().getName())) return;
 
         final Player p = e.getPlayer();
         final GameMode from = p.getGameMode();      // old mode (event fires before apply)

--- a/src/main/java/com/discordlogger/listener/player/PlayerJoin.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerJoin.java
@@ -1,5 +1,6 @@
 package com.discordlogger.listener.player;
 
+import com.discordlogger.filter.Filters;
 import com.discordlogger.log.Log;
 import com.discordlogger.util.ClientPlatform;
 import com.discordlogger.util.Names;
@@ -17,6 +18,7 @@ public final class PlayerJoin implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onJoin(PlayerJoinEvent e) {
         if (!plugin.getConfig().getBoolean("log.player.join.enabled", true)) return;
+        if (Filters.blocksPlayer(e.getPlayer()) || Filters.blocksWorld(e.getPlayer().getWorld().getName())) return;
 
         // Delay slightly so nickname plugins can set displayName
         plugin.getServer().getScheduler().runTaskLater(plugin, () -> {

--- a/src/main/java/com/discordlogger/listener/player/PlayerQuit.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerQuit.java
@@ -1,5 +1,6 @@
 package com.discordlogger.listener.player;
 
+import com.discordlogger.filter.Filters;
 import com.discordlogger.log.Log;
 import com.discordlogger.util.Names;
 import org.bukkit.Bukkit;
@@ -17,6 +18,7 @@ public final class PlayerQuit implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onQuit(PlayerQuitEvent e) {
         if (!plugin.getConfig().getBoolean("log.player.quit.enabled", true)) return;
+        if (Filters.blocksPlayer(e.getPlayer()) || Filters.blocksWorld(e.getPlayer().getWorld().getName())) return;
 
         String who = Names.display(e.getPlayer(), plugin);
         String msg = who + " left the server";

--- a/src/main/java/com/discordlogger/listener/player/PlayerTeleport.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerTeleport.java
@@ -1,5 +1,6 @@
 package com.discordlogger.listener.player;
 
+import com.discordlogger.filter.Filters;
 import com.discordlogger.log.Log;
 import com.discordlogger.util.Names;
 import org.bukkit.Location;
@@ -26,6 +27,7 @@ public final class PlayerTeleport implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onTeleport(PlayerTeleportEvent e) {
         if (!plugin.getConfig().getBoolean("log.player.teleport.enabled", true)) return;
+        if (Filters.blocksPlayer(e.getPlayer()) || Filters.blocksWorld(e.getPlayer().getWorld().getName())) return;
 
         final Player p = e.getPlayer();
         final String playerName = Names.display(p, plugin);

--- a/src/main/java/com/discordlogger/listener/server/Explosion.java
+++ b/src/main/java/com/discordlogger/listener/server/Explosion.java
@@ -1,5 +1,6 @@
 package com.discordlogger.listener.server;
 
+import com.discordlogger.filter.Filters;
 import com.discordlogger.log.Log;
 import com.discordlogger.util.Names;
 import org.bukkit.Location;
@@ -47,9 +48,20 @@ public final class Explosion implements Listener {
         return plugin.getConfig().getBoolean("log.server.explosion.enabled", true);
     }
 
+    /**
+     * Explosions have no player, but they do have a world, so the world filter still
+     * applies — otherwise "don't log anything in creative_plot" would silently leak
+     * every TNT blast from it.
+     */
+    private static boolean filteredWorld(org.bukkit.Location loc) {
+        final org.bukkit.World w = (loc == null) ? null : loc.getWorld();
+        return w != null && Filters.blocksWorld(w.getName());
+    }
+
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onEntityExplode(EntityExplodeEvent e) {
         if (!enabled()) return;
+        if (filteredWorld(e.getLocation())) return;
 
         final EntityType type = (e.getEntity() == null) ? null : e.getEntity().getType();
         final String source = (type == null) ? "Unknown" : toTitle(type.name());
@@ -82,6 +94,7 @@ public final class Explosion implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockExplode(BlockExplodeEvent e) {
         if (!enabled()) return;
+        if (filteredWorld(e.getBlock() == null ? null : e.getBlock().getLocation())) return;
 
         final Block b = e.getBlock();
         final Material mat = (b == null) ? null : b.getType();

--- a/src/main/java/com/discordlogger/listener/server/ServerCommand.java
+++ b/src/main/java/com/discordlogger/listener/server/ServerCommand.java
@@ -1,5 +1,6 @@
 package com.discordlogger.listener.server;
 
+import com.discordlogger.filter.Filters;
 import com.discordlogger.log.Log;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -17,6 +18,8 @@ public final class ServerCommand implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onServerCommand(ServerCommandEvent e) {
         if (!plugin.getConfig().getBoolean("log.server.command.enabled", true)) return;
+        // Console has no player, so only the command filter applies.
+        if (Filters.blocksCommand(e.getCommand())) return;
         final String who = Log.mdEscape(e.getSender().getName()); // "Server" for console
         final String cmd = Log.mdEscape(Log.redactWebhooks("/" + e.getCommand()));
         Log.eventWithThumb("Server Command", who + " ran: " + cmd, THUMB_SERVER);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -36,6 +36,16 @@
 
 # Documentation for this config can be found at https://discordlogger.godtiergamers.xyz/config/v10/
 
+#############################
+# D O   N O T   E D I T     #
+#############################
+
+# Identifies which config format this file uses, so the plugin can upgrade it
+# correctly when you update. Changing it will not convert anything -- it only
+# misleads the upgrader. If it goes missing the plugin works it out from the keys
+# below, so deleting it is survivable, just unnecessary.
+config-version: 10
+
 ###################
 # WEBHOOK OPTIONS #
 ###################

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -36,14 +36,10 @@
 
 # Documentation for this config can be found at https://discordlogger.godtiergamers.xyz/config/v10/
 
-#############################
-# D O   N O T   E D I T     #
-#############################
+#########################
+# D O   N O T   E D I T #
+#########################
 
-# Identifies which config format this file uses, so the plugin can upgrade it
-# correctly when you update. Changing it will not convert anything -- it only
-# misleads the upgrader. If it goes missing the plugin works it out from the keys
-# below, so deleting it is survivable, just unnecessary.
 config-version: 10
 
 ###################
@@ -74,14 +70,15 @@ embeds:
   enabled: true
   author: "Server Logs" # Can be modified for proxy servers (e.g. Survival, Creative)
 
-####################################################################################
-#                                                                                  #
-#     ___  _  _  _                                                                 #
-#    | __|(_)| || |_  ___  _ _  ___                                                #
-#    | _| | || ||  _|/ -_)| '_|(_-<                                                #
-#    |_|  |_||_| \__|\___||_|  /__/                                                #
-#                                                                                  #
-####################################################################################
+###################################################
+#  ______ _____ _   _______ ______ _____   _____  #
+# |  ____|_   _| | |__   __|  ____|  __ \ / ____| #
+# | |__    | | | |    | |  | |__  | |__) | (___   #
+# |  __|   | | | |    | |  |  __| |  _  / \___ \  #
+# | |     _| |_| |____| |  | |____| | \ \ ____) | #
+# |_|    |_____|______|_|  |______|_|  \_\_____/  #
+#                                                 #
+###################################################
 
 # Filters apply on top of the toggles below: an event that is enabled can still be
 # skipped if it matches something here.
@@ -226,4 +223,5 @@ log:
       enabled: true
       color: "#16A085" # dark teal
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
 # CONFIG VERSION V10, SHIPPED WITH v2.1.6 (x-release-please-version)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -66,6 +66,48 @@ embeds:
 
 ####################################################################################
 #                                                                                  #
+#     ___  _  _  _                                                                 #
+#    | __|(_)| || |_  ___  _ _  ___                                                #
+#    | _| | || ||  _|/ -_)| '_|(_-<                                                #
+#    |_|  |_||_| \__|\___||_|  /__/                                                #
+#                                                                                  #
+####################################################################################
+
+# Filters apply on top of the toggles below: an event that is enabled can still be
+# skipped if it matches something here.
+
+filters:
+  # Never log these commands, whoever runs them. Matched on the command word, so
+  # arguments and a plugin prefix are ignored -- "/essentials:msg hi" matches "msg".
+  # The defaults exist because these leak: login commands carry passwords in plain
+  # text, and private messages are private.
+  ignored_commands:
+    - login
+    - register
+    - changepassword
+    - unregister
+    - msg
+    - tell
+    - whisper
+    - w
+    - r
+    - reply
+
+  # Never log anything from these players. Accepts names or UUIDs, mixed freely.
+  ignored_players: []
+
+  # Players with this permission are never logged -- useful for staff alts, or a bot
+  # account whose activity would drown everything else. Empty disables the check.
+  exempt_permission: ""
+
+  # Never log events that happen in these worlds.
+  ignored_worlds: []
+
+  # Skip chat messages containing any of these (case-insensitive).
+  ignored_chat_containing: []
+
+####################################################################################
+#                                                                                  #
 #     _                      _                ___         _    _                   #
 #    | |    ___  __ _  __ _ (_) _ _   __ _   / _ \  _ __ | |_ (_) ___  _ _   ___   #
 #    | |__ / _ \/ _` |/ _` || || ' \ / _` | | (_) || '_ \|  _|| |/ _ \| ' \ (_-<   #

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -40,6 +40,7 @@
 # D O   N O T   E D I T #
 #########################
 
+# Set automatically
 config-version: 10
 
 ###################

--- a/src/test/java/com/discordlogger/config/ConfigMigratorListTest.java
+++ b/src/test/java/com/discordlogger/config/ConfigMigratorListTest.java
@@ -1,0 +1,112 @@
+package com.discordlogger.config;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Migrating list values.
+ *
+ * <p>The migrator replaced scalars only. Every value in the config happened to be a
+ * scalar until {@code filters:} arrived, and a list hitting the scalar path did not
+ * fail loudly — it wrote {@code ignored_commands:"[login, register, …]"}, which is
+ * not valid YAML and left the original items orphaned below it. A user upgrading
+ * would have had their config broken and their deny-list lost.
+ *
+ * <p>That matters more than most config keys: the deny-list is what stops
+ * {@code /login} posting a password to Discord.
+ */
+class ConfigMigratorListTest {
+
+    private static String shipped;
+    private static int current;
+
+    @BeforeAll
+    static void load() throws Exception {
+        shipped = Files.readString(Path.of("src/main/resources/config.yml"));
+        current = ConfigMigrator.extractVersion(shipped);
+    }
+
+    private static Map<?, ?> filtersOf(String yaml) {
+        return (Map<?, ?>) ((Map<?, ?>) new Yaml().load(yaml)).get("filters");
+    }
+
+    @Test
+    @DisplayName("a customised deny-list survives migration")
+    void customEntriesArePreserved() {
+        String user = shipped.replace("    - login\n", "    - login\n    - mypluginsecret\n");
+        String out = ConfigMigrator.migrateText(shipped, user, current, current);
+
+        @SuppressWarnings("unchecked")
+        List<String> commands = (List<String>) filtersOf(out).get("ignored_commands");
+        assertTrue(commands.contains("mypluginsecret"),
+                "an entry the admin added must not be reverted to the shipped defaults");
+        assertTrue(commands.contains("login"), "the shipped entries must still be there too");
+    }
+
+    @Test
+    @DisplayName("a list the user filled from empty is carried over")
+    void filledFromEmpty() {
+        String user = shipped.replace("  ignored_players: []",
+                "  ignored_players:\n    - Notch\n    - 00000000-0000-0000-0009-01f2a3b4c5d6");
+        String out = ConfigMigrator.migrateText(shipped, user, current, current);
+
+        @SuppressWarnings("unchecked")
+        List<String> players = (List<String>) filtersOf(out).get("ignored_players");
+        assertEquals(List.of("Notch", "00000000-0000-0000-0009-01f2a3b4c5d6"), players);
+    }
+
+    @Test
+    @DisplayName("an empty list stays inline rather than becoming a quoted string")
+    void emptyListsStayEmpty() {
+        String out = ConfigMigrator.migrateText(shipped, shipped, current, current);
+        assertEquals(List.of(), filtersOf(out).get("ignored_worlds"));
+        assertTrue(out.contains("ignored_worlds: []"),
+                "an empty list should read as [] the way it was written");
+    }
+
+    @Test
+    @DisplayName("migrating an unchanged config is byte-identical")
+    void identityMigrationIsStable() {
+        // The regression that caught the quoting bug: rendering every item as a
+        // quoted string rewrote a plain "- login" into a quoted one on every upgrade, churning
+        // a file nobody had edited.
+        String out = ConfigMigrator.migrateText(shipped, shipped, current, current);
+        assertEquals(shipped.stripTrailing(), out.stripTrailing());
+    }
+
+    @Test
+    @DisplayName("the result is still valid YAML with comments intact")
+    void outputRemainsValid() {
+        String user = shipped.replace("    - login\n", "    - login\n    - custom\n");
+        String out = ConfigMigrator.migrateText(shipped, user, current, current);
+
+        new Yaml().load(out);   // throws if the list splice produced invalid YAML
+        assertEquals(shipped.lines().filter(l -> l.strip().startsWith("#")).count(),
+                out.lines().filter(l -> l.strip().startsWith("#")).count(),
+                "splicing a list must not disturb the surrounding comments");
+    }
+
+    @Test
+    @DisplayName("entries YAML would read as booleans or numbers stay strings")
+    void reservedWordsAreQuoted() {
+        // A command called "no" or "on" is unlikely but legal, and unquoted it would
+        // come back as a boolean — silently no longer matching anything.
+        String user = shipped.replace("    - login\n", "    - login\n    - \"no\"\n    - \"3\"\n");
+        String out = ConfigMigrator.migrateText(shipped, user, current, current);
+
+        @SuppressWarnings("unchecked")
+        List<Object> commands = (List<Object>) filtersOf(out).get("ignored_commands");
+        assertTrue(commands.contains("no"), "should still be the string no, not the boolean false");
+        assertTrue(commands.contains("3"), "should still be the string 3, not the number 3");
+    }
+}

--- a/src/test/java/com/discordlogger/config/SchemaDetectorTest.java
+++ b/src/test/java/com/discordlogger/config/SchemaDetectorTest.java
@@ -1,0 +1,105 @@
+package com.discordlogger.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Recognising a config by its keys rather than by what it claims.
+ *
+ * <p>The schema was declared only by a comment on the last line, which is the least
+ * durable thing in a config file. When it went missing the migrator returned
+ * UNKNOWN, skipped migration, and the plugin then read a file whose shape it did
+ * not match — every option silently falling back to its default, with nothing in
+ * the log to explain it.
+ */
+class SchemaDetectorTest {
+
+    private static Map<String, Object> flat(String yaml) {
+        return ConfigMigrator.flattenYaml(new Yaml().load(yaml));
+    }
+
+    private static String shipped() throws Exception {
+        return Files.readString(Path.of("src/main/resources/config.yml"));
+    }
+
+    @Test
+    @DisplayName("the shipped config is recognised as its own schema")
+    void recognisesTheShippedConfig() throws Exception {
+        final String text = shipped();
+        assertEquals(ConfigMigrator.extractVersion(text), SchemaDetector.infer(flat(text)),
+                "the shipped file's declared version and its actual shape must agree — "
+                        + "if they do not, one of them was updated without the other");
+    }
+
+    @Test
+    @DisplayName("a config with no version marker at all is still identified")
+    void survivesLosingEveryMarker() throws Exception {
+        // Both markers gone: the trailer deleted and the key removed. This is the case
+        // the whole class exists for.
+        String stripped = shipped()
+                .lines()
+                .filter(l -> !l.contains("CONFIG VERSION"))
+                .filter(l -> !l.startsWith("config-version:"))
+                .reduce("", (a, b) -> a + b + "\n");
+
+        assertEquals(10, SchemaDetector.infer(flat(stripped)),
+                "with no declaration anywhere, the keys still say what this file is");
+    }
+
+    @Test
+    @DisplayName("older schemas are identified by the key that introduced them")
+    void identifiesEachHistoricalSchema() {
+        assertEquals(9, SchemaDetector.infer(flat(
+                "webhook:\n  url: ''\nformat:\n  time: x\nembeds:\n  author: a\n  colors:\n"
+                        + "    server:\n      explosion: '#fff'\n")));
+        assertEquals(8, SchemaDetector.infer(flat(
+                "webhook:\n  url: ''\nformat:\n  time: x\nembeds:\n  author: a\n  colors:\n"
+                        + "    player:\n      gamemode: '#fff'\n")));
+        assertEquals(7, SchemaDetector.infer(flat(
+                "webhook:\n  url: ''\nformat:\n  time: x\nembeds:\n  author: a\n  colors:\n"
+                        + "    moderation:\n      ban: '#fff'\n")));
+        assertEquals(6, SchemaDetector.infer(flat(
+                "webhook:\n  url: ''\nformat:\n  time: x\nembeds:\n  author: a\n  colors:\n"
+                        + "    ban: '#fff'\n")));
+        assertEquals(3, SchemaDetector.infer(flat(
+                "webhook:\n  url: ''\nformat:\n  time: x\nembeds:\n  author: a\n")));
+        assertEquals(2, SchemaDetector.infer(flat("webhook:\n  url: ''\nformat:\n  time: x\n")));
+    }
+
+    @Test
+    @DisplayName("a v9 config is not mistaken for v10")
+    void doesNotOverreadOlderConfigs() {
+        // v9 events are bare booleans; v10 made them sections. Getting this wrong
+        // would skip the migration that restructures them.
+        String v9 = "webhook:\n  url: ''\nformat:\n  time: x\nembeds:\n  author: a\n  colors:\n"
+                + "    server:\n      explosion: '#fff'\nlog:\n  player:\n    join: true\n";
+        assertEquals(9, SchemaDetector.infer(flat(v9)));
+        assertNotEquals(10, SchemaDetector.infer(flat(v9)));
+    }
+
+    @Test
+    @DisplayName("deleting an ordinary option does not change the detected schema")
+    void toleratesMissingOptions() throws Exception {
+        // An admin who deletes options they do not use must not have their config
+        // treated as an older schema and rewritten.
+        String trimmed = shipped().replace("  nicknames: true\n", "")
+                                  .replace("      show_coords: false", "");
+        assertEquals(10, SchemaDetector.infer(flat(trimmed)));
+    }
+
+    @Test
+    @DisplayName("something that is not a config at all is not claimed")
+    void ignoresUnrelatedYaml() {
+        assertEquals(SchemaDetector.UNKNOWN, SchemaDetector.infer(flat("name: SomePlugin\nversion: 1.0\n")));
+        assertEquals(SchemaDetector.UNKNOWN, SchemaDetector.infer(Map.of()));
+        assertEquals(SchemaDetector.UNKNOWN, SchemaDetector.infer(null));
+    }
+}

--- a/src/test/java/com/discordlogger/filter/FiltersTest.java
+++ b/src/test/java/com/discordlogger/filter/FiltersTest.java
@@ -1,0 +1,118 @@
+package com.discordlogger.filter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.yaml.snakeyaml.Yaml;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Command matching, and the shipped deny-list.
+ *
+ * <p>The matching is the security-relevant part. A deny-list that "msg" defeats by
+ * typing "/essentials:msg" is worse than no deny-list, because the admin believes
+ * private messages are excluded when they are not — and the same reasoning applies
+ * to {@code /login}, which carries a password in plain text.
+ *
+ * <p>{@code blocksPlayer} and {@code blocksWorld} need a live server and config, so
+ * they are exercised on a test server rather than here; what is pinned here is the
+ * pure normalisation they all route through, plus the shipped defaults.
+ */
+class FiltersTest {
+
+    @ParameterizedTest(name = "{0} -> {1}")
+    @CsvSource({
+            "'/msg hello there',            msg",
+            "'msg hello there',             msg",
+            "'/MSG Hello',                  msg",
+            "'/essentials:msg hello',       msg",
+            "'/minecraft:tell someone hi',  tell",
+            "'/login hunter2',              login",
+            "'  /login   hunter2  ',        login",
+            "'/register pw pw',             register",
+            "'/gamemode creative',          gamemode",
+            "'/',                           ''",
+    })
+    void reducesACommandToItsIdentifyingWord(String raw, String expected) {
+        assertEquals(expected, Filters.normaliseCommand(raw));
+    }
+
+    @Test
+    @DisplayName("a plugin qualifier cannot be used to slip past the list")
+    void qualifiedFormsNormaliseIdentically() {
+        // The bypass this guards: an admin denies "msg", a player types
+        // "/essentials:msg" and the message is logged anyway.
+        for (String variant : List.of("/msg hi", "/essentials:msg hi", "/ESSENTIALS:MSG hi")) {
+            assertEquals("msg", Filters.normaliseCommand(variant), variant);
+        }
+        for (String variant : List.of("/login pw", "/authme:login pw", "/AuthMe:Login pw")) {
+            assertEquals("login", Filters.normaliseCommand(variant), variant);
+        }
+    }
+
+    @ParameterizedTest(name = "shipped default denies /{0}")
+    @ValueSource(strings = {"login", "register", "changepassword", "unregister",
+                            "msg", "tell", "whisper", "w", "r", "reply"})
+    @DisplayName("the shipped config denies the commands that leak")
+    void shippedDefaultsCoverLeakyCommands(String command) throws Exception {
+        assertTrue(shippedIgnoredCommands().contains(command),
+                "config.yml should deny /" + command + " by default — command logging posts "
+                        + "the full line, so this one would publish a password or a private message");
+    }
+
+    @Test
+    @DisplayName("the shipped deny-list is normalised already, so it matches what players type")
+    void shippedEntriesAreInMatchableForm() throws Exception {
+        for (String entry : shippedIgnoredCommands()) {
+            assertEquals(entry, Filters.normaliseCommand(entry),
+                    "'" + entry + "' in config.yml does not normalise to itself, so it would "
+                            + "never match anything a player types");
+        }
+    }
+
+    @Test
+    @DisplayName("the other filter lists ship empty, so nothing is silently hidden")
+    void nonCommandFiltersShipEmpty() throws Exception {
+        Map<?, ?> filters = shippedFilters();
+        assertEquals(List.of(), filters.get("ignored_players"));
+        assertEquals(List.of(), filters.get("ignored_worlds"));
+        assertEquals(List.of(), filters.get("ignored_chat_containing"));
+        assertEquals("", filters.get("exempt_permission"),
+                "an exempt permission that defaulted to something real would hide activity "
+                        + "on every server that happens to grant it");
+    }
+
+    @Test
+    @DisplayName("blank and malformed input never matches")
+    void handlesJunk() {
+        assertFalse(Filters.blocksCommand(null));
+        assertFalse(Filters.blocksCommand(""));
+        assertFalse(Filters.blocksCommand("   "));
+        assertFalse(Filters.blocksChat(null));
+        assertFalse(Filters.blocksChat(""));
+        assertFalse(Filters.blocksWorld(null));
+        assertFalse(Filters.blocksPlayer(null));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<?, ?> shippedFilters() throws Exception {
+        Map<String, Object> root = (Map<String, Object>) new Yaml()
+                .load(Files.readString(Path.of("src/main/resources/config.yml")));
+        return (Map<?, ?>) root.get("filters");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> shippedIgnoredCommands() throws Exception {
+        return (List<String>) shippedFilters().get("ignored_commands");
+    }
+}


### PR DESCRIPTION
Event toggles are all-or-nothing. `filters:` applies on top of them, so an enabled event can still be skipped.

```yaml
filters:
  ignored_commands: [login, register, changepassword, unregister, msg, tell, whisper, w, r, reply]
  ignored_players: []          # names or UUIDs, mixed freely
  exempt_permission: ""        # players holding this are never logged
  ignored_worlds: []
  ignored_chat_containing: []
```

## Why the command list ships non-empty

Command logging posts the line **exactly as typed**. On any server running AuthMe or similar, `/login <password>` and `/register <password>` were going to Discord in plain text, and `/msg` was publishing private messages. An empty default would have left that as-is for everyone who never thinks to look.

Matching strips the slash, the arguments **and any plugin qualifier** — `/msg`, `/MSG` and `/essentials:msg` all match `msg`. Without that last step the list is trivially bypassed, which for a filter whose job is keeping passwords out of a channel is the difference between working and appearing to work.

## Design notes

- **Filtering lives in the listener**, not `Log` — that's where the player, world and raw command still exist. By the time a message reaches `Log` it's rendered prose.
- **Moderation is deliberately not filtered by player.** `ignored_players` means "this account's own activity"; a ban is a record of *staff* action, and hiding it guts the audit trail.
- `Filters` reloads *before* `Log.init`, so a reload can't briefly log something the new config filters.

## A migration bug this exposed

`ConfigMigrator` replaced **scalars only** — every config value was a scalar until `filters:` arrived. A list took that path silently and wrote:

```
  ignored_commands:"[login, register, …]"
```

Invalid YAML, original items orphaned below. A user upgrading would have had their config broken and their deny-list lost — the one that stops `/login` reaching Discord.

Now it splices list blocks bottom-up (top-down invalidates later indices), and quotes an item only when YAML would otherwise resolve it to a boolean or number — so a plain `- login` isn't churned into `- "login"` on every upgrade. `ConfigMigratorListTest` pins all of it, verified by reverting the fix.

**138 tests.**
