### PR TITLE
fix(release): send Modrinth the project id, not the slug

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,18 @@ on:
   push:
     branches: [main]
 
+  # Re-publish an already-tagged release to the listings without cutting a new
+  # one. A publish that can only ever run as a side effect of the release commit
+  # strands the release when it fails -- which is exactly what happened to
+  # v2.2.0, where Hangar succeeded and Modrinth 400'd, leaving no way to retry
+  # short of faking another release.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to publish to Modrinth/Hangar, e.g. v2.2.0"
+        required: true
+        type: string
+
 concurrency:
   group: release-please-${{ github.ref }}
   cancel-in-progress: false
@@ -147,7 +159,14 @@ jobs:
   # asset, so its downloads land on GitHub's counter.
   publish-listings:
     needs: [release-please, build-artifact]
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    # `always()` is required because both needs are skipped on a manual dispatch;
+    # without it the job would be skipped too. The tag is whichever of the two
+    # paths supplied one.
+    if: >-
+      ${{ always() && (
+        needs.release-please.outputs.releases_created == 'true'
+        || github.event_name == 'workflow_dispatch'
+      ) }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -159,7 +178,7 @@ jobs:
       - name: Download the released JAR
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ needs.release-please.outputs.tag_name }}
+          TAG: ${{ inputs.tag || needs.release-please.outputs.tag_name }}
         run: |
           set -euo pipefail
           mkdir -p target
@@ -171,7 +190,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
           HANGAR_API_KEY: ${{ secrets.HANGAR_API_KEY }}
-          TAG: ${{ needs.release-please.outputs.tag_name }}
+          TAG: ${{ inputs.tag || needs.release-please.outputs.tag_name }}
         run: |
           set -euo pipefail
           jar="$(ls -1 target/*.jar | head -n1)"

--- a/scripts/publish-listings.py
+++ b/scripts/publish-listings.py
@@ -202,6 +202,23 @@ def validate_game_versions(versions: list[str]) -> None:
 # ------------------------------------------------------------------ modrinth
 
 
+def modrinth_project_id() -> str:
+    """The project's real base62 id, resolved from its slug.
+
+    `project_id` in a version payload is NOT slug-or-id like the read endpoints
+    are -- Modrinth base62-decodes it. The 13-character slug overflows that
+    decode and comes back as a 400 that names neither the field nor the slug
+    ("Base62 decoding overflowed"), which is why this went unnoticed until a
+    real release tried to publish. Resolved at runtime rather than hardcoded so
+    the two can never disagree.
+    """
+    project = request(f"{MODRINTH_API}/project/{MODRINTH_PROJECT}")
+    ident = (project or {}).get("id", "")
+    if not ident:
+        fail(f"Modrinth returned no id for project '{MODRINTH_PROJECT}'")
+    return ident
+
+
 def publish_modrinth(
     token: str, jar: Path, version: str, game_versions: list[str], changelog: str, dry: bool
 ) -> None:
@@ -221,7 +238,7 @@ def publish_modrinth(
         "version_type": "release",
         "loaders": ["paper"],
         "featured": True,
-        "project_id": MODRINTH_PROJECT,
+        "project_id": modrinth_project_id(),
         "file_parts": ["file"],
         "primary_file": "file",
     }


### PR DESCRIPTION
v2.2.0 published to Hangar, then 400'd on Modrinth:

```
Modrinth: POST https://api.modrinth.com/v2/version -> HTTP 400:
{"error":"invalid_input","description":"Error while parsing JSON: Base62 decoding overflowed at line 1 column 14684"}
```

### Cause

`project_id` in a version payload is **not** slug-or-id like Modrinth's read endpoints — it gets base62-decoded. We were sending the 13-character slug `discordlogger`; the real id is `fOFFYkM1` (8 chars). 13 characters overflows the decode.

It hid well: the error names neither the field nor the slug, and every *read* path in the script (the duplicate check, `--check-auth`) accepts a slug happily. Nothing caught it until a real release tried to publish.

Now resolved from the slug at runtime, so the id and the project can't drift apart.

### Also: the publish is re-runnable now

`publish-listings` only ever ran as a side effect of the release commit, gated on `releases_created`. So when it fails, the release is stranded with no way to retry short of faking another one — exactly where v2.2.0 is. Added a `workflow_dispatch` with a `tag` input.

`build-artifact` stays release-only; a manual publish downloads the JAR from the existing release rather than rebuilding it.

### Verified

`--dry-run` against the real v2.2.0 JAR: `"project_id": "fOFFYkM1"`, payload otherwise unchanged, game versions still validate as `26.1, 26.1.1, 26.1.2, 26.2`.

Once merged, `workflow_dispatch` with `tag: v2.2.0` finishes the stranded publish — Hangar will no-op ("already has 2.2.0") and Modrinth will go through.