### PR TITLE
fix(release): stamp lang.yml's trailer alongside config.yml

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -154,12 +154,15 @@ jobs:
           python3 - <<'PY'
           import os, re, datetime
 
-          path = "src/main/resources/config.yml"
+          # Every config file the plugin ships carries the same trailer, so every
+          # one has to be stamped. Missing lang.yml left it claiming the source
+          # version, with the release-please marker still in it, in a file users open.
+          paths = [
+              "src/main/resources/config.yml",
+              "src/main/resources/lang.yml",
+          ]
           new_tag = os.environ["NEW_TAG"]
           built = datetime.datetime.utcnow().strftime("%d-%m-%Y")
-
-          with open(path, "r", encoding="utf-8") as f:
-              text = f.read()
 
           # Consumes any existing BUILT/annotation suffix too, so this stays
           # idempotent if it's ever run more than once against the same checkout.
@@ -171,14 +174,18 @@ jobs:
           def repl(m):
               return f"CONFIG VERSION V{m.group(1)}, SHIPPED WITH {new_tag} BUILT {built}"
 
-          new_text, n = pattern.subn(repl, text, count=1)
-          if n == 0:
-              raise SystemExit("Could not find CONFIG VERSION trailer in " + path)
+          for path in paths:
+              with open(path, "r", encoding="utf-8") as f:
+                  text = f.read()
 
-          with open(path, "w", encoding="utf-8") as f:
-              f.write(new_text)
+              new_text, n = pattern.subn(repl, text, count=1)
+              if n == 0:
+                  raise SystemExit("Could not find CONFIG VERSION trailer in " + path)
 
-          print(f"Stamped {new_tag} BUILT {built} into {path}")
+              with open(path, "w", encoding="utf-8") as f:
+                  f.write(new_text)
+
+              print(f"Stamped {new_tag} BUILT {built} into {path}")
           PY
 
       - name: Build

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -71,17 +71,20 @@ jobs:
           java-version: ${{ steps.javaver.outputs.version }}
           cache: maven
 
-      - name: Stamp build date into config.yml trailer
+      - name: Stamp build date into the config trailers
         run: |
           set -euo pipefail
           python3 - <<'PY'
           import re, datetime
 
-          path = "src/main/resources/config.yml"
+          # Every config file the plugin ships carries the same trailer, so every
+          # one has to be stamped. Missing lang.yml left it claiming the source
+          # version, with the release-please marker still in it, in a file users open.
+          paths = [
+              "src/main/resources/config.yml",
+              "src/main/resources/lang.yml",
+          ]
           built = datetime.datetime.utcnow().strftime("%d-%m-%Y")
-
-          with open(path, "r", encoding="utf-8") as f:
-              text = f.read()
 
           # Trailer already contains the correct released version (release-please
           # rewrote it in the merged Release PR) -- we only append the build date.
@@ -95,14 +98,18 @@ jobs:
           def repl(m):
               return f"{m.group(1)} BUILT {built}"
 
-          new_text, n = pattern.subn(repl, text, count=1)
-          if n == 0:
-              raise SystemExit("Could not find CONFIG VERSION trailer in " + path)
+          for path in paths:
+              with open(path, "r", encoding="utf-8") as f:
+                  text = f.read()
 
-          with open(path, "w", encoding="utf-8") as f:
-              f.write(new_text)
+              new_text, n = pattern.subn(repl, text, count=1)
+              if n == 0:
+                  raise SystemExit("Could not find CONFIG VERSION trailer in " + path)
 
-          print(f"Stamped build date {built} into {path}")
+              with open(path, "w", encoding="utf-8") as f:
+                  f.write(new_text)
+
+              print(f"Stamped build date {built} into {path}")
           PY
 
       - name: Build (skip tests for speed)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,8 @@ Path-filtered (`dorny/paths-filter`): `build` runs on `src/**`/`pom.xml` changes
 
 ### `lang.yml`
 
+**Every config file must be stamped and bumped.** Three places know about the trailer, and all three take a list, not a single path: `release-please-config.json`'s `extra-files` (bumps `SHIPPED WITH` when a release is cut), `nightly.yml` (stamps the beta tag and build date), and `release-please.yml`'s `build-artifact` (appends the build date). Adding a config file and forgetting one leaves it claiming an old version with the `(x-release-please-version)` marker still in it — in a file users open. That happened to `lang.yml` and was caught only by inspecting a nightly artifact.
+
 **The config version is global.** `lang.yml` carries the same `config-version` and the same `CONFIG VERSION V<n>` trailer as `config.yml` — every config file this plugin ships moves as one, so there is never a combination of versions to reason about. `Lang.reload` runs it through `ConfigMigrator.migrateIfVersionChanged`, which is file-agnostic.
 
 That required un-hardcoding the rotation names: they were `config.new.yml` / `config.old.yml`, so a second migrated file would have overwritten the first one's backup. They are now derived from the file being migrated (`lang.yml` → `lang.old.yml`).

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,6 +23,10 @@
         {
           "type": "generic",
           "path": "src/main/resources/config.yml"
+        },
+        {
+          "type": "generic",
+          "path": "src/main/resources/lang.yml"
         }
       ]
     }


### PR DESCRIPTION
The nightly built fine but shipped this:

```
config.yml  # CONFIG VERSION V10, SHIPPED WITH v2.2.0-BETA.3 BUILT 02-08-2026   ✅
lang.yml    # CONFIG VERSION V10, SHIPPED WITH v2.1.6 (x-release-please-version) ❌
```

Three places know about the trailer and all three named `config.yml` alone: release-please's `extra-files`, `nightly.yml`'s stamping step, and the release build's date stamp.

So `lang.yml` would have gone out claiming 2.1.6, with a build-tool marker still in a file users open, and no way to tell which release it came from.

Each now takes a **list**, so adding a config file is one line rather than remembering three separate places. Simulated both stamping steps locally — both files come out with the same tag and date.

Found by inspecting the nightly artifact, not by any check, so AGENTS.md now records the requirement.