### PR TITLE
feat(filters): add nine more filters covering the noisiest events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,9 +63,11 @@ To add a new synced location: wrap the value in `<!-- dl:sync:KEY -->` markers (
 
 ## Build & test
 
-**There are no automated tests.** A JUnit suite covering `ConfigMigrator`, `SchemaDetector`, `Filters`, `Lang` and webhook redaction existed and was removed at the maintainer's request; it is recoverable from git history at `eeaf402`. The JUnit dependency and surefire plugin remain in `pom.xml`, so re-adding tests is a matter of dropping files into `src/test/java`.
+**Tests exist and gate CI** (JUnit 5 + surefire; `ci.yml` runs `mvn clean package` with tests on). `mvn test` runs them in ~10s.
 
-**What this means in practice:** changes to `ConfigMigrator` are the highest-risk edits in the repo and now have no automated guard. It runs exactly once on every existing install, and a mistake there destroys settings the user cannot get back. Verify migrations by hand against a customised config before shipping one.
+**Never assert the trailer's exact form.** `nightly.yml` and the release build both rewrite it before compiling — the `(x-release-please-version)` marker only exists in the source file. Two tests pinned that marker and made *every nightly fail for three days* while CI stayed green, because CI does not stamp. Assert `CONFIG VERSION V\d+` survives, not what follows it.
+
+`ConfigMigrator` is the highest-risk code in the repo — it runs exactly once on every existing install, and a mistake destroys settings the user cannot get back. That is what most of the suite covers.
 
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,10 @@ Death causes are keyed by the enum name lowercased with hyphens (`FIRE_TICK` →
 
 Applied in the **listener**, not in `Log` — that is where the player, world and raw command still exist; by the time a message reaches `Log` it is rendered prose. `Filters` holds an immutable snapshot swapped atomically on reload, and `applyRuntimeConfig` reloads it *before* `Log.init` so a reload cannot briefly log something the new config filters.
 
+**14 filters**, in three groups: *who* (`ignored_players`, `exempt_permission`), *where* (`ignored_worlds`), and *what* (commands, chat, advancements, teleports, deaths, explosions). Each listener checks the ones relevant to it — `Filters` holds no event knowledge, and no listener holds filter logic.
+
+`only_log_commands` is an allow-list that wins outright when set, with the deny-list applying inside it. `log_recipe_advancements` was a hardcoded skip in `PlayerAdvancement` and is now a setting, defaulting to the old behaviour.
+
 `filters.ignored_commands` **ships non-empty**, which is unusual for this project and deliberate: command logging posts the line as typed, so `/login` published passwords in plain text and `/msg` published private messages. Matching is on the command word after stripping the slash, arguments and any plugin qualifier — without that last step `/essentials:msg` would bypass an entry of `msg`, which would make a security-flavoured filter worthless.
 
 **Moderation events are deliberately not filtered by player.** `ignored_players` means "this account's own activity", not "everything mentioning this account"; a ban is a record of staff action and hiding it guts the audit trail.

--- a/docs/assets/configs/v10/config.template.yml
+++ b/docs/assets/configs/v10/config.template.yml
@@ -105,6 +105,11 @@ filters:
     - r
     - reply
 
+  # An ALLOW-list. When this has anything in it, ONLY these commands are logged and
+  # everything else is skipped -- useful if you only care about moderation commands.
+  # Leave empty to log everything except ignored_commands above.
+  only_log_commands: []
+
   # Never log anything from these players. Accepts names or UUIDs, mixed freely.
   ignored_players: []
 
@@ -117,6 +122,42 @@ filters:
 
   # Skip chat messages containing any of these (case-insensitive).
   ignored_chat_containing: []
+
+  # Skip chat shorter than this many characters. 0 disables it.
+  # Useful against "hi", "?", "." spam. Counts characters, not words.
+  minimum_chat_length: 0
+
+  # Advancements never logged. Matched on the full key, and a trailing * matches a
+  # whole tab -- "minecraft:husbandry/*" is every farming advancement.
+  ignored_advancements: []
+
+  # Recipe unlocks and tab roots fire constantly and mean nothing to a reader, so
+  # they are skipped. Set true only if you genuinely want them.
+  log_recipe_advancements: false
+
+  # Teleport causes never logged. Teleports are the noisiest event on most servers,
+  # and most of them are plugin warps rather than anything worth recording.
+  # Values: PLUGIN, COMMAND, ENDER_PEARL, CHORUS_FRUIT, NETHER_PORTAL, END_PORTAL,
+  #         END_GATEWAY, SPECTATE, DISMOUNT, EXIT_BED, CONSUMABLE_EFFECT, UNKNOWN
+  ignored_teleport_causes: []
+
+  # Skip teleports shorter than this many blocks. 0 disables it.
+  # Never applies across worlds -- a nether portal is not a short hop.
+  minimum_teleport_distance: 0
+
+  # Deaths with these causes are never logged. Same names as the death causes in
+  # lang.yml, upper case: VOID, FALL, LAVA, KILL, ENTITY_ATTACK, and so on.
+  # A void world or a parkour course can produce a lot of VOID and FALL deaths.
+  ignored_death_causes: []
+
+  # Explosions from these sources are never logged. Use the entity name for mob and
+  # TNT explosions (CREEPER, PRIMED_TNT, END_CRYSTAL, FIREBALL, WITHER_SKULL) or the
+  # block name for block ones (BED, RESPAWN_ANCHOR).
+  ignored_explosion_sources: []
+
+  # Skip explosions that destroyed fewer than this many blocks. 0 disables it.
+  # A creeper going off in the air breaks nothing and is rarely worth a message.
+  minimum_explosion_blocks: 0
 
 ####################################################################################
 #                                                                                  #

--- a/docs/assets/configs/v10/config.template.yml
+++ b/docs/assets/configs/v10/config.template.yml
@@ -135,11 +135,18 @@ filters:
   # they are skipped. Set true only if you genuinely want them.
   log_recipe_advancements: false
 
-  # Teleport causes never logged. Teleports are the noisiest event on most servers,
-  # and most of them are plugin warps rather than anything worth recording.
+  # Teleport causes never logged. Teleports are the noisiest event on most servers.
+  # The defaults are the ones that are not really teleports at all -- Minecraft moves
+  # the player a block or two and reports it as one. Nobody wants a Discord message
+  # because someone got out of bed.
   # Values: PLUGIN, COMMAND, ENDER_PEARL, CHORUS_FRUIT, NETHER_PORTAL, END_PORTAL,
   #         END_GATEWAY, SPECTATE, DISMOUNT, EXIT_BED, CONSUMABLE_EFFECT, UNKNOWN
-  ignored_teleport_causes: []
+  # Add PLUGIN if you use Essentials or similar -- /home, /warp and /spawn all
+  # arrive as PLUGIN and are usually the bulk of what is left.
+  ignored_teleport_causes:
+    - EXIT_BED      # standing up from a bed
+    - DISMOUNT      # getting off a horse, boat or minecart
+    - SPECTATE      # a spectator jumping to a player
 
   # Skip teleports shorter than this many blocks. 0 disables it.
   # Never applies across worlds -- a nether portal is not a short hop.

--- a/docs/assets/configs/v10/config.yml
+++ b/docs/assets/configs/v10/config.yml
@@ -131,11 +131,18 @@ filters:
   # they are skipped. Set true only if you genuinely want them.
   log_recipe_advancements: false
 
-  # Teleport causes never logged. Teleports are the noisiest event on most servers,
-  # and most of them are plugin warps rather than anything worth recording.
+  # Teleport causes never logged. Teleports are the noisiest event on most servers.
+  # The defaults are the ones that are not really teleports at all -- Minecraft moves
+  # the player a block or two and reports it as one. Nobody wants a Discord message
+  # because someone got out of bed.
   # Values: PLUGIN, COMMAND, ENDER_PEARL, CHORUS_FRUIT, NETHER_PORTAL, END_PORTAL,
   #         END_GATEWAY, SPECTATE, DISMOUNT, EXIT_BED, CONSUMABLE_EFFECT, UNKNOWN
-  ignored_teleport_causes: []
+  # Add PLUGIN if you use Essentials or similar -- /home, /warp and /spawn all
+  # arrive as PLUGIN and are usually the bulk of what is left.
+  ignored_teleport_causes:
+    - EXIT_BED      # standing up from a bed
+    - DISMOUNT      # getting off a horse, boat or minecart
+    - SPECTATE      # a spectator jumping to a player
 
   # Skip teleports shorter than this many blocks. 0 disables it.
   # Never applies across worlds -- a nether portal is not a short hop.

--- a/docs/assets/configs/v10/config.yml
+++ b/docs/assets/configs/v10/config.yml
@@ -101,6 +101,11 @@ filters:
     - r
     - reply
 
+  # An ALLOW-list. When this has anything in it, ONLY these commands are logged and
+  # everything else is skipped -- useful if you only care about moderation commands.
+  # Leave empty to log everything except ignored_commands above.
+  only_log_commands: []
+
   # Never log anything from these players. Accepts names or UUIDs, mixed freely.
   ignored_players: []
 
@@ -113,6 +118,42 @@ filters:
 
   # Skip chat messages containing any of these (case-insensitive).
   ignored_chat_containing: []
+
+  # Skip chat shorter than this many characters. 0 disables it.
+  # Useful against "hi", "?", "." spam. Counts characters, not words.
+  minimum_chat_length: 0
+
+  # Advancements never logged. Matched on the full key, and a trailing * matches a
+  # whole tab -- "minecraft:husbandry/*" is every farming advancement.
+  ignored_advancements: []
+
+  # Recipe unlocks and tab roots fire constantly and mean nothing to a reader, so
+  # they are skipped. Set true only if you genuinely want them.
+  log_recipe_advancements: false
+
+  # Teleport causes never logged. Teleports are the noisiest event on most servers,
+  # and most of them are plugin warps rather than anything worth recording.
+  # Values: PLUGIN, COMMAND, ENDER_PEARL, CHORUS_FRUIT, NETHER_PORTAL, END_PORTAL,
+  #         END_GATEWAY, SPECTATE, DISMOUNT, EXIT_BED, CONSUMABLE_EFFECT, UNKNOWN
+  ignored_teleport_causes: []
+
+  # Skip teleports shorter than this many blocks. 0 disables it.
+  # Never applies across worlds -- a nether portal is not a short hop.
+  minimum_teleport_distance: 0
+
+  # Deaths with these causes are never logged. Same names as the death causes in
+  # lang.yml, upper case: VOID, FALL, LAVA, KILL, ENTITY_ATTACK, and so on.
+  # A void world or a parkour course can produce a lot of VOID and FALL deaths.
+  ignored_death_causes: []
+
+  # Explosions from these sources are never logged. Use the entity name for mob and
+  # TNT explosions (CREEPER, PRIMED_TNT, END_CRYSTAL, FIREBALL, WITHER_SKULL) or the
+  # block name for block ones (BED, RESPAWN_ANCHOR).
+  ignored_explosion_sources: []
+
+  # Skip explosions that destroyed fewer than this many blocks. 0 disables it.
+  # A creeper going off in the air breaks nothing and is rarely worth a message.
+  minimum_explosion_blocks: 0
 
 ####################################################################################
 #                                                                                  #

--- a/docs/config/v10/index.md
+++ b/docs/config/v10/index.md
@@ -134,7 +134,9 @@ Applied on top of the event toggles: an event that is **enabled** can still be s
 if it matches a filter. This is how you exclude specific things without turning a whole
 category off.
 
-Each list is independent — use one and leave the rest empty if you like.
+There are 14 of them, each independent — use one and leave the rest empty if you like.
+They fall into three groups: **who** (players, permission), **where** (worlds), and
+**what** (commands, chat, advancements, teleports, deaths, explosions).
 
 #### `filters.ignored_commands`
 Commands that are never logged, whoever runs them.
@@ -259,6 +261,135 @@ filters:
 
 Because it matches inside words, keep entries distinctive: an entry of `ass` would also
 skip "password" and "grass".
+
+#### `filters.only_log_commands`
+An **allow-list**. When it has anything in it, only those commands are logged and
+everything else is skipped:
+
+```yaml
+filters:
+  only_log_commands:
+    - ban
+    - kick
+    - op
+    - deop
+```
+
+Useful when you want a moderation record rather than a log of everything typed —
+otherwise you would have to enumerate every command you *don't* want.
+
+Leave it empty to log everything except `ignored_commands`. When both are set, the
+allow-list decides first and the deny-list still applies inside it, so you can allow
+a set and then exclude one from it.
+
+#### `filters.minimum_chat_length`
+Skips chat shorter than this many characters. `0` disables it.
+
+```yaml
+filters:
+  minimum_chat_length: 3      # drops "hi", "?", "."
+```
+
+Counts characters, not words, and trims whitespace first.
+
+#### `filters.ignored_advancements`
+Advancements never logged. Matched on the full key, with a trailing `*` for a whole
+tab:
+
+```yaml
+filters:
+  ignored_advancements:
+    - "minecraft:husbandry/*"              # every farming advancement
+    - "minecraft:story/mine_stone"         # just this one
+```
+
+The wildcard matters because advancements are grouped by tab — `story/`, `husbandry/`,
+`adventure/`, `nether/`, `end/` — so excluding a category is one line rather than
+twenty.
+
+Vanilla has around 110 non-recipe advancements, and a new player works through dozens
+in their first session, so this is usually the difference between a usable channel and
+a flooded one.
+
+#### `filters.log_recipe_advancements`
+Recipe unlocks and tab roots fire constantly and mean nothing to a reader, so they are
+skipped. Set `true` only if you genuinely want them:
+
+```yaml
+filters:
+  log_recipe_advancements: false     # default
+```
+
+> This was hardcoded before v10 and is now a setting, so a server that wants recipe
+> unlocks can have them.
+
+#### `filters.ignored_teleport_causes`
+Teleports are the noisiest event on most servers, and most of them are plugin warps
+rather than anything worth recording.
+
+```yaml
+filters:
+  ignored_teleport_causes:
+    - PLUGIN          # /warp, /home, /spawn — anything a plugin moved
+    - COMMAND         # vanilla /tp
+    - ENDER_PEARL
+```
+
+Accepted values: `PLUGIN`, `COMMAND`, `ENDER_PEARL`, `CHORUS_FRUIT`, `NETHER_PORTAL`,
+`END_PORTAL`, `END_GATEWAY`, `SPECTATE`, `DISMOUNT`, `EXIT_BED`, `CONSUMABLE_EFFECT`,
+`UNKNOWN`. Case-insensitive.
+
+> `PLUGIN` is the one to reach for first. On a server with Essentials or similar, most
+> teleports are that.
+
+#### `filters.minimum_teleport_distance`
+Skips teleports shorter than this many blocks. `0` disables it.
+
+```yaml
+filters:
+  minimum_teleport_distance: 10
+```
+
+**Never applies across worlds** — a nether portal is not a short hop, so it is always
+logged regardless of this setting.
+
+#### `filters.ignored_death_causes`
+Deaths with these causes are never logged. Same names as the death causes in
+`lang.yml`, in upper case:
+
+```yaml
+filters:
+  ignored_death_causes:
+    - VOID       # a void world, or a parkour course
+    - FALL
+```
+
+A minigame arena or a void map can otherwise produce a constant stream of the same
+death.
+
+#### `filters.ignored_explosion_sources`
+Explosions from these sources are never logged. Use the **entity** name for mob and TNT
+explosions, or the **block** name for block ones:
+
+```yaml
+filters:
+  ignored_explosion_sources:
+    - CREEPER
+    - PRIMED_TNT
+    - BED                # exploding in the Nether
+    - RESPAWN_ANCHOR     # exploding in the Overworld
+```
+
+#### `filters.minimum_explosion_blocks`
+Skips explosions that destroyed fewer than this many blocks. `0` disables it.
+
+```yaml
+filters:
+  minimum_explosion_blocks: 5
+```
+
+A creeper going off in the air, or against bedrock, breaks nothing and is rarely worth
+a message. This keeps the ones that actually damaged a build.
 
 ---
 
@@ -712,6 +843,11 @@ filters:
     - r
     - reply
 
+  # An ALLOW-list. When this has anything in it, ONLY these commands are logged and
+  # everything else is skipped -- useful if you only care about moderation commands.
+  # Leave empty to log everything except ignored_commands above.
+  only_log_commands: []
+
   # Never log anything from these players. Accepts names or UUIDs, mixed freely.
   ignored_players: []
 
@@ -724,6 +860,42 @@ filters:
 
   # Skip chat messages containing any of these (case-insensitive).
   ignored_chat_containing: []
+
+  # Skip chat shorter than this many characters. 0 disables it.
+  # Useful against "hi", "?", "." spam. Counts characters, not words.
+  minimum_chat_length: 0
+
+  # Advancements never logged. Matched on the full key, and a trailing * matches a
+  # whole tab -- "minecraft:husbandry/*" is every farming advancement.
+  ignored_advancements: []
+
+  # Recipe unlocks and tab roots fire constantly and mean nothing to a reader, so
+  # they are skipped. Set true only if you genuinely want them.
+  log_recipe_advancements: false
+
+  # Teleport causes never logged. Teleports are the noisiest event on most servers,
+  # and most of them are plugin warps rather than anything worth recording.
+  # Values: PLUGIN, COMMAND, ENDER_PEARL, CHORUS_FRUIT, NETHER_PORTAL, END_PORTAL,
+  #         END_GATEWAY, SPECTATE, DISMOUNT, EXIT_BED, CONSUMABLE_EFFECT, UNKNOWN
+  ignored_teleport_causes: []
+
+  # Skip teleports shorter than this many blocks. 0 disables it.
+  # Never applies across worlds -- a nether portal is not a short hop.
+  minimum_teleport_distance: 0
+
+  # Deaths with these causes are never logged. Same names as the death causes in
+  # lang.yml, upper case: VOID, FALL, LAVA, KILL, ENTITY_ATTACK, and so on.
+  # A void world or a parkour course can produce a lot of VOID and FALL deaths.
+  ignored_death_causes: []
+
+  # Explosions from these sources are never logged. Use the entity name for mob and
+  # TNT explosions (CREEPER, PRIMED_TNT, END_CRYSTAL, FIREBALL, WITHER_SKULL) or the
+  # block name for block ones (BED, RESPAWN_ANCHOR).
+  ignored_explosion_sources: []
+
+  # Skip explosions that destroyed fewer than this many blocks. 0 disables it.
+  # A creeper going off in the air breaks nothing and is rarely worth a message.
+  minimum_explosion_blocks: 0
 
 ####################################################################################
 #                                                                                  #

--- a/docs/config/v10/index.md
+++ b/docs/config/v10/index.md
@@ -327,9 +327,25 @@ filters:
 Teleports are the noisiest event on most servers, and most of them are plugin warps
 rather than anything worth recording.
 
+**Three are excluded by default**, because Minecraft reports them as teleports when
+the player has moved a block or two:
+
 ```yaml
 filters:
   ignored_teleport_causes:
+    - EXIT_BED      # standing up from a bed
+    - DISMOUNT      # getting off a horse, boat or minecart
+    - SPECTATE      # a spectator jumping to a player
+```
+
+Add more as needed:
+
+```yaml
+filters:
+  ignored_teleport_causes:
+    - EXIT_BED
+    - DISMOUNT
+    - SPECTATE
     - PLUGIN          # /warp, /home, /spawn — anything a plugin moved
     - COMMAND         # vanilla /tp
     - ENDER_PEARL
@@ -873,11 +889,18 @@ filters:
   # they are skipped. Set true only if you genuinely want them.
   log_recipe_advancements: false
 
-  # Teleport causes never logged. Teleports are the noisiest event on most servers,
-  # and most of them are plugin warps rather than anything worth recording.
+  # Teleport causes never logged. Teleports are the noisiest event on most servers.
+  # The defaults are the ones that are not really teleports at all -- Minecraft moves
+  # the player a block or two and reports it as one. Nobody wants a Discord message
+  # because someone got out of bed.
   # Values: PLUGIN, COMMAND, ENDER_PEARL, CHORUS_FRUIT, NETHER_PORTAL, END_PORTAL,
   #         END_GATEWAY, SPECTATE, DISMOUNT, EXIT_BED, CONSUMABLE_EFFECT, UNKNOWN
-  ignored_teleport_causes: []
+  # Add PLUGIN if you use Essentials or similar -- /home, /warp and /spawn all
+  # arrive as PLUGIN and are usually the bulk of what is left.
+  ignored_teleport_causes:
+    - EXIT_BED      # standing up from a bed
+    - DISMOUNT      # getting off a horse, boat or minecart
+    - SPECTATE      # a spectator jumping to a player
 
   # Skip teleports shorter than this many blocks. 0 disables it.
   # Never applies across worlds -- a nether portal is not a short hop.

--- a/src/main/java/com/discordlogger/config/ConfigMigrator.java
+++ b/src/main/java/com/discordlogger/config/ConfigMigrator.java
@@ -95,7 +95,7 @@ public final class ConfigMigrator {
                 final int[] span = listSpanInDefault(defLines, target);
                 if (span != null) {
                     listEdits.add(new ListEdit(span[0], span[1],
-                            renderList(defLines.get(span[0]), userList)));
+                            renderList(defLines.subList(span[0], span[1]), userList)));
                 }
                 continue;
             }
@@ -144,9 +144,35 @@ public final class ConfigMigrator {
         return new int[]{pos.index(), end};
     }
 
-    /** The user's list, written under the default's own key line and indentation. */
-    private static List<String> renderList(String keyLine, List<?> values) {
+    /**
+     * The user's list, written under the default's own key line and indentation.
+     *
+     * <p>Inline comments on the default's items are carried over to any item with the
+     * same value. Without that, a shipped list like
+     * {@code - EXIT_BED   # standing up from a bed} loses its explanation the first
+     * time the file is migrated, and the config quietly becomes less readable on every
+     * upgrade even for someone who changed nothing.
+     */
+    private static List<String> renderList(List<String> defaultBlock, List<?> values) {
+        final String keyLine = defaultBlock.get(0);
         final int keyIndent = leadingSpaces(keyLine);
+
+        // value -> the comment that followed it in the shipped file
+        final Map<String, String> comments = new LinkedHashMap<>();
+        for (int i = 1; i < defaultBlock.size(); i++) {
+            final String line = defaultBlock.get(i);
+            final String trimmed = line.strip();
+            if (!trimmed.startsWith("-")) continue;
+            final String afterDash = trimmed.substring(1);
+            final int hash = findUnquotedHash(afterDash, 0);
+            if (hash < 0) continue;
+            final String value = afterDash.substring(0, hash).strip();
+            if (value.isEmpty()) continue;
+            // Keep the original spacing between the value and its comment, so an
+            // unchanged file round-trips byte for byte rather than being reindented.
+            final int valueEnd = afterDash.indexOf(value) + value.length();
+            comments.put(value, afterDash.substring(valueEnd));
+        }
         final int colon = keyLine.indexOf(':', keyIndent);
         final String comment = inlineCommentOf(keyLine.substring(colon + 1));
         final String key = keyLine.substring(0, colon + 1);
@@ -159,7 +185,9 @@ public final class ConfigMigrator {
         out.add(key + comment);
         final String indent = " ".repeat(keyIndent + 2);
         for (Object v : values) {
-            out.add(indent + "- " + renderListItem(v));
+            final String rendered = renderListItem(v);
+            final String itemComment = comments.get(rendered);
+            out.add(indent + "- " + rendered + (itemComment == null ? "" : itemComment));
         }
         return out;
     }

--- a/src/main/java/com/discordlogger/filter/Filters.java
+++ b/src/main/java/com/discordlogger/filter/Filters.java
@@ -43,13 +43,33 @@ public final class Filters {
             Set<String> ignoredNames,
             Set<UUID> ignoredUuids,
             Set<String> ignoredCommands,
+            Set<String> onlyCommands,
             Set<String> ignoredWorlds,
             List<String> chatPatterns,
+            int minChatLength,
+            List<String> ignoredAdvancements,
+            boolean logRecipeAdvancements,
+            Set<String> ignoredTeleportCauses,
+            double minTeleportDistance,
+            Set<String> ignoredDeathCauses,
+            Set<String> ignoredExplosionSources,
+            int minExplosionBlocks,
             String exemptPermission
     ) {
         static Snapshot empty() {
-            return new Snapshot(Set.of(), Set.of(), Set.of(), Set.of(), List.of(), "");
+            return new Snapshot(Set.of(), Set.of(), Set.of(), Set.of(), Set.of(), List.of(), 0,
+                    List.of(), false, Set.of(), 0d, Set.of(), Set.of(), 0, "");
         }
+    }
+
+    /** Reads a list of enum-ish names into a normalised set: upper case, underscores. */
+    private static Set<String> constantSet(JavaPlugin plugin, String path) {
+        final Set<String> out = new LinkedHashSet<>();
+        for (String entry : plugin.getConfig().getStringList(path)) {
+            if (entry == null || entry.isBlank()) continue;
+            out.add(entry.trim().toUpperCase(Locale.ROOT).replace('-', '_').replace(' ', '_'));
+        }
+        return out;
     }
 
     /** Re-read the filter config. Called from applyRuntimeConfig, so /reload picks it up. */
@@ -87,16 +107,42 @@ public final class Filters {
                 .map(s -> s.toLowerCase(Locale.ROOT))
                 .toList();
 
+        final Set<String> onlyCommands = new LinkedHashSet<>();
+        for (String entry : plugin.getConfig().getStringList("filters.only_log_commands")) {
+            if (entry == null || entry.isBlank()) continue;
+            onlyCommands.add(normaliseCommand(entry));
+        }
+
+        final List<String> advancements = plugin.getConfig()
+                .getStringList("filters.ignored_advancements").stream()
+                .filter(a -> a != null && !a.isBlank())
+                .map(a -> a.trim().toLowerCase(Locale.ROOT))
+                .toList();
+
         final String perm = plugin.getConfig().getString("filters.exempt_permission", "").trim();
 
-        current = new Snapshot(names, uuids, commands, worlds, patterns, perm);
+        current = new Snapshot(
+                names, uuids, commands, onlyCommands, worlds, patterns,
+                Math.max(0, plugin.getConfig().getInt("filters.minimum_chat_length", 0)),
+                advancements,
+                plugin.getConfig().getBoolean("filters.log_recipe_advancements", false),
+                constantSet(plugin, "filters.ignored_teleport_causes"),
+                Math.max(0d, plugin.getConfig().getDouble("filters.minimum_teleport_distance", 0d)),
+                constantSet(plugin, "filters.ignored_death_causes"),
+                constantSet(plugin, "filters.ignored_explosion_sources"),
+                Math.max(0, plugin.getConfig().getInt("filters.minimum_explosion_blocks", 0)),
+                perm);
 
-        final int total = names.size() + uuids.size() + commands.size()
-                + worlds.size() + patterns.size();
-        if (total > 0 || !perm.isEmpty()) {
-            plugin.getLogger().info("Log filters active: " + commands.size() + " command(s), "
-                    + (names.size() + uuids.size()) + " player(s), " + worlds.size() + " world(s), "
-                    + patterns.size() + " chat pattern(s)"
+        final Snapshot snap = current;
+        final int rules = snap.ignoredNames().size() + snap.ignoredUuids().size()
+                + snap.ignoredCommands().size() + snap.onlyCommands().size()
+                + snap.ignoredWorlds().size() + snap.chatPatterns().size()
+                + snap.ignoredAdvancements().size() + snap.ignoredTeleportCauses().size()
+                + snap.ignoredDeathCauses().size() + snap.ignoredExplosionSources().size();
+        if (rules > 0 || !perm.isEmpty()) {
+            plugin.getLogger().info("Log filters active: " + rules + " rule(s)"
+                    + (snap.onlyCommands().isEmpty() ? ""
+                       : ", command allow-list of " + snap.onlyCommands().size())
                     + (perm.isEmpty() ? "" : ", exempt permission '" + perm + "'") + ".");
         }
     }
@@ -128,18 +174,97 @@ public final class Filters {
     /**
      * True when this command should never be logged.
      *
+     * <p>{@code only_log_commands} is an allow-list and wins outright when set: a
+     * server that wants nothing but moderation commands should not also have to
+     * enumerate every command it does not want. The deny-list still applies inside
+     * it, so a command can be allow-listed by prefix and then excluded.
+     *
      * @param raw the command as typed, with or without a leading slash and arguments
      */
     public static boolean blocksCommand(String raw) {
         if (raw == null || raw.isBlank()) return false;
-        return current.ignoredCommands().contains(normaliseCommand(raw));
+        final Snapshot snap = current;
+        final String word = normaliseCommand(raw);
+
+        if (!snap.onlyCommands().isEmpty() && !snap.onlyCommands().contains(word)) return true;
+        return snap.ignoredCommands().contains(word);
     }
 
-    /** True when a chat line contains any configured pattern. */
+    /**
+     * True when this advancement should not be logged.
+     *
+     * <p>Entries match the full key ({@code minecraft:husbandry/plant_seed}) and
+     * support a trailing {@code *}. The wildcard matters because advancements are
+     * grouped by tab, so "stop logging the farming ones" should be one line rather
+     * than twenty.
+     *
+     * @param key       the full namespaced key
+     * @param path      the key's path, e.g. {@code husbandry/plant_seed}
+     */
+    public static boolean blocksAdvancement(String key, String path) {
+        final Snapshot snap = current;
+
+        // Recipe unlocks and tab roots fire constantly and mean nothing to a reader.
+        // Kept as a filter rather than hardcoded so a server that genuinely wants
+        // them can have them, but off by default because almost nobody does.
+        if (!snap.logRecipeAdvancements() && path != null
+                && (path.startsWith("recipes/") || path.startsWith("recipe/")
+                    || path.endsWith("/root") || path.equals("story/root"))) {
+            return true;
+        }
+
+        if (key == null || snap.ignoredAdvancements().isEmpty()) return false;
+        final String lower = key.toLowerCase(Locale.ROOT);
+        for (String entry : snap.ignoredAdvancements()) {
+            if (entry.endsWith("*")) {
+                if (lower.startsWith(entry.substring(0, entry.length() - 1))) return true;
+            } else if (lower.equals(entry)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** True when a teleport should not be logged, by its cause or how short it was. */
+    public static boolean blocksTeleport(String cause, Double distance) {
+        final Snapshot snap = current;
+        if (cause != null && snap.ignoredTeleportCauses()
+                .contains(cause.toUpperCase(Locale.ROOT))) return true;
+
+        // A distance of null means the two points are in different worlds, which is
+        // never "a short hop" and so is never filtered by distance.
+        return distance != null && snap.minTeleportDistance() > 0d
+                && distance < snap.minTeleportDistance();
+    }
+
+    /** True when a death with this damage cause should not be logged. */
+    public static boolean blocksDeath(String damageCause) {
+        return damageCause != null
+                && current.ignoredDeathCauses().contains(damageCause.toUpperCase(Locale.ROOT));
+    }
+
+    /**
+     * True when an explosion should not be logged.
+     *
+     * @param source        the entity type that exploded, or null for a block
+     * @param affectedBlocks how many blocks it destroyed
+     */
+    public static boolean blocksExplosion(String source, int affectedBlocks) {
+        final Snapshot snap = current;
+        if (source != null && snap.ignoredExplosionSources()
+                .contains(source.toUpperCase(Locale.ROOT))) return true;
+        return snap.minExplosionBlocks() > 0 && affectedBlocks < snap.minExplosionBlocks();
+    }
+
+    /** True when a chat line contains any configured pattern, or is too short to be worth logging. */
     public static boolean blocksChat(String message) {
         if (message == null || message.isEmpty()) return false;
+        final Snapshot snap = current;
+
+        if (snap.minChatLength() > 0 && message.strip().length() < snap.minChatLength()) return true;
+
         final String haystack = message.toLowerCase(Locale.ROOT);
-        for (String needle : current.chatPatterns()) {
+        for (String needle : snap.chatPatterns()) {
             if (haystack.contains(needle)) return true;
         }
         return false;

--- a/src/main/java/com/discordlogger/listener/player/PlayerAdvancement.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerAdvancement.java
@@ -28,9 +28,9 @@ public final class PlayerAdvancement implements Listener {
         final String ns = key.getNamespace();   // usually "minecraft"
         final String path = key.getKey();       // e.g., "adventure/sleep_in_bed"
 
-        // Always ignore recipe/root advancements to avoid spam
-        if (path.startsWith("recipes/") || path.startsWith("recipe/")) return;
-        if (path.endsWith("/root") || path.equals("story/root")) return;
+        // Recipe/root suppression lives in Filters now, so a server can opt back in,
+        // and specific advancements or whole tabs can be excluded by key.
+        if (Filters.blocksAdvancement(ns + ":" + path, path)) return;
 
         final String playerName = Names.display(e.getPlayer(), plugin);
         final String pretty = prettyTitle(path);

--- a/src/main/java/com/discordlogger/listener/player/PlayerDeath.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerDeath.java
@@ -33,6 +33,10 @@ public final class PlayerDeath implements Listener {
         if (Filters.blocksPlayer(e.getEntity()) || Filters.blocksWorld(e.getEntity().getWorld().getName())) return;
 
         final Player victim = e.getEntity();
+
+        final EntityDamageEvent lastDamage = victim.getLastDamageCause();
+        if (Filters.blocksDeath(lastDamage == null ? null : lastDamage.getCause().name())) return;
+
         final String vName = Names.display(victim, (JavaPlugin) plugin);
 
         final List<Log.Field> fields = new ArrayList<>();

--- a/src/main/java/com/discordlogger/listener/player/PlayerTeleport.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerTeleport.java
@@ -37,6 +37,17 @@ public final class PlayerTeleport implements Listener {
         final Location to = e.getTo();
 
         final boolean worldChange = worldsDifferent(from, to);
+
+        // Distance is null across a world change, which is never a "short hop".
+        Double travelled = null;
+        if (!worldChange && from != null && to != null && from.getWorld() != null) {
+            try {
+                travelled = from.distance(to);
+            } catch (IllegalArgumentException ignored) {
+                travelled = null;
+            }
+        }
+        if (Filters.blocksTeleport(e.getCause() == null ? null : e.getCause().name(), travelled)) return;
         final String fromStr = fmtLoc(from);
         final String toStr = fmtLoc(to);
 

--- a/src/main/java/com/discordlogger/listener/server/Explosion.java
+++ b/src/main/java/com/discordlogger/listener/server/Explosion.java
@@ -72,6 +72,9 @@ public final class Explosion implements Listener {
         final String world = (w == null) ? "unknown" : w.getName();
 
         final int affected = (e.blockList() == null) ? 0 : e.blockList().size();
+        // Filter on the entity that exploded: CREEPER, PRIMED_TNT, END_CRYSTAL…
+        if (Filters.blocksExplosion(type == null ? null : type.name(), affected)) return;
+
         final String yield  = fmtYield(e.getYield());
 
         List<Log.Field> fields = new ArrayList<>();
@@ -107,6 +110,10 @@ public final class Explosion implements Listener {
         final String world = (w == null) ? "unknown" : w.getName();
 
         final int affected = (e.blockList() == null) ? 0 : e.blockList().size();
+        // A block explosion has a Material rather than an EntityType, so "BED"
+        // and "RESPAWN_ANCHOR" filter the same way "CREEPER" does.
+        if (Filters.blocksExplosion(mat == null ? null : mat.name(), affected)) return;
+
         final String yield  = fmtYield(e.getYield());
 
         List<Log.Field> fields = new ArrayList<>();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -131,11 +131,18 @@ filters:
   # they are skipped. Set true only if you genuinely want them.
   log_recipe_advancements: false
 
-  # Teleport causes never logged. Teleports are the noisiest event on most servers,
-  # and most of them are plugin warps rather than anything worth recording.
+  # Teleport causes never logged. Teleports are the noisiest event on most servers.
+  # The defaults are the ones that are not really teleports at all -- Minecraft moves
+  # the player a block or two and reports it as one. Nobody wants a Discord message
+  # because someone got out of bed.
   # Values: PLUGIN, COMMAND, ENDER_PEARL, CHORUS_FRUIT, NETHER_PORTAL, END_PORTAL,
   #         END_GATEWAY, SPECTATE, DISMOUNT, EXIT_BED, CONSUMABLE_EFFECT, UNKNOWN
-  ignored_teleport_causes: []
+  # Add PLUGIN if you use Essentials or similar -- /home, /warp and /spawn all
+  # arrive as PLUGIN and are usually the bulk of what is left.
+  ignored_teleport_causes:
+    - EXIT_BED      # standing up from a bed
+    - DISMOUNT      # getting off a horse, boat or minecart
+    - SPECTATE      # a spectator jumping to a player
 
   # Skip teleports shorter than this many blocks. 0 disables it.
   # Never applies across worlds -- a nether portal is not a short hop.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -101,6 +101,11 @@ filters:
     - r
     - reply
 
+  # An ALLOW-list. When this has anything in it, ONLY these commands are logged and
+  # everything else is skipped -- useful if you only care about moderation commands.
+  # Leave empty to log everything except ignored_commands above.
+  only_log_commands: []
+
   # Never log anything from these players. Accepts names or UUIDs, mixed freely.
   ignored_players: []
 
@@ -113,6 +118,42 @@ filters:
 
   # Skip chat messages containing any of these (case-insensitive).
   ignored_chat_containing: []
+
+  # Skip chat shorter than this many characters. 0 disables it.
+  # Useful against "hi", "?", "." spam. Counts characters, not words.
+  minimum_chat_length: 0
+
+  # Advancements never logged. Matched on the full key, and a trailing * matches a
+  # whole tab -- "minecraft:husbandry/*" is every farming advancement.
+  ignored_advancements: []
+
+  # Recipe unlocks and tab roots fire constantly and mean nothing to a reader, so
+  # they are skipped. Set true only if you genuinely want them.
+  log_recipe_advancements: false
+
+  # Teleport causes never logged. Teleports are the noisiest event on most servers,
+  # and most of them are plugin warps rather than anything worth recording.
+  # Values: PLUGIN, COMMAND, ENDER_PEARL, CHORUS_FRUIT, NETHER_PORTAL, END_PORTAL,
+  #         END_GATEWAY, SPECTATE, DISMOUNT, EXIT_BED, CONSUMABLE_EFFECT, UNKNOWN
+  ignored_teleport_causes: []
+
+  # Skip teleports shorter than this many blocks. 0 disables it.
+  # Never applies across worlds -- a nether portal is not a short hop.
+  minimum_teleport_distance: 0
+
+  # Deaths with these causes are never logged. Same names as the death causes in
+  # lang.yml, upper case: VOID, FALL, LAVA, KILL, ENTITY_ATTACK, and so on.
+  # A void world or a parkour course can produce a lot of VOID and FALL deaths.
+  ignored_death_causes: []
+
+  # Explosions from these sources are never logged. Use the entity name for mob and
+  # TNT explosions (CREEPER, PRIMED_TNT, END_CRYSTAL, FIREBALL, WITHER_SKULL) or the
+  # block name for block ones (BED, RESPAWN_ANCHOR).
+  ignored_explosion_sources: []
+
+  # Skip explosions that destroyed fewer than this many blocks. 0 disables it.
+  # A creeper going off in the air breaks nothing and is rarely worth a message.
+  minimum_explosion_blocks: 0
 
 ####################################################################################
 #                                                                                  #

--- a/src/test/java/com/discordlogger/config/ConfigMigratorDecisionTest.java
+++ b/src/test/java/com/discordlogger/config/ConfigMigratorDecisionTest.java
@@ -1,0 +1,78 @@
+package com.discordlogger.config;
+
+import com.discordlogger.config.ConfigMigrator.Status;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Which way a migration runs, and whether it runs at all.
+ *
+ * <p>The case that matters is AHEAD: before this logic existed, migration fired
+ * whenever the two schema numbers merely differed, so a config from a newer
+ * install — a rolled-back server, or a file copied between servers — was
+ * rewritten against the older shipped default and every key the newer schema
+ * had added was silently deleted.
+ */
+class ConfigMigratorDecisionTest {
+
+    @ParameterizedTest(name = "config v{0} on a v{1} build -> {2}")
+    @CsvSource({
+            "9,  9,  UP_TO_DATE",
+            "9,  10, UPGRADED",
+            "1,  10, UPGRADED",
+            "2,  10, UPGRADED",
+            "10, 9,  AHEAD",
+            "11, 10, AHEAD",
+    })
+    void decidesFromTheTwoSchemaNumbers(int installed, int shipped, Status expected) {
+        assertEquals(expected, ConfigMigrator.decide(installed, shipped));
+    }
+
+    @Test
+    @DisplayName("an unreadable trailer on either side is never treated as a migration")
+    void unknownWhenEitherVersionIsMissing() {
+        assertEquals(Status.UNKNOWN, ConfigMigrator.decide(null, 10));
+        assertEquals(Status.UNKNOWN, ConfigMigrator.decide(9, null));
+        assertEquals(Status.UNKNOWN, ConfigMigrator.decide(null, null));
+    }
+
+    @Test
+    @DisplayName("versions compare numerically, not as text")
+    void comparesNumericallyNotLexicographically() {
+        // As strings "9" > "10", which would invert the decision and downgrade
+        // every v9 config the moment a two-digit schema shipped.
+        assertEquals(Status.UPGRADED, ConfigMigrator.decide(9, 10));
+        assertEquals(Status.AHEAD, ConfigMigrator.decide(10, 9));
+    }
+
+    @Test
+    @DisplayName("the shipped config's trailer parses")
+    void shippedTrailerIsReadable() throws Exception {
+        String shipped = Files.readString(Path.of("src/main/resources/config.yml"));
+        Integer version = ConfigMigrator.extractVersion(shipped);
+        assertEquals(currentSchema(), version,
+                "the shipped config.yml trailer must match the schema this build claims");
+    }
+
+    @Test
+    @DisplayName("a config with no trailer at all yields no version")
+    void missingTrailerYieldsNull() {
+        assertNull(ConfigMigrator.extractVersion("log:\n  player:\n    join:\n      enabled: true\n"));
+        assertNull(ConfigMigrator.extractVersion(""));
+        assertNull(ConfigMigrator.extractVersion(null));
+    }
+
+    /** Read from the shipped file so this test never needs editing on a schema bump. */
+    private static int currentSchema() throws Exception {
+        String shipped = Files.readString(Path.of("src/main/resources/config.yml"));
+        return ConfigMigrator.extractVersion(shipped);
+    }
+}

--- a/src/test/java/com/discordlogger/config/ConfigMigratorListTest.java
+++ b/src/test/java/com/discordlogger/config/ConfigMigratorListTest.java
@@ -1,0 +1,112 @@
+package com.discordlogger.config;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Migrating list values.
+ *
+ * <p>The migrator replaced scalars only. Every value in the config happened to be a
+ * scalar until {@code filters:} arrived, and a list hitting the scalar path did not
+ * fail loudly — it wrote {@code ignored_commands:"[login, register, …]"}, which is
+ * not valid YAML and left the original items orphaned below it. A user upgrading
+ * would have had their config broken and their deny-list lost.
+ *
+ * <p>That matters more than most config keys: the deny-list is what stops
+ * {@code /login} posting a password to Discord.
+ */
+class ConfigMigratorListTest {
+
+    private static String shipped;
+    private static int current;
+
+    @BeforeAll
+    static void load() throws Exception {
+        shipped = Files.readString(Path.of("src/main/resources/config.yml"));
+        current = ConfigMigrator.extractVersion(shipped);
+    }
+
+    private static Map<?, ?> filtersOf(String yaml) {
+        return (Map<?, ?>) ((Map<?, ?>) new Yaml().load(yaml)).get("filters");
+    }
+
+    @Test
+    @DisplayName("a customised deny-list survives migration")
+    void customEntriesArePreserved() {
+        String user = shipped.replace("    - login\n", "    - login\n    - mypluginsecret\n");
+        String out = ConfigMigrator.migrateText(shipped, user, current, current);
+
+        @SuppressWarnings("unchecked")
+        List<String> commands = (List<String>) filtersOf(out).get("ignored_commands");
+        assertTrue(commands.contains("mypluginsecret"),
+                "an entry the admin added must not be reverted to the shipped defaults");
+        assertTrue(commands.contains("login"), "the shipped entries must still be there too");
+    }
+
+    @Test
+    @DisplayName("a list the user filled from empty is carried over")
+    void filledFromEmpty() {
+        String user = shipped.replace("  ignored_players: []",
+                "  ignored_players:\n    - Notch\n    - 00000000-0000-0000-0009-01f2a3b4c5d6");
+        String out = ConfigMigrator.migrateText(shipped, user, current, current);
+
+        @SuppressWarnings("unchecked")
+        List<String> players = (List<String>) filtersOf(out).get("ignored_players");
+        assertEquals(List.of("Notch", "00000000-0000-0000-0009-01f2a3b4c5d6"), players);
+    }
+
+    @Test
+    @DisplayName("an empty list stays inline rather than becoming a quoted string")
+    void emptyListsStayEmpty() {
+        String out = ConfigMigrator.migrateText(shipped, shipped, current, current);
+        assertEquals(List.of(), filtersOf(out).get("ignored_worlds"));
+        assertTrue(out.contains("ignored_worlds: []"),
+                "an empty list should read as [] the way it was written");
+    }
+
+    @Test
+    @DisplayName("migrating an unchanged config is byte-identical")
+    void identityMigrationIsStable() {
+        // The regression that caught the quoting bug: rendering every item as a
+        // quoted string rewrote a plain "- login" into a quoted one on every upgrade, churning
+        // a file nobody had edited.
+        String out = ConfigMigrator.migrateText(shipped, shipped, current, current);
+        assertEquals(shipped.stripTrailing(), out.stripTrailing());
+    }
+
+    @Test
+    @DisplayName("the result is still valid YAML with comments intact")
+    void outputRemainsValid() {
+        String user = shipped.replace("    - login\n", "    - login\n    - custom\n");
+        String out = ConfigMigrator.migrateText(shipped, user, current, current);
+
+        new Yaml().load(out);   // throws if the list splice produced invalid YAML
+        assertEquals(shipped.lines().filter(l -> l.strip().startsWith("#")).count(),
+                out.lines().filter(l -> l.strip().startsWith("#")).count(),
+                "splicing a list must not disturb the surrounding comments");
+    }
+
+    @Test
+    @DisplayName("entries YAML would read as booleans or numbers stay strings")
+    void reservedWordsAreQuoted() {
+        // A command called "no" or "on" is unlikely but legal, and unquoted it would
+        // come back as a boolean — silently no longer matching anything.
+        String user = shipped.replace("    - login\n", "    - login\n    - \"no\"\n    - \"3\"\n");
+        String out = ConfigMigrator.migrateText(shipped, user, current, current);
+
+        @SuppressWarnings("unchecked")
+        List<Object> commands = (List<Object>) filtersOf(out).get("ignored_commands");
+        assertTrue(commands.contains("no"), "should still be the string no, not the boolean false");
+        assertTrue(commands.contains("3"), "should still be the string 3, not the number 3");
+    }
+}

--- a/src/test/java/com/discordlogger/config/ConfigMigratorPathTest.java
+++ b/src/test/java/com/discordlogger/config/ConfigMigratorPathTest.java
@@ -1,0 +1,123 @@
+package com.discordlogger.config;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.yaml.snakeyaml.Yaml;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Where an old key lands in the current schema.
+ *
+ * <p>Migration steps one schema at a time because renames compose. Colours were
+ * flat ({@code embeds.colors.player_join}) until v7 nested them, then moved beside
+ * their toggle in v10. Resolving v6 straight to v10 would apply only the last
+ * step's renames, so a v6 user's colours would match nothing and be replaced by
+ * defaults — the exact loss the schema trailer exists to prevent.
+ */
+class ConfigMigratorPathTest {
+
+    /** The live schema's flattened defaults — every resolved path must exist in here. */
+    private static Map<String, Object> defaults;
+    private static int current;
+
+    @BeforeAll
+    static void loadShippedConfig() throws Exception {
+        String shipped = Files.readString(Path.of("src/main/resources/config.yml"));
+        defaults = ConfigMigrator.flattenYaml(new Yaml().load(shipped));
+        current = ConfigMigrator.extractVersion(shipped);
+    }
+
+    @ParameterizedTest(name = "v{1}: {0} -> {2}")
+    @CsvSource({
+            // v6 wrote colours flat; v7 nested them; v10 moved them beside the toggle.
+            "embeds.colors.player_join,          6, log.player.join.color",
+            "embeds.colors.server_command,       6, log.server.command.color",
+            "embeds.colors.player_death,         6, log.player.death.color",
+            // v6 moderation colours had no group at all.
+            "embeds.colors.ban,                  6, log.moderation.ban.color",
+            "embeds.colors.unban,                6, log.moderation.unban.color",
+            "embeds.colors.kick,                 6, log.moderation.kick.color",
+            // v7 and v8 already nested, so only the v10 move applies.
+            "embeds.colors.player.teleport,      7, log.player.teleport.color",
+            "embeds.colors.moderation.deop,      8, log.moderation.deop.color",
+            "embeds.colors.player.gamemode,      8, log.player.gamemode.color",
+            // v9 is the single-step case.
+            "embeds.colors.player.join,          9, log.player.join.color",
+            "log.player.join,                    9, log.player.join.enabled",
+            "log.server.explosion,               9, log.server.explosion.enabled",
+    })
+    void renamesCompose(String oldPath, int from, String expected) {
+        assertEquals(expected, ConfigMigrator.resolvePath(oldPath, defaults, from, current));
+    }
+
+    @Test
+    @DisplayName("v9's 'whitelist' colour belongs to the whitelist_edit toggle")
+    void whitelistColourFindsItsRenamedToggle() {
+        // The colour key and the toggle key never matched: v9 had a colour called
+        // "whitelist" but a toggle called "whitelist_edit". v10 merged them.
+        assertEquals("log.moderation.whitelist_edit.color",
+                ConfigMigrator.resolvePath("embeds.colors.moderation.whitelist", defaults, 9, current));
+    }
+
+    @Test
+    @DisplayName("every v9 event toggle survives the upgrade")
+    void allV9TogglesResolve() {
+        String[][] groups = {
+                {"player", "join", "quit", "chat", "command", "death", "advancement", "teleport", "gamemode"},
+                {"server", "command", "start", "stop", "explosion"},
+                {"moderation", "ban", "unban", "kick", "op", "deop", "whitelist_toggle", "whitelist_edit"},
+        };
+        for (String[] group : groups) {
+            for (int i = 1; i < group.length; i++) {
+                String path = "log." + group[0] + "." + group[i];
+                assertEquals(path + ".enabled",
+                        ConfigMigrator.resolvePath(path, defaults, 9, current),
+                        path + " must carry over; if it does not, that user's setting is lost");
+            }
+        }
+    }
+
+    @ParameterizedTest(name = "{0} is untouched by any step")
+    @ValueSource(strings = {"webhook.url", "format.time", "format.name", "format.nicknames",
+            "embeds.enabled", "embeds.author"})
+    void keysThatNeverMovedPassStraightThrough(String path) {
+        // From the oldest schema on record, so every intermediate step is exercised.
+        assertEquals(path, ConfigMigrator.resolvePath(path, defaults, 2, current));
+    }
+
+    @Test
+    @DisplayName("a key that genuinely no longer exists resolves to nothing")
+    void removedKeysAreNotForcedSomewhere() {
+        // v6's embeds.colors.server was a single fallback colour; v7 turned that
+        // same name into a section, so the scalar has no successor. Inventing a
+        // destination would be worse than dropping it.
+        assertNull(ConfigMigrator.resolvePath("embeds.colors.server", defaults, 6, current));
+        assertNull(ConfigMigrator.resolvePath("log.player.nonsense", defaults, 9, current));
+        assertNull(ConfigMigrator.resolvePath("embeds.colors.nope.nope", defaults, 9, current));
+    }
+
+    @Test
+    @DisplayName("every resolved path actually exists in the shipped defaults")
+    void resolvedPathsAreReal() {
+        for (String flat : new String[]{"player_join", "player_quit", "player_chat",
+                "player_command", "player_death", "server_command", "ban", "unban", "kick"}) {
+            String resolved = ConfigMigrator.resolvePath("embeds.colors." + flat, defaults, 6, current);
+            assertNotNull(resolved, flat + " (a v6 colour) must land somewhere");
+            // resolvePath only returns paths present in defMap, so this is belt and
+            // braces against a future change loosening that.
+            org.junit.jupiter.api.Assertions.assertTrue(defaults.containsKey(resolved),
+                    resolved + " is not a real key in the shipped config");
+        }
+    }
+}

--- a/src/test/java/com/discordlogger/config/ConfigMigratorSetScalarTest.java
+++ b/src/test/java/com/discordlogger/config/ConfigMigratorSetScalarTest.java
@@ -1,0 +1,109 @@
+package com.discordlogger.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Writing a single value back into config.yml without wrecking the file.
+ *
+ * <p>{@code /discordlogger webhook} needs this. The obvious implementation —
+ * {@code getConfig().set()} then {@code saveConfig()} — re-serialises the whole
+ * file through Bukkit's YAML writer and drops every comment, including the
+ * {@code CONFIG VERSION V<n>} trailer. A config saved that way looks like it has
+ * no schema at all, which breaks migration for that user permanently.
+ */
+class ConfigMigratorSetScalarTest {
+
+    @TempDir
+    Path dir;
+
+    private Path config;
+    private String before;
+
+    @BeforeEach
+    void copyShippedConfig() throws Exception {
+        before = Files.readString(Path.of("src/main/resources/config.yml"));
+        config = dir.resolve("config.yml");
+        Files.writeString(config, before);
+    }
+
+    @Test
+    @DisplayName("the value is written and the file still parses")
+    void writesTheValue() throws Exception {
+        String url = "https://discord.com/api/webhooks/123456789/TOKEN";
+        assertTrue(ConfigMigrator.setScalar(config.toFile(), "webhook.url", url));
+
+        Map<?, ?> parsed = (Map<?, ?>) new Yaml().load(Files.readString(config));
+        assertEquals(url, ((Map<?, ?>) parsed.get("webhook")).get("url"));
+    }
+
+    @Test
+    @DisplayName("exactly one line changes — nothing else in the file is touched")
+    void changesOnlyTheTargetLine() throws Exception {
+        ConfigMigrator.setScalar(config.toFile(), "webhook.url", "https://discord.com/api/webhooks/1/T");
+
+        List<String> was = List.of(before.split("\n", -1));
+        List<String> now = List.of(Files.readString(config).split("\n", -1));
+
+        assertEquals(was.size(), now.size(), "line count must not change");
+        long differing = java.util.stream.IntStream.range(0, was.size())
+                .filter(i -> !was.get(i).equals(now.get(i)))
+                .count();
+        assertEquals(1, differing, "only webhook.url's line should differ");
+    }
+
+    @Test
+    @DisplayName("comments, banners and the schema trailer all survive")
+    void preservesEverythingElse() throws Exception {
+        ConfigMigrator.setScalar(config.toFile(), "webhook.url", "https://discord.com/api/webhooks/1/T");
+        String after = Files.readString(config);
+
+        assertEquals(before.lines().filter(l -> l.strip().startsWith("#")).count(),
+                after.lines().filter(l -> l.strip().startsWith("#")).count(),
+                "comments are the documentation; losing them makes the file unusable by hand");
+        // The form of the trailer varies by build -- the source carries the
+        // release-please marker, a nightly carries its beta tag and build date -- so
+        // this asserts only that it is still there and still parseable.
+        assertTrue(after.strip().matches("(?s).*CONFIG VERSION V\\d+.*"),
+                "the trailer must survive or ConfigMigrator can no longer detect the schema");
+        assertEquals(ConfigMigrator.extractVersion(before), ConfigMigrator.extractVersion(after));
+    }
+
+    @Test
+    @DisplayName("an unknown key reports failure instead of corrupting the file")
+    void unknownKeyIsRejected() throws Exception {
+        assertFalse(ConfigMigrator.setScalar(config.toFile(), "webhook.does_not_exist", "x"));
+        assertEquals(before, Files.readString(config), "a failed write must leave the file alone");
+    }
+
+    @Test
+    @DisplayName("a missing file fails rather than throwing")
+    void missingFileIsHandled() {
+        assertFalse(ConfigMigrator.setScalar(new File(dir.toFile(), "nope.yml"), "webhook.url", "x"));
+    }
+
+    @Test
+    @DisplayName("a nested key deeper than the old schema's maximum still resolves")
+    void writesDeeplyNestedKeys() throws Exception {
+        // v10 toggles sit four levels down; the line finder predates that depth.
+        assertTrue(ConfigMigrator.setScalar(config.toFile(), "log.player.join.enabled", false));
+
+        Map<?, ?> parsed = (Map<?, ?>) new Yaml().load(Files.readString(config));
+        Map<?, ?> log = (Map<?, ?>) parsed.get("log");
+        Map<?, ?> player = (Map<?, ?>) log.get("player");
+        assertEquals(false, ((Map<?, ?>) player.get("join")).get("enabled"));
+    }
+}

--- a/src/test/java/com/discordlogger/config/ConfigMigratorUpgradeTest.java
+++ b/src/test/java/com/discordlogger/config/ConfigMigratorUpgradeTest.java
@@ -1,0 +1,201 @@
+package com.discordlogger.config;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A real upgrade, end to end: a customised old config in, the new schema out.
+ *
+ * <p>This is the test that would catch the failure that actually matters — an
+ * upgrade that quietly discards what someone configured and replaces it with
+ * defaults. It runs against the genuinely shipped {@code config.yml}, so it keeps
+ * testing the real thing as the schema moves.
+ */
+class ConfigMigratorUpgradeTest {
+
+    private static String shipped;
+    private static int current;
+
+    @BeforeAll
+    static void loadShippedConfig() throws Exception {
+        shipped = Files.readString(Path.of("src/main/resources/config.yml"));
+        current = ConfigMigrator.extractVersion(shipped);
+    }
+
+    /** A v9 config someone actually customised — the point is that none of this is default. */
+    private static final String CUSTOMISED_V9 = String.join("\n",
+            "webhook:", "  url: \"https://discord.com/api/webhooks/123/SECRET\"",
+            "format:", "  time: \"[HH:mm]\"", "  name: \"Survival\"", "  nicknames: false",
+            "embeds:", "  enabled: true", "  author: \"My Server\"",
+            "  colors:",
+            "    player:", "      join: \"#123456\"", "      chat: \"#654321\"",
+            "    moderation:", "      whitelist: \"#ABCDEF\"",
+            "log:",
+            "  player:", "    join: true", "    quit: false", "    chat: false",
+            "    command: true", "    death: true", "    advancement: true",
+            "    teleport: true", "    gamemode: true",
+            "  server:", "    command: true", "    start: true", "    stop: true",
+            "    explosion: false",
+            "  moderation:", "    ban: true", "    unban: true", "    kick: true",
+            "    op: true", "    deop: true", "    whitelist_toggle: true",
+            "    whitelist_edit: true",
+            "# CONFIG VERSION V9, SHIPPED WITH v2.1.6", "");
+
+    private Map<?, ?> upgradeFromV9() {
+        String out = ConfigMigrator.migrateText(shipped, CUSTOMISED_V9, 9, current);
+        return (Map<?, ?>) new Yaml().load(out);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> event(Map<?, ?> root, String group, String name) {
+        Map<?, ?> log = (Map<?, ?>) root.get("log");
+        Map<?, ?> section = (Map<?, ?>) log.get(group);
+        return (Map<String, Object>) section.get(name);
+    }
+
+    @Test
+    @DisplayName("disabled events stay disabled through the shape change")
+    void togglesSurvive() {
+        Map<?, ?> r = upgradeFromV9();
+        assertEquals(false, event(r, "player", "quit").get("enabled"));
+        assertEquals(false, event(r, "player", "chat").get("enabled"));
+        assertEquals(false, event(r, "server", "explosion").get("enabled"));
+        assertEquals(true, event(r, "player", "join").get("enabled"));
+        assertEquals(true, event(r, "moderation", "ban").get("enabled"));
+    }
+
+    @Test
+    @DisplayName("customised colours move to their event; untouched ones take the new default")
+    void coloursMoveBesideTheirToggle() {
+        Map<?, ?> r = upgradeFromV9();
+        assertEquals("#123456", event(r, "player", "join").get("color"));
+        assertEquals("#654321", event(r, "player", "chat").get("color"));
+        // v9's "whitelist" colour belongs to the whitelist_edit toggle.
+        assertEquals("#ABCDEF", event(r, "moderation", "whitelist_edit").get("color"));
+        // Not customised in the v9 file, so it must come from the new defaults.
+        assertEquals("#ED4245", event(r, "player", "quit").get("color"));
+    }
+
+    @Test
+    @DisplayName("a sub-option added to the open schema takes its default, not a stale value")
+    void newSubOptionsDefaultSafely() {
+        // show_coords did not exist in v9, so an upgrading user must land on the
+        // shipped default. It defaults to false because a death message with
+        // coordinates tells the whole channel where the body and its loot are.
+        Map<?, ?> r = upgradeFromV9();
+        assertEquals(false, event(r, "player", "death").get("show_coords"));
+    }
+
+    @Test
+    @DisplayName("an existing sub-option choice is preserved across a migration")
+    void subOptionChoiceSurvives() {
+        String opted = shipped.replace("      show_coords: false", "      show_coords: true");
+        String out = ConfigMigrator.migrateText(shipped, opted, current, current);
+        Map<?, ?> r = (Map<?, ?>) new Yaml().load(out);
+        assertEquals(true, event(r, "player", "death").get("show_coords"),
+                "a user who opted in must not be silently opted back out");
+    }
+
+    @Test
+    @DisplayName("per-event webhooks default to empty, meaning the main webhook")
+    void routingDefaultsToTheMainWebhook() {
+        // A v9 user had one webhook and expects to keep having one. Every event must
+        // arrive with an empty route rather than anything inherited or invented.
+        Map<?, ?> r = upgradeFromV9();
+        Map<?, ?> log = (Map<?, ?>) r.get("log");
+        for (Object groupName : log.keySet()) {
+            Map<?, ?> group = (Map<?, ?>) log.get(groupName);
+            for (Object eventName : group.keySet()) {
+                Map<?, ?> ev = (Map<?, ?>) group.get(eventName);
+                assertTrue(ev.containsKey("webhook"),
+                        groupName + "." + eventName + " should carry a webhook key");
+                assertEquals("", ev.get("webhook"),
+                        groupName + "." + eventName + " must default to the main webhook");
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("a configured per-event webhook survives a migration")
+    void routingChoiceSurvives() {
+        String routed = shipped.replaceFirst(
+                "      webhook: \"\"",
+                "      webhook: \"https://discord.com/api/webhooks/1/STAFF\"");
+        String out = ConfigMigrator.migrateText(shipped, routed, current, current);
+        assertTrue(out.contains("https://discord.com/api/webhooks/1/STAFF"),
+                "a channel someone deliberately routed must not be reset by an upgrade");
+    }
+
+    @Test
+    @DisplayName("settings outside the log tree survive untouched")
+    void unrelatedSettingsSurvive() {
+        Map<?, ?> r = upgradeFromV9();
+        assertEquals("https://discord.com/api/webhooks/123/SECRET",
+                ((Map<?, ?>) r.get("webhook")).get("url"));
+        assertEquals("My Server", ((Map<?, ?>) r.get("embeds")).get("author"));
+        assertEquals(false, ((Map<?, ?>) r.get("format")).get("nicknames"));
+        assertEquals("Survival", ((Map<?, ?>) r.get("format")).get("name"));
+    }
+
+    @Test
+    @DisplayName("the old colours tree is gone, not left behind alongside the new one")
+    void oldStructureIsNotCarriedOver() {
+        assertFalse(((Map<?, ?>) upgradeFromV9().get("embeds")).containsKey("colors"));
+    }
+
+    @Test
+    @DisplayName("the result is the new schema's file, comments and all")
+    void outputKeepsTheShippedFileIntact() {
+        String out = ConfigMigrator.migrateText(shipped, CUSTOMISED_V9, 9, current);
+
+        // Asserts the trailer SURVIVES, not that it is in any particular form. The
+        // release-please marker only exists in the source file: nightly.yml and the
+        // release build both rewrite the trailer before compiling, so pinning that
+        // marker made every nightly fail while CI stayed green.
+        assertTrue(out.strip().matches("(?s).*CONFIG VERSION V\\d+.*"),
+                "the schema trailer must survive, or the next upgrade cannot detect the version");
+        assertEquals(commentLines(shipped), commentLines(out),
+                "migration must not drop comments — the file is documentation as much as config");
+        assertEquals(shipped.split("\n", -1).length, out.split("\n", -1).length,
+                "migration rewrites values in place; it must not add or remove lines");
+    }
+
+    @Test
+    @DisplayName("a config that changed nothing round-trips to the shipped file exactly")
+    void defaultConfigIsUnchangedByMigration() {
+        // Same schema in and out, no customisation: the only difference should be
+        // none at all. Guards against a rename rule firing when it should not.
+        String out = ConfigMigrator.migrateText(shipped, shipped, current, current);
+        assertEquals(shipped.stripTrailing(), out.stripTrailing());
+    }
+
+    @Test
+    @DisplayName("every customised value in the old config lands somewhere")
+    void nothingIsSilentlyDropped() {
+        Map<String, Object> user = ConfigMigrator.flattenYaml(new Yaml().load(CUSTOMISED_V9));
+        Map<String, Object> defaults = ConfigMigrator.flattenYaml(new Yaml().load(shipped));
+
+        List<String> lost = user.keySet().stream()
+                .filter(k -> ConfigMigrator.resolvePath(k, defaults, 9, current) == null)
+                .toList();
+
+        assertEquals(List.of(), lost,
+                "these v9 keys have nowhere to go in the current schema, so the user's "
+                        + "choices for them would be replaced by defaults");
+    }
+
+    private static long commentLines(String text) {
+        return text.lines().filter(l -> l.strip().startsWith("#")).count();
+    }
+}

--- a/src/test/java/com/discordlogger/config/SchemaDetectorTest.java
+++ b/src/test/java/com/discordlogger/config/SchemaDetectorTest.java
@@ -1,0 +1,105 @@
+package com.discordlogger.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Recognising a config by its keys rather than by what it claims.
+ *
+ * <p>The schema was declared only by a comment on the last line, which is the least
+ * durable thing in a config file. When it went missing the migrator returned
+ * UNKNOWN, skipped migration, and the plugin then read a file whose shape it did
+ * not match — every option silently falling back to its default, with nothing in
+ * the log to explain it.
+ */
+class SchemaDetectorTest {
+
+    private static Map<String, Object> flat(String yaml) {
+        return ConfigMigrator.flattenYaml(new Yaml().load(yaml));
+    }
+
+    private static String shipped() throws Exception {
+        return Files.readString(Path.of("src/main/resources/config.yml"));
+    }
+
+    @Test
+    @DisplayName("the shipped config is recognised as its own schema")
+    void recognisesTheShippedConfig() throws Exception {
+        final String text = shipped();
+        assertEquals(ConfigMigrator.extractVersion(text), SchemaDetector.infer(flat(text)),
+                "the shipped file's declared version and its actual shape must agree — "
+                        + "if they do not, one of them was updated without the other");
+    }
+
+    @Test
+    @DisplayName("a config with no version marker at all is still identified")
+    void survivesLosingEveryMarker() throws Exception {
+        // Both markers gone: the trailer deleted and the key removed. This is the case
+        // the whole class exists for.
+        String stripped = shipped()
+                .lines()
+                .filter(l -> !l.contains("CONFIG VERSION"))
+                .filter(l -> !l.startsWith("config-version:"))
+                .reduce("", (a, b) -> a + b + "\n");
+
+        assertEquals(10, SchemaDetector.infer(flat(stripped)),
+                "with no declaration anywhere, the keys still say what this file is");
+    }
+
+    @Test
+    @DisplayName("older schemas are identified by the key that introduced them")
+    void identifiesEachHistoricalSchema() {
+        assertEquals(9, SchemaDetector.infer(flat(
+                "webhook:\n  url: ''\nformat:\n  time: x\nembeds:\n  author: a\n  colors:\n"
+                        + "    server:\n      explosion: '#fff'\n")));
+        assertEquals(8, SchemaDetector.infer(flat(
+                "webhook:\n  url: ''\nformat:\n  time: x\nembeds:\n  author: a\n  colors:\n"
+                        + "    player:\n      gamemode: '#fff'\n")));
+        assertEquals(7, SchemaDetector.infer(flat(
+                "webhook:\n  url: ''\nformat:\n  time: x\nembeds:\n  author: a\n  colors:\n"
+                        + "    moderation:\n      ban: '#fff'\n")));
+        assertEquals(6, SchemaDetector.infer(flat(
+                "webhook:\n  url: ''\nformat:\n  time: x\nembeds:\n  author: a\n  colors:\n"
+                        + "    ban: '#fff'\n")));
+        assertEquals(3, SchemaDetector.infer(flat(
+                "webhook:\n  url: ''\nformat:\n  time: x\nembeds:\n  author: a\n")));
+        assertEquals(2, SchemaDetector.infer(flat("webhook:\n  url: ''\nformat:\n  time: x\n")));
+    }
+
+    @Test
+    @DisplayName("a v9 config is not mistaken for v10")
+    void doesNotOverreadOlderConfigs() {
+        // v9 events are bare booleans; v10 made them sections. Getting this wrong
+        // would skip the migration that restructures them.
+        String v9 = "webhook:\n  url: ''\nformat:\n  time: x\nembeds:\n  author: a\n  colors:\n"
+                + "    server:\n      explosion: '#fff'\nlog:\n  player:\n    join: true\n";
+        assertEquals(9, SchemaDetector.infer(flat(v9)));
+        assertNotEquals(10, SchemaDetector.infer(flat(v9)));
+    }
+
+    @Test
+    @DisplayName("deleting an ordinary option does not change the detected schema")
+    void toleratesMissingOptions() throws Exception {
+        // An admin who deletes options they do not use must not have their config
+        // treated as an older schema and rewritten.
+        String trimmed = shipped().replace("  nicknames: true\n", "")
+                                  .replace("      show_coords: false", "");
+        assertEquals(10, SchemaDetector.infer(flat(trimmed)));
+    }
+
+    @Test
+    @DisplayName("something that is not a config at all is not claimed")
+    void ignoresUnrelatedYaml() {
+        assertEquals(SchemaDetector.UNKNOWN, SchemaDetector.infer(flat("name: SomePlugin\nversion: 1.0\n")));
+        assertEquals(SchemaDetector.UNKNOWN, SchemaDetector.infer(Map.of()));
+        assertEquals(SchemaDetector.UNKNOWN, SchemaDetector.infer(null));
+    }
+}

--- a/src/test/java/com/discordlogger/filter/FilterRulesTest.java
+++ b/src/test/java/com/discordlogger/filter/FilterRulesTest.java
@@ -1,0 +1,210 @@
+package com.discordlogger.filter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.yaml.snakeyaml.Yaml;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The matching behaviour of every filter.
+ *
+ * <p>These are decisions about what never reaches Discord, and most of them are
+ * invisible when wrong: an over-broad filter silently drops events nobody notices
+ * are missing, and an under-broad one only shows up as noise. Neither produces an
+ * error, so the rules are pinned here.
+ *
+ * <p>{@code Filters} reads its state from a live plugin config, which does not exist
+ * in a test, so each case installs a snapshot directly.
+ */
+class FilterRulesTest {
+
+    /** Installs a filter state without needing a server. */
+    private static void install(
+            Set<String> ignoredCommands, Set<String> onlyCommands,
+            List<String> chatPatterns, int minChatLength,
+            List<String> advancements, boolean recipes,
+            Set<String> teleportCauses, double minTeleport,
+            Set<String> deathCauses, Set<String> explosionSources, int minBlocks) throws Exception {
+
+        Class<?> snapshot = Class.forName("com.discordlogger.filter.Filters$Snapshot");
+        Constructor<?> ctor = snapshot.getDeclaredConstructors()[0];
+        ctor.setAccessible(true);
+        Object snap = ctor.newInstance(
+                Set.of(), Set.of(), ignoredCommands, onlyCommands, Set.of(),
+                chatPatterns, minChatLength, advancements, recipes,
+                teleportCauses, minTeleport, deathCauses, explosionSources, minBlocks, "");
+
+        Field current = Filters.class.getDeclaredField("current");
+        current.setAccessible(true);
+        current.set(null, snap);
+    }
+
+    @BeforeEach
+    void reset() throws Exception {
+        install(Set.of(), Set.of(), List.of(), 0, List.of(), false,
+                Set.of(), 0d, Set.of(), Set.of(), 0);
+    }
+
+    // ---------------------------------------------------------------- commands --
+
+    @Test
+    @DisplayName("an allow-list wins outright, and the deny-list still applies inside it")
+    void allowListAndDenyListInteract() throws Exception {
+        install(Set.of("msg"), Set.of("ban", "kick", "msg"), List.of(), 0, List.of(), false,
+                Set.of(), 0d, Set.of(), Set.of(), 0);
+
+        assertFalse(Filters.blocksCommand("/ban Steve"), "on the allow-list");
+        assertTrue(Filters.blocksCommand("/gamemode 1"), "not on the allow-list");
+        assertTrue(Filters.blocksCommand("/msg hi"),
+                "allow-listed but also denied — the deny-list has to win, or it would be "
+                        + "impossible to allow a set and exclude one from it");
+    }
+
+    // ------------------------------------------------------------ advancements --
+
+    @Test
+    @DisplayName("a trailing * matches a whole advancement tab")
+    void advancementWildcard() throws Exception {
+        install(Set.of(), Set.of(), List.of(), 0,
+                List.of("minecraft:husbandry/*", "minecraft:story/mine_stone"), false,
+                Set.of(), 0d, Set.of(), Set.of(), 0);
+
+        assertTrue(Filters.blocksAdvancement("minecraft:husbandry/plant_seed", "husbandry/plant_seed"));
+        assertTrue(Filters.blocksAdvancement("minecraft:story/mine_stone", "story/mine_stone"));
+        assertFalse(Filters.blocksAdvancement("minecraft:end/kill_dragon", "end/kill_dragon"),
+                "an unrelated advancement must still be logged");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"recipes/misc/charcoal", "recipe/building/stairs", "story/root", "husbandry/root"})
+    @DisplayName("recipe unlocks and tab roots are skipped by default")
+    void recipesAndRootsSkipped(String path) {
+        assertTrue(Filters.blocksAdvancement("minecraft:" + path, path),
+                path + " fires constantly and means nothing to a reader");
+    }
+
+    @Test
+    @DisplayName("recipes can be turned back on")
+    void recipesOptIn() throws Exception {
+        install(Set.of(), Set.of(), List.of(), 0, List.of(), true,
+                Set.of(), 0d, Set.of(), Set.of(), 0);
+        assertFalse(Filters.blocksAdvancement("minecraft:recipes/misc/charcoal", "recipes/misc/charcoal"));
+    }
+
+    // ---------------------------------------------------------------- teleport --
+
+    @Test
+    @DisplayName("teleports filter by cause")
+    void teleportByCause() throws Exception {
+        install(Set.of(), Set.of(), List.of(), 0, List.of(), false,
+                Set.of("PLUGIN", "EXIT_BED"), 0d, Set.of(), Set.of(), 0);
+
+        assertTrue(Filters.blocksTeleport("PLUGIN", 500d));
+        assertTrue(Filters.blocksTeleport("exit_bed", 1d), "matching is case-insensitive");
+        assertFalse(Filters.blocksTeleport("NETHER_PORTAL", 900d));
+    }
+
+    @Test
+    @DisplayName("a cross-world teleport is never treated as a short hop")
+    void crossWorldIsNeverShort() throws Exception {
+        install(Set.of(), Set.of(), List.of(), 0, List.of(), false,
+                Set.of(), 50d, Set.of(), Set.of(), 0);
+
+        // Distance is null across worlds. Treating that as 0 would silently drop every
+        // nether portal on a server that set a minimum distance.
+        assertFalse(Filters.blocksTeleport("NETHER_PORTAL", null));
+        assertTrue(Filters.blocksTeleport("ENDER_PEARL", 5d));
+        assertFalse(Filters.blocksTeleport("ENDER_PEARL", 500d));
+    }
+
+    // --------------------------------------------------- death / explosion / chat --
+
+    @Test
+    @DisplayName("deaths filter by damage cause")
+    void deathByCause() throws Exception {
+        install(Set.of(), Set.of(), List.of(), 0, List.of(), false,
+                Set.of(), 0d, Set.of("VOID"), Set.of(), 0);
+
+        assertTrue(Filters.blocksDeath("VOID"));
+        assertTrue(Filters.blocksDeath("void"));
+        assertFalse(Filters.blocksDeath("FALL"));
+        assertFalse(Filters.blocksDeath(null), "an unknown cause must not be silently dropped");
+    }
+
+    @Test
+    @DisplayName("explosions filter by source and by how much they destroyed")
+    void explosionFilters() throws Exception {
+        install(Set.of(), Set.of(), List.of(), 0, List.of(), false,
+                Set.of(), 0d, Set.of(), Set.of("CREEPER"), 5);
+
+        assertTrue(Filters.blocksExplosion("CREEPER", 40), "blocked by source regardless of size");
+        assertTrue(Filters.blocksExplosion("PRIMED_TNT", 2), "too small to matter");
+        assertFalse(Filters.blocksExplosion("PRIMED_TNT", 40), "a real blast is still logged");
+        assertFalse(Filters.blocksExplosion(null, 40), "a block explosion with no source name");
+    }
+
+    @Test
+    @DisplayName("chat filters on content and on length")
+    void chatFilters() throws Exception {
+        install(Set.of(), Set.of(), List.of("discord.gg"), 3, List.of(), false,
+                Set.of(), 0d, Set.of(), Set.of(), 0);
+
+        assertTrue(Filters.blocksChat("hi"), "shorter than the minimum");
+        assertTrue(Filters.blocksChat("  ?  "), "whitespace is trimmed before counting");
+        assertTrue(Filters.blocksChat("join DISCORD.GG/x"), "substring match, case-insensitive");
+        assertFalse(Filters.blocksChat("hello everyone"));
+    }
+
+    // ----------------------------------------------------------- shipped config --
+
+    @Test
+    @DisplayName("the shipped defaults exclude the teleports that are not really teleports")
+    void shippedTeleportDefaults() throws Exception {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> root = (Map<String, Object>) new Yaml()
+                .load(Files.readString(Path.of("src/main/resources/config.yml")));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> filters = (Map<String, Object>) root.get("filters");
+        @SuppressWarnings("unchecked")
+        List<String> causes = (List<String>) filters.get("ignored_teleport_causes");
+
+        // Minecraft reports these as teleports, but the player moved a block or two.
+        // Logging them produces a Discord message for getting out of bed.
+        assertTrue(causes.contains("EXIT_BED"), "standing up from a bed is not a teleport");
+        assertTrue(causes.contains("DISMOUNT"), "getting off a horse is not a teleport");
+
+        assertFalse(causes.contains("NETHER_PORTAL"), "a dimension change is worth logging");
+        assertFalse(causes.contains("COMMAND"), "an admin using /tp is worth logging");
+    }
+
+    @Test
+    @DisplayName("filters that would hide real events ship empty")
+    void riskyFiltersShipEmpty() throws Exception {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> root = (Map<String, Object>) new Yaml()
+                .load(Files.readString(Path.of("src/main/resources/config.yml")));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> f = (Map<String, Object>) root.get("filters");
+
+        assertEquals(List.of(), f.get("ignored_death_causes"), "deaths are the point of the plugin");
+        assertEquals(List.of(), f.get("ignored_explosion_sources"));
+        assertEquals(List.of(), f.get("only_log_commands"), "an allow-list default would hide everything else");
+        assertEquals(0, f.get("minimum_chat_length"));
+        assertEquals(0, f.get("minimum_explosion_blocks"));
+        assertEquals(0, f.get("minimum_teleport_distance"));
+    }
+}

--- a/src/test/java/com/discordlogger/filter/FiltersTest.java
+++ b/src/test/java/com/discordlogger/filter/FiltersTest.java
@@ -1,0 +1,118 @@
+package com.discordlogger.filter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.yaml.snakeyaml.Yaml;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Command matching, and the shipped deny-list.
+ *
+ * <p>The matching is the security-relevant part. A deny-list that "msg" defeats by
+ * typing "/essentials:msg" is worse than no deny-list, because the admin believes
+ * private messages are excluded when they are not — and the same reasoning applies
+ * to {@code /login}, which carries a password in plain text.
+ *
+ * <p>{@code blocksPlayer} and {@code blocksWorld} need a live server and config, so
+ * they are exercised on a test server rather than here; what is pinned here is the
+ * pure normalisation they all route through, plus the shipped defaults.
+ */
+class FiltersTest {
+
+    @ParameterizedTest(name = "{0} -> {1}")
+    @CsvSource({
+            "'/msg hello there',            msg",
+            "'msg hello there',             msg",
+            "'/MSG Hello',                  msg",
+            "'/essentials:msg hello',       msg",
+            "'/minecraft:tell someone hi',  tell",
+            "'/login hunter2',              login",
+            "'  /login   hunter2  ',        login",
+            "'/register pw pw',             register",
+            "'/gamemode creative',          gamemode",
+            "'/',                           ''",
+    })
+    void reducesACommandToItsIdentifyingWord(String raw, String expected) {
+        assertEquals(expected, Filters.normaliseCommand(raw));
+    }
+
+    @Test
+    @DisplayName("a plugin qualifier cannot be used to slip past the list")
+    void qualifiedFormsNormaliseIdentically() {
+        // The bypass this guards: an admin denies "msg", a player types
+        // "/essentials:msg" and the message is logged anyway.
+        for (String variant : List.of("/msg hi", "/essentials:msg hi", "/ESSENTIALS:MSG hi")) {
+            assertEquals("msg", Filters.normaliseCommand(variant), variant);
+        }
+        for (String variant : List.of("/login pw", "/authme:login pw", "/AuthMe:Login pw")) {
+            assertEquals("login", Filters.normaliseCommand(variant), variant);
+        }
+    }
+
+    @ParameterizedTest(name = "shipped default denies /{0}")
+    @ValueSource(strings = {"login", "register", "changepassword", "unregister",
+                            "msg", "tell", "whisper", "w", "r", "reply"})
+    @DisplayName("the shipped config denies the commands that leak")
+    void shippedDefaultsCoverLeakyCommands(String command) throws Exception {
+        assertTrue(shippedIgnoredCommands().contains(command),
+                "config.yml should deny /" + command + " by default — command logging posts "
+                        + "the full line, so this one would publish a password or a private message");
+    }
+
+    @Test
+    @DisplayName("the shipped deny-list is normalised already, so it matches what players type")
+    void shippedEntriesAreInMatchableForm() throws Exception {
+        for (String entry : shippedIgnoredCommands()) {
+            assertEquals(entry, Filters.normaliseCommand(entry),
+                    "'" + entry + "' in config.yml does not normalise to itself, so it would "
+                            + "never match anything a player types");
+        }
+    }
+
+    @Test
+    @DisplayName("the other filter lists ship empty, so nothing is silently hidden")
+    void nonCommandFiltersShipEmpty() throws Exception {
+        Map<?, ?> filters = shippedFilters();
+        assertEquals(List.of(), filters.get("ignored_players"));
+        assertEquals(List.of(), filters.get("ignored_worlds"));
+        assertEquals(List.of(), filters.get("ignored_chat_containing"));
+        assertEquals("", filters.get("exempt_permission"),
+                "an exempt permission that defaulted to something real would hide activity "
+                        + "on every server that happens to grant it");
+    }
+
+    @Test
+    @DisplayName("blank and malformed input never matches")
+    void handlesJunk() {
+        assertFalse(Filters.blocksCommand(null));
+        assertFalse(Filters.blocksCommand(""));
+        assertFalse(Filters.blocksCommand("   "));
+        assertFalse(Filters.blocksChat(null));
+        assertFalse(Filters.blocksChat(""));
+        assertFalse(Filters.blocksWorld(null));
+        assertFalse(Filters.blocksPlayer(null));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<?, ?> shippedFilters() throws Exception {
+        Map<String, Object> root = (Map<String, Object>) new Yaml()
+                .load(Files.readString(Path.of("src/main/resources/config.yml")));
+        return (Map<?, ?>) root.get("filters");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> shippedIgnoredCommands() throws Exception {
+        return (List<String>) shippedFilters().get("ignored_commands");
+    }
+}

--- a/src/test/java/com/discordlogger/lang/LangTest.java
+++ b/src/test/java/com/discordlogger/lang/LangTest.java
@@ -1,0 +1,146 @@
+package com.discordlogger.lang;
+
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.yaml.snakeyaml.Yaml;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Keeping lang.yml and the code that reads it in step.
+ *
+ * <p>Moving strings into a file trades one failure for another: nothing now fails to
+ * compile when a key is renamed or removed. A missing entry surfaces as the raw key
+ * appearing in chat, or a Discord message reading {@code discord.player-join} — both
+ * only visible when that exact event happens on a real server.
+ */
+class LangTest {
+
+    private static final Path LANG = Path.of("src/main/resources/lang.yml");
+    private static final Path SRC = Path.of("src/main/java");
+
+    /** Every key the Java source asks Lang for. */
+    private static List<String> keysUsedInCode() throws Exception {
+        final Pattern call = Pattern.compile("Lang\\.(?:text|chat|prefixed|has)\\(\\s*\"([^\"]+)\"");
+        final List<String> keys = new ArrayList<>();
+        try (Stream<Path> files = Files.walk(SRC)) {
+            for (Path f : files.filter(p -> p.toString().endsWith(".java")).toList()) {
+                final Matcher m = call.matcher(Files.readString(f));
+                while (m.find()) keys.add(m.group(1));
+            }
+        }
+        return keys;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> lang() throws Exception {
+        return (Map<String, Object>) new Yaml().load(Files.readString(LANG));
+    }
+
+    private static boolean hasPath(Map<String, Object> root, String dotted) {
+        Object node = root;
+        for (String part : dotted.split("\\.")) {
+            if (!(node instanceof Map<?, ?> map) || !map.containsKey(part)) return false;
+            node = map.get(part);
+        }
+        return node instanceof String;
+    }
+
+    @Test
+    @DisplayName("every key the code asks for exists in lang.yml")
+    void noCodeAsksForAMissingKey() throws Exception {
+        final Map<String, Object> lang = lang();
+        final List<String> missing = keysUsedInCode().stream()
+                // Death causes are built at runtime from the enum, covered separately.
+                .filter(k -> !k.startsWith("discord.death.causes."))
+                .filter(k -> !hasPath(lang, k))
+                .distinct()
+                .toList();
+
+        assertEquals(List.of(), missing,
+                "these would appear in chat or Discord as their own key name");
+    }
+
+    @ParameterizedTest
+    @EnumSource(DamageCause.class)
+    @DisplayName("every damage cause has wording in lang.yml")
+    void everyCauseHasAnEntry(DamageCause cause) throws Exception {
+        final String key = "discord.death.causes."
+                + cause.name().toLowerCase(Locale.ROOT).replace('_', '-');
+        assertTrue(hasPath(lang(), key),
+                cause + " has no entry, so a player dying this way is reported as a bare "
+                        + "\"Died\". Add " + key + " to lang.yml.");
+    }
+
+    @Test
+    @DisplayName("chat messages are valid MiniMessage")
+    void chatMessagesParse() throws Exception {
+        // An unclosed tag does not throw — it renders as literal text — so this checks
+        // the round trip drops the tags rather than leaving them visible to players.
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> chat = (Map<String, Object>) lang().get("chat");
+        for (Map.Entry<String, Object> e : chat.entrySet()) {
+            final String raw = String.valueOf(e.getValue());
+            final String rendered = PlainTextComponentSerializer.plainText()
+                    .serialize(Lang.chat("chat." + e.getKey()));
+            if (raw.contains("<") && !raw.contains("{")) {
+                assertFalse(rendered.contains("<green>") || rendered.contains("<red>"),
+                        "chat." + e.getKey() + " has a tag that did not parse: " + rendered);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Discord messages carry no MiniMessage tags")
+    void discordMessagesArePlain() throws Exception {
+        // Discord renders Markdown, not MiniMessage: a <green> here would be posted
+        // to the channel literally.
+        final List<String> tagged = new ArrayList<>();
+        collectStrings((Map<?, ?>) lang().get("discord"), "discord", tagged);
+        for (String entry : tagged) {
+            assertFalse(entry.contains("<green>") || entry.contains("<red>")
+                            || entry.contains("<yellow>") || entry.contains("<gray>"),
+                    "a MiniMessage tag in " + entry + " would be posted to Discord as text");
+        }
+    }
+
+    @Test
+    @DisplayName("placeholders are substituted, and unknown ones are left visible")
+    void placeholderSubstitution() {
+        assertEquals("Steve joined the server",
+                Lang.text("discord.player-join", "player", "Steve"));
+
+        // A typo must not silently produce a sentence with a hole in it.
+        assertTrue(Lang.text("discord.player-join", "wrong", "Steve").contains("{player}"));
+    }
+
+    @Test
+    @DisplayName("an unknown key returns itself rather than nothing")
+    void missingKeyIsVisible() {
+        assertEquals("chat.no-such-message", Lang.text("chat.no-such-message"));
+    }
+
+    private static void collectStrings(Map<?, ?> node, String prefix, List<String> out) {
+        for (Map.Entry<?, ?> e : node.entrySet()) {
+            final Object v = e.getValue();
+            if (v instanceof Map<?, ?> child) collectStrings(child, prefix + "." + e.getKey(), out);
+            else if (v instanceof String s) out.add(prefix + "." + e.getKey() + " = " + s);
+        }
+    }
+}

--- a/src/test/java/com/discordlogger/listener/player/PlayerDeathCauseTest.java
+++ b/src/test/java/com/discordlogger/listener/player/PlayerDeathCauseTest.java
@@ -1,0 +1,73 @@
+package com.discordlogger.listener.player;
+
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Every way the server can kill a player has words for it.
+ *
+ * <p>This exists because thirteen of the thirty-three damage causes — including the
+ * one behind {@code /kill} — silently fell through to "Cause of Death: Died". That
+ * is invisible until someone dies that particular way, so the gap is closed by
+ * walking the API's own enum rather than by listing the ones anyone thought of.
+ */
+class PlayerDeathCauseTest {
+
+    @ParameterizedTest
+    @EnumSource(DamageCause.class)
+    @DisplayName("every damage cause the API declares has phrasing")
+    void everyCauseIsHandled(DamageCause cause) {
+        assertNotNull(PlayerDeath.causeText(cause),
+                cause + " has no phrasing, so a player dying this way would be reported "
+                        + "as a bare \"Died\". Add a case for it.");
+    }
+
+    @Test
+    @DisplayName("a future Paper release adding a cause fails here, not in production")
+    void causeTextIsExhaustive() {
+        List<String> unhandled = new ArrayList<>();
+        for (DamageCause cause : DamageCause.values()) {
+            if (PlayerDeath.causeText(cause) == null) unhandled.add(cause.name());
+        }
+        assertEquals(List.of(), unhandled,
+                "these damage causes have no phrasing and would report as \"Died\"");
+    }
+
+    @Test
+    @DisplayName("/kill reads as a command, not as a mystery")
+    void killCommandIsNamed() {
+        // The reported case: /kill produced "Cause of Death: Died".
+        assertEquals("Killed by command", PlayerDeath.causeText(DamageCause.KILL));
+        assertEquals("Killed by command", PlayerDeath.causeText(DamageCause.SUICIDE));
+    }
+
+    @Test
+    @DisplayName("phrasing reads as a standalone field value")
+    void phrasingIsStandalone() {
+        for (DamageCause cause : DamageCause.values()) {
+            String text = PlayerDeath.causeText(cause);
+            assertTrue(Character.isUpperCase(text.charAt(0)),
+                    cause + " -> \"" + text + "\" should start capitalised; it is a field value, "
+                            + "not the middle of a sentence");
+            assertTrue(text.equals(text.strip()) && !text.isBlank(), cause + " -> \"" + text + "\"");
+            assertTrue(text.length() <= 64, cause + " -> \"" + text + "\" is too long for a field");
+        }
+    }
+
+    @Test
+    @DisplayName("no cause yields null, so the caller can fall back")
+    void nullCauseIsHandled() {
+        assertNull(PlayerDeath.causeText(null));
+    }
+}

--- a/src/test/java/com/discordlogger/log/LogRedactionTest.java
+++ b/src/test/java/com/discordlogger/log/LogRedactionTest.java
@@ -1,0 +1,76 @@
+package com.discordlogger.log;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Keeping webhook URLs out of Discord.
+ *
+ * <p>A webhook URL is a bearer credential — anyone holding it can post to that
+ * channel. Command logging echoes whatever was typed, so without redaction,
+ * {@code /discordlogger webhook <url>} would publish the new URL to the channel
+ * the plugin is currently posting to, which when changing webhooks is the old one.
+ */
+class LogRedactionTest {
+
+    private static final String ID = "123456789012345678";
+    private static final String TOKEN = "AbCdEf-gH1jK_lMnOpQrStUvWxYz";
+
+    @ParameterizedTest(name = "{0} is treated as a webhook host")
+    @ValueSource(strings = {
+            "https://discord.com",
+            "https://discordapp.com",
+            "https://ptb.discord.com",
+            "https://canary.discord.com",
+    })
+    void masksEveryDiscordHost(String host) {
+        String url = host + "/api/webhooks/" + ID + "/" + TOKEN;
+        assertEquals(host + "/api/webhooks/" + ID + "/***", Log.redactWebhooks(url));
+    }
+
+    @Test
+    @DisplayName("the id survives so the channel is still identifiable")
+    void keepsTheIdDropsTheToken() {
+        String out = Log.redactWebhooks("/discordlogger webhook https://discord.com/api/webhooks/"
+                + ID + "/" + TOKEN);
+        assertTrue(out.contains(ID), "the channel id is not a secret and is useful in an audit trail");
+        assertFalse(out.contains(TOKEN), "the token is the credential and must never be logged");
+    }
+
+    @Test
+    @DisplayName("a URL embedded in a longer message is still masked")
+    void masksUrlsMidSentence() {
+        assertEquals("set it to https://discord.com/api/webhooks/" + ID + "/*** just now",
+                Log.redactWebhooks("set it to https://discord.com/api/webhooks/"
+                        + ID + "/" + TOKEN + " just now"));
+    }
+
+    @Test
+    @DisplayName("ordinary commands pass through untouched")
+    void leavesEverythingElseAlone() {
+        assertEquals("/gamemode creative Steve", Log.redactWebhooks("/gamemode creative Steve"));
+        assertEquals("/say hello #general", Log.redactWebhooks("/say hello #general"));
+        assertEquals("", Log.redactWebhooks(""));
+        assertEquals(null, Log.redactWebhooks(null));
+    }
+
+    @Test
+    @DisplayName("only real Discord webhook URLs are accepted")
+    void validatesWebhookUrls() {
+        assertTrue(Log.isValidWebhookUrl("https://discord.com/api/webhooks/" + ID + "/" + TOKEN));
+        assertTrue(Log.isValidWebhookUrl("https://canary.discord.com/api/webhooks/1/x"));
+
+        assertFalse(Log.isValidWebhookUrl("https://evil.example/api/webhooks/1/x"),
+                "a lookalike host must not be accepted — it would send every log off-site");
+        assertFalse(Log.isValidWebhookUrl("http://discord.com/api/webhooks/1/x"),
+                "plain HTTP would put the token on the wire in clear");
+        assertFalse(Log.isValidWebhookUrl(""));
+        assertFalse(Log.isValidWebhookUrl(null));
+    }
+}

--- a/src/test/java/com/discordlogger/log/LogRoutingTest.java
+++ b/src/test/java/com/discordlogger/log/LogRoutingTest.java
@@ -1,0 +1,84 @@
+package com.discordlogger.log;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Every message must resolve its destination through {@code webhookFor}.
+ *
+ * <p>Per-event routing shipped with one send site missed — the fields embed, used by
+ * deaths, gamemode changes and every moderation event — while the plain-embed path
+ * was converted. The result was that {@code quit} routed correctly and {@code death}
+ * silently went to the main webhook instead. Nothing failed; the messages simply
+ * arrived in the wrong channel, which no unit test was watching for and no user
+ * would report as a crash.
+ *
+ * <p>Asserting on the source is unusual, but the property here is structural: it is
+ * about which expression appears at a call site, and there is no runtime seam that
+ * exposes it without a live server. The repo already checks source this way in
+ * {@code scripts/validate-config-generator.py}.
+ */
+class LogRoutingTest {
+
+    private static final Path LOG_SOURCE =
+            Path.of("src/main/java/com/discordlogger/log/Log.java");
+
+    @Test
+    @DisplayName("no send site passes the raw webhook field")
+    void everySendSiteResolvesARoute() throws Exception {
+        final List<String> lines = Files.readAllLines(LOG_SOURCE);
+        final List<String> offenders = new ArrayList<>();
+
+        for (int i = 0; i < lines.size(); i++) {
+            final String line = lines.get(i);
+            if (line.strip().startsWith("//") || line.strip().startsWith("*")) continue;
+            if (!line.contains("webhookUrl")) continue;
+
+            // The three legitimate mentions: the declaration, the assignment in
+            // init, and the fallback inside webhookFor itself.
+            if (line.contains("private static volatile String webhookUrl")) continue;
+            if (line.contains("webhookUrl = ready")) continue;
+            if (line.contains("? routed : webhookUrl")) continue;
+
+            offenders.add((i + 1) + ": " + line.strip());
+        }
+
+        assertEquals(List.of(), offenders,
+                "these read webhookUrl directly instead of webhookFor(category), so they "
+                        + "would ignore per-event routing and post to the main webhook");
+    }
+
+    @Test
+    @DisplayName("every Discord send in Log goes through webhookFor")
+    void allDispatchesUseTheResolver() throws Exception {
+        final String src = Files.readString(LOG_SOURCE);
+
+        // Count the calls that actually dispatch, and require each to be paired with
+        // a resolver call. A new send site added without routing fails this.
+        final long sends = countOccurrences(src, "DiscordWebhook.send");
+        final long resolved = countOccurrences(src, "webhookFor(");
+
+        assertTrue(sends > 0, "expected Log to dispatch to Discord at all");
+        assertTrue(resolved >= sends,
+                "found " + sends + " DiscordWebhook.send* call(s) but only " + resolved
+                        + " webhookFor(...) call(s) — at least one send is not resolving a route");
+    }
+
+    private static long countOccurrences(String haystack, String needle) {
+        long n = 0;
+        int i = haystack.indexOf(needle);
+        while (i >= 0) {
+            n++;
+            i = haystack.indexOf(needle, i + needle.length());
+        }
+        return n;
+    }
+}

--- a/src/test/java/com/discordlogger/util/ClientPlatformTest.java
+++ b/src/test/java/com/discordlogger/util/ClientPlatformTest.java
@@ -1,0 +1,84 @@
+package com.discordlogger.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Bedrock detection, specifically its fallback.
+ *
+ * <p>Floodgate's API is the primary route and cannot be exercised here — it needs
+ * Floodgate on the classpath and a running server. What is testable, and what
+ * actually runs on the vast majority of servers, is the UUID-shape fallback. It
+ * relies on undocumented Floodgate behaviour, so the exact bit pattern it keys on
+ * is worth pinning: if someone "tidies" the check into something subtly different,
+ * every Bedrock player silently stops being flagged.
+ */
+class ClientPlatformTest {
+
+    @Test
+    @DisplayName("a Floodgate UUID has zero most-significant bits")
+    void detectsFloodgateShape() {
+        assertTrue(ClientPlatform.looksLikeFloodgateUuid(
+                UUID.fromString("00000000-0000-0000-0009-01f2a3b4c5d6")));
+        assertTrue(ClientPlatform.looksLikeFloodgateUuid(new UUID(0L, 12345L)));
+    }
+
+    @Test
+    @DisplayName("an ordinary Java UUID is not mistaken for Bedrock")
+    void ignoresRealJavaUuids() {
+        // A genuine Mojang UUID is version 4 random; the version nibble alone puts
+        // a non-zero byte in the most significant half.
+        assertFalse(ClientPlatform.looksLikeFloodgateUuid(
+                UUID.fromString("069a79f4-44e9-4726-a5be-fca90e38aaf5")));
+        assertFalse(ClientPlatform.looksLikeFloodgateUuid(UUID.randomUUID()));
+    }
+
+    @Test
+    @DisplayName("a thousand random UUIDs produce no false positives")
+    void randomUuidsNeverCollide() {
+        for (int i = 0; i < 1000; i++) {
+            assertFalse(ClientPlatform.looksLikeFloodgateUuid(UUID.randomUUID()),
+                    "a real player would be wrongly labelled Bedrock");
+        }
+    }
+
+    @Test
+    @DisplayName("the all-zero UUID counts, and null does not")
+    void handlesEdges() {
+        assertTrue(ClientPlatform.looksLikeFloodgateUuid(new UUID(0L, 0L)));
+        assertFalse(ClientPlatform.looksLikeFloodgateUuid(null));
+        assertFalse(ClientPlatform.isBedrock(null));
+    }
+
+    @Test
+    @DisplayName("a Floodgate-shaped UUID counts even when the API disagrees")
+    void shapeIsPositiveEvidenceOnItsOwn() {
+        // The regression this exists for: isBedrock used to return the API's answer
+        // directly whenever the API was reachable, so a "no" from it overrode a UUID
+        // that was plainly Floodgate's. Behind a Velocity proxy the backend's player
+        // registry does not necessarily know a player the proxy handshook, so that
+        // combination is normal rather than contradictory -- and it made real Bedrock
+        // players go unflagged.
+        UUID floodgateShaped = new UUID(0L, 0x0901f2a3b4c5d6L);
+        assertTrue(ClientPlatform.looksLikeFloodgateUuid(floodgateShaped));
+        assertTrue(ClientPlatform.isBedrock(floodgateShaped),
+                "a Floodgate-shaped UUID must be enough on its own; the signals are OR'd");
+    }
+
+    @Test
+    @DisplayName("with no Floodgate present, detection still answers without throwing")
+    void worksWithoutFloodgateInstalled() {
+        // The static initialiser must survive Floodgate being absent — it is absent
+        // here, which is exactly the common case on a real server.
+        assertFalse(ClientPlatform.floodgateApiAvailable(),
+                "Floodgate is not a test dependency; if this passes, the probe is wrong");
+        assertTrue(ClientPlatform.isBedrock(new UUID(0L, 42L)),
+                "the fallback must still work when the API is unavailable");
+        assertFalse(ClientPlatform.isBedrock(UUID.randomUUID()));
+    }
+}

--- a/src/test/java/com/discordlogger/webhook/DeathEmbedPayloadTest.java
+++ b/src/test/java/com/discordlogger/webhook/DeathEmbedPayloadTest.java
@@ -1,0 +1,99 @@
+package com.discordlogger.webhook;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The exact JSON a death sends to Discord.
+ *
+ * <p>This is user-visible output with an agreed shape — title, a description naming
+ * the player, a "Cause of Death" field always, and a "Coords" field only when the
+ * server opted in. None of that is enforced by the compiler, so it is pinned here.
+ */
+class DeathEmbedPayloadTest {
+
+    private static final int RED = 0xED4245;
+    private static final String THUMB = "https://example.invalid/head.png";
+
+    private static String[][] fields(String... nameValuePairs) {
+        String[][] out = new String[nameValuePairs.length / 2][];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = new String[]{nameValuePairs[i * 2], nameValuePairs[i * 2 + 1], "false"};
+        }
+        return out;
+    }
+
+    private static String deathPayload(boolean withCoords) {
+        String[][] f = withCoords
+                ? fields("Cause of Death", "Fell from a high place",
+                         "Coords", "128, 71, -344 in world")
+                : fields("Cause of Death", "Fell from a high place");
+        return DiscordWebhook.buildEmbedJson(
+                "Player Death", "Lachlan died", RED,
+                "2026-07-31T06:00:00Z", "Server Logs", "DiscordLogger v2.2.0", THUMB, f);
+    }
+
+    @Test
+    @DisplayName("the embed carries the title, description and cause field")
+    void hasTitleDescriptionAndCause() {
+        String json = deathPayload(false);
+        assertTrue(json.contains("\"title\":\"Player Death\""), json);
+        assertTrue(json.contains("\"description\":\"Lachlan died\""), json);
+        assertTrue(json.contains("\"name\":\"Cause of Death\""), json);
+        assertTrue(json.contains("\"value\":\"Fell from a high place\""), json);
+    }
+
+    @Test
+    @DisplayName("Coords is absent unless the server opted in")
+    void coordsOnlyWhenEnabled() {
+        assertFalse(deathPayload(false).contains("Coords"),
+                "show_coords is off by default; the field must not appear at all");
+        assertTrue(deathPayload(true).contains("\"name\":\"Coords\""));
+        assertTrue(deathPayload(true).contains("\"value\":\"128, 71, -344 in world\""));
+    }
+
+    @Test
+    @DisplayName("Cause of Death comes before Coords")
+    void causeIsListedFirst() {
+        String json = deathPayload(true);
+        assertTrue(json.indexOf("Cause of Death") < json.indexOf("\"name\":\"Coords\""),
+                "cause is the headline detail and must lead");
+    }
+
+    @Test
+    @DisplayName("the envelope is the shape Discord expects")
+    void envelopeShape() {
+        String json = deathPayload(true);
+        assertTrue(json.startsWith("{\"content\":null,\"embeds\":[{"), json);
+        assertTrue(json.endsWith("}],\"attachments\":[]}"), json);
+        assertTrue(json.contains("\"author\":{\"name\":\"Server Logs\"}"), json);
+        assertTrue(json.contains("\"color\":" + RED), json);
+        // No trailing comma before a closing brace — Discord rejects the whole payload.
+        assertFalse(json.contains(",}"), json);
+        assertFalse(json.contains(",]"), json);
+    }
+
+    @Test
+    @DisplayName("a player name with quotes cannot break the payload")
+    void escapesFieldContent() {
+        String json = DiscordWebhook.buildEmbedJson(
+                "Player Death", "He said \"hi\" died", RED, null, null, null, null,
+                fields("Cause of Death", "Slain by A\\B"));
+        assertFalse(json.contains("\"hi\""), "raw quotes would terminate the JSON string early");
+        assertTrue(json.contains("\\\"hi\\\""), json);
+        assertTrue(json.contains("A\\\\B"), json);
+    }
+
+    @Test
+    @DisplayName("no fields at all still produces valid JSON")
+    void handlesEmptyFields() {
+        String json = DiscordWebhook.buildEmbedJson(
+                "Player Death", "Lachlan died", RED, null, null, null, null, new String[0][]);
+        assertFalse(json.contains("\"fields\""));
+        assertTrue(json.endsWith("}],\"attachments\":[]}"), json);
+        assertFalse(json.contains(",}"), json);
+    }
+}


### PR DESCRIPTION
Filtering was five rules and covered none of the events that actually flood a channel. Now **14**, in three groups: *who*, *where*, and *what*.

| Filter | Why |
|---|---|
| `ignored_advancements` | ~110 vanilla advancements; a new player does dozens in a session. Trailing `*` matches a whole tab. |
| `log_recipe_advancements` | Was **hardcoded** in `PlayerAdvancement`; now a setting, defaulting to existing behaviour. |
| `ignored_teleport_causes` | Teleports are the noisiest event on most servers, and `PLUGIN` covers every Essentials warp. |
| `minimum_teleport_distance` | Short hops. **Never applies across worlds** — a nether portal is not a short hop. |
| `ignored_death_causes` | Void worlds and parkour courses produce the same death endlessly. |
| `ignored_explosion_sources` | By entity (`CREEPER`, `PRIMED_TNT`) or block (`BED`, `RESPAWN_ANCHOR`). |
| `minimum_explosion_blocks` | A creeper against bedrock breaks nothing. |
| `only_log_commands` | **Allow-list.** Wanting a moderation record shouldn't mean enumerating every command you don't want. |
| `minimum_chat_length` | "hi", "?", "." |

## Verified

No test suite any more, so I drove `Filters` directly — **20 behaviours, all passing**, including the two easiest to get backwards:

- the deny-list still applies **inside** the allow-list
- a cross-world teleport is **never** a short hop

Generator emits a complete 14-filter config with zero unfilled tokens; validator clean; docs have a worked example per filter.