### PR TITLE
docs: remove the completed lang.yml item from TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,6 @@ Got an idea that isn't here? Open a [feature request](https://github.com/GodTier
 ## Plugin
 
 - **Deeper logging modes** — option to relay the full server console rather than only the specific events currently supported.
-- **`lang.yml` with MiniMessage** — move every user-facing string into a language file so wording and formatting can be fully rewritten without touching code.
 
 ## Website & docs
 


### PR DESCRIPTION
Shipped in #142 — 30 chat keys, 33 death causes, 8 Discord templates, MiniMessage for in-game.

Console messages stay in English by design (a translated error is un-searchable); that's recorded in AGENTS.md rather than left as outstanding work.