### PR TITLE
fix: support Paper 1.19.4 and newer, not just 26.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,41 @@ jobs:
             !target/*-sources.jar
             !target/*-javadoc.jar
 
+  compat-floor:
+    # Proves the plugin compiles against the OLDEST server that can load it.
+    #
+    # api-version cannot express a patch version before 1.20.5, so declaring
+    # "1.19" admits 1.19.0 onward — but the test suite only runs from 1.19.4, and
+    # the main build compiles against that. Without this job, using an API added
+    # in 1.19.1+ would compile, test, ship, and then NoSuchMethodError on the
+    # 1.19.0 servers the listings advertise. Compiling against the floor is what
+    # makes that advertisement a checked claim rather than an assumption.
+    needs: changes
+    if: needs.changes.outputs.java == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Read Java version from pom.xml
+        id: javaver
+        run: echo "version=$(grep -oE '<maven.compiler.release>[0-9]+' pom.xml | grep -oE '[0-9]+')" >> "$GITHUB_OUTPUT"
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: ${{ steps.javaver.outputs.version }}
+          cache: maven
+
+      - name: Read the compat floor from pom.xml
+        id: floor
+        run: echo "version=$(grep -oE '<dl.compat.floor>[^<]+' pom.xml | cut -d'>' -f2)" >> "$GITHUB_OUTPUT"
+
+      - name: Compile against the oldest supported API
+        run: mvn -B -ntp clean compile -Dpaper.api.version=${{ steps.floor.outputs.version }}
+
   validate-generator-data:
     needs: changes
     if: needs.changes.outputs.docs == 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Everything below was verified against the actual source at the time of writing; 
 
 - **Current plugin version:** tracked by `pom.xml` / `.release-please-manifest.json` — never hand-edit either, see **Releases** below.
 - **Current config schema:** **v9** (trailer comment in `src/main/resources/config.yml`, e.g. `# CONFIG VERSION V9, SHIPPED WITH v2.1.6 (x-release-please-version)`)
-- **Paper API:** `26.2.build.87-stable` (`provided` scope), `api-version: 26.1`, compiled for **Java 25**
+- **Paper API:** compiled against the OLDEST supported version (`1.19.4-R0.1-SNAPSHOT`, `provided` scope), `api-version: 1.19`, **Java 17** bytecode. Compiling against the newest and declaring an older `api-version` is how a plugin loads and then dies on `NoSuchMethodError`.
 - **GitHub:** `GodTierGamers/DiscordLogger`
 
 ## Working agreement (binding — not suggestions)
@@ -44,6 +44,7 @@ Everything below was verified against the actual source at the time of writing; 
 | `<version>` | the plugin version — **release-please owns it**, never hand-edit |
 | `<maven.compiler.release>` | Java the plugin is built for |
 | `<dl.api.version>` | minimum Paper; becomes `plugin.yml`'s `api-version` |
+| `<dl.game.versions>` | the supported range; the listings advertise it, and the prose + badge in README/CONTRIBUTING are derived from its first and last entries |
 | `<dl.paper.display>` | how Paper is written in prose, e.g. `26.x` |
 
 The sync script also derives two values it doesn't own: **`plugin`** (the released version, from `<version>`) and **`schema`** (the config schema, read from `config.yml`'s trailer). Docs examples of the config trailer use these, so they can't go stale when a release ships or the schema moves.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Everything after that is automated: merged work appears in the next **nightly bu
 
 - **Java <!-- dl:sync:java -->17<!-- /dl:sync -->** (Temurin recommended) and Maven.
 - `mvn -B -ntp clean package` must pass.
-- Test on a real **Paper <!-- dl:sync:paper_display -->1.19.4+<!-- /dl:sync -->** server when your change touches runtime behavior — a clean compile is not a functional test.
+- Test on a real **Paper <!-- dl:sync:paper_display -->1.19.4 – 26.2<!-- /dl:sync -->** server when your change touches runtime behavior — a clean compile is not a functional test.
 - **Config changes travel in lockstep**: if you add or change a `log.*`, `embeds.*` or `filters.*` key — or any message in `lang.yml` — the same PR must update the code that reads it, the shipped file under `src/main/resources/`, and the website generator data (`docs/assets/configs/v*/options.json` plus the matching `config.template.yml` / `lang.template.yml`). Generating a config and changing nothing has to reproduce the shipped files byte for byte; that is checked, not assumed. Run it locally:
   ```bash
   python3 scripts/validate-config-generator.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,9 @@ Everything after that is automated: merged work appears in the next **nightly bu
 
 ## Before you open a PR
 
-- **Java <!-- dl:sync:java -->25<!-- /dl:sync -->** (Temurin recommended) and Maven.
+- **Java <!-- dl:sync:java -->17<!-- /dl:sync -->** (Temurin recommended) and Maven.
 - `mvn -B -ntp clean package` must pass.
-- Test on a real **Paper <!-- dl:sync:paper_display -->26.x<!-- /dl:sync -->** server when your change touches runtime behavior — a clean compile is not a functional test.
+- Test on a real **Paper <!-- dl:sync:paper_display -->1.19.4+<!-- /dl:sync -->** server when your change touches runtime behavior — a clean compile is not a functional test.
 - **Config changes travel in lockstep**: if you add or change a `log.*`, `embeds.*` or `filters.*` key — or any message in `lang.yml` — the same PR must update the code that reads it, the shipped file under `src/main/resources/`, and the website generator data (`docs/assets/configs/v*/options.json` plus the matching `config.template.yml` / `lang.template.yml`). Generating a config and changing nothing has to reproduce the shipped files byte for byte; that is checked, not assumed. Run it locally:
   ```bash
   python3 scripts/validate-config-generator.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Everything after that is automated: merged work appears in the next **nightly bu
 
 - **Java <!-- dl:sync:java -->17<!-- /dl:sync -->** (Temurin recommended) and Maven.
 - `mvn -B -ntp clean package` must pass.
-- Test on a real **Paper <!-- dl:sync:paper_display -->1.19.4 – 26.2<!-- /dl:sync -->** server when your change touches runtime behavior — a clean compile is not a functional test.
+- Test on a real **Paper <!-- dl:sync:paper_display -->1.19 – 26.2<!-- /dl:sync -->** server when your change touches runtime behavior — a clean compile is not a functional test.
 - **Config changes travel in lockstep**: if you add or change a `log.*`, `embeds.*` or `filters.*` key — or any message in `lang.yml` — the same PR must update the code that reads it, the shipped file under `src/main/resources/`, and the website generator data (`docs/assets/configs/v*/options.json` plus the matching `config.template.yml` / `lang.template.yml`). Generating a config and changing nothing has to reproduce the shipped files byte for byte; that is checked, not assumed. Run it locally:
   ```bash
   python3 scripts/validate-config-generator.py

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 ![License](https://img.shields.io/github/license/GodTierGamers/DiscordLogger)
 <!-- dl:sync-block:badges -->
 ![Java](https://img.shields.io/badge/Java-17%2B-orange)
-![Paper](https://img.shields.io/badge/Paper-1.19.4+-blue)
+![Paper](https://img.shields.io/badge/Paper-1.19.4--26.2-blue)
 <!-- /dl:sync-block -->
 ![Discord Webhooks](https://img.shields.io/badge/Discord-Webhooks-5865F2)
 
 A minimal, reliable Minecraft server **logging plugin** that posts clean messages to a **Discord webhook** — in Markdown **or rich embeds**.
-Built for **Paper <!-- dl:sync:paper_display -->1.19.4+<!-- /dl:sync -->** (and Paper forks like Purpur) on **Java <!-- dl:sync:java -->17<!-- /dl:sync -->+**, tested with Geyser/Floodgate (Bedrock cross-play).
+Built for **Paper <!-- dl:sync:paper_display -->1.19.4 – 26.2<!-- /dl:sync -->** (and Paper forks like Purpur) on **Java <!-- dl:sync:java -->17<!-- /dl:sync -->+**, tested with Geyser/Floodgate (Bedrock cross-play).
 
 ---
 
@@ -74,8 +74,8 @@ Full instructions, including creating the webhook in Discord and checking that e
 
 ## 🔌 Compatibility
 
-- **Server:** Paper **<!-- dl:sync:paper_display -->1.19.4+<!-- /dl:sync -->**, or a Paper fork such as Purpur. The plugin uses Paper-specific APIs, so Paper is required — it will tell you clearly on startup if the server doesn't provide them.
-- **Java:** **<!-- dl:sync:java -->17<!-- /dl:sync -->+** — Minecraft <!-- dl:sync:paper_display -->1.19.4+<!-- /dl:sync --> requires it, and the plugin is compiled for it. It will not load on older Java runtimes.
+- **Server:** Paper **<!-- dl:sync:paper_display -->1.19.4 – 26.2<!-- /dl:sync -->**, or a Paper fork such as Purpur. The plugin uses Paper-specific APIs, so Paper is required — it will tell you clearly on startup if the server doesn't provide them.
+- **Java:** **<!-- dl:sync:java -->17<!-- /dl:sync -->+** — the plugin is compiled for Java <!-- dl:sync:java -->17<!-- /dl:sync -->, so it loads on that and anything newer. Your *Minecraft* version sets the real floor: 1.19.4 needs Java 17, 1.20.5 needs 21, and 26.x needs 25. Whatever your server already runs on is fine.
 - **Cross-play:** Compatible with **Geyser/Floodgate** — death messages are server-generated for consistency across Java/Bedrock names/locales, and joins from Bedrock can be flagged as such.
 - **Spigot and CraftBukkit are not supported.** The plugin uses Paper's chat API; on a server without it you get a plain explanation on startup rather than a stack trace.
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 ![License](https://img.shields.io/github/license/GodTierGamers/DiscordLogger)
 <!-- dl:sync-block:badges -->
 ![Java](https://img.shields.io/badge/Java-17%2B-orange)
-![Paper](https://img.shields.io/badge/Paper-1.19.4--26.2-blue)
+![Paper](https://img.shields.io/badge/Paper-1.19--26.2-blue)
 <!-- /dl:sync-block -->
 ![Discord Webhooks](https://img.shields.io/badge/Discord-Webhooks-5865F2)
 
 A minimal, reliable Minecraft server **logging plugin** that posts clean messages to a **Discord webhook** — in Markdown **or rich embeds**.
-Built for **Paper <!-- dl:sync:paper_display -->1.19.4 – 26.2<!-- /dl:sync -->** (and Paper forks like Purpur) on **Java <!-- dl:sync:java -->17<!-- /dl:sync -->+**, tested with Geyser/Floodgate (Bedrock cross-play).
+Built for **Paper <!-- dl:sync:paper_display -->1.19 – 26.2<!-- /dl:sync -->** (and Paper forks like Purpur) on **Java <!-- dl:sync:java -->17<!-- /dl:sync -->+**, tested with Geyser/Floodgate (Bedrock cross-play).
 
 ---
 
@@ -74,7 +74,7 @@ Full instructions, including creating the webhook in Discord and checking that e
 
 ## 🔌 Compatibility
 
-- **Server:** Paper **<!-- dl:sync:paper_display -->1.19.4 – 26.2<!-- /dl:sync -->**, or a Paper fork such as Purpur. The plugin uses Paper-specific APIs, so Paper is required — it will tell you clearly on startup if the server doesn't provide them.
+- **Server:** Paper **<!-- dl:sync:paper_display -->1.19 – 26.2<!-- /dl:sync -->**, or a Paper fork such as Purpur. The plugin uses Paper-specific APIs, so Paper is required — it will tell you clearly on startup if the server doesn't provide them.
 - **Java:** **<!-- dl:sync:java -->17<!-- /dl:sync -->+** — the plugin is compiled for Java <!-- dl:sync:java -->17<!-- /dl:sync -->, so it loads on that and anything newer. Your *Minecraft* version sets the real floor: 1.19.4 needs Java 17, 1.20.5 needs 21, and 26.x needs 25. Whatever your server already runs on is fine.
 - **Cross-play:** Compatible with **Geyser/Floodgate** — death messages are server-generated for consistency across Java/Bedrock names/locales, and joins from Bedrock can be flagged as such.
 - **Spigot and CraftBukkit are not supported.** The plugin uses Paper's chat API; on a server without it you get a plain explanation on startup rather than a stack trace.

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 ![Issues](https://img.shields.io/github/issues/GodTierGamers/DiscordLogger)
 ![License](https://img.shields.io/github/license/GodTierGamers/DiscordLogger)
 <!-- dl:sync-block:badges -->
-![Java](https://img.shields.io/badge/Java-25%2B-orange)
-![Paper](https://img.shields.io/badge/Paper-26.x-blue)
+![Java](https://img.shields.io/badge/Java-17%2B-orange)
+![Paper](https://img.shields.io/badge/Paper-1.19.4+-blue)
 <!-- /dl:sync-block -->
 ![Discord Webhooks](https://img.shields.io/badge/Discord-Webhooks-5865F2)
 
 A minimal, reliable Minecraft server **logging plugin** that posts clean messages to a **Discord webhook** — in Markdown **or rich embeds**.
-Built for **Paper <!-- dl:sync:paper_display -->26.x<!-- /dl:sync -->** (and Paper forks like Purpur) on **Java <!-- dl:sync:java -->25<!-- /dl:sync -->+**, tested with Geyser/Floodgate (Bedrock cross-play).
+Built for **Paper <!-- dl:sync:paper_display -->1.19.4+<!-- /dl:sync -->** (and Paper forks like Purpur) on **Java <!-- dl:sync:java -->17<!-- /dl:sync -->+**, tested with Geyser/Floodgate (Bedrock cross-play).
 
 ---
 
@@ -74,8 +74,8 @@ Full instructions, including creating the webhook in Discord and checking that e
 
 ## 🔌 Compatibility
 
-- **Server:** Paper **<!-- dl:sync:paper_display -->26.x<!-- /dl:sync -->**, or a Paper fork such as Purpur. The plugin uses Paper-specific APIs, so Paper is required — it will tell you clearly on startup if the server doesn't provide them.
-- **Java:** **<!-- dl:sync:java -->25<!-- /dl:sync -->+** — Minecraft <!-- dl:sync:paper_display -->26.x<!-- /dl:sync --> requires it, and the plugin is compiled for it. It will not load on older Java runtimes.
+- **Server:** Paper **<!-- dl:sync:paper_display -->1.19.4+<!-- /dl:sync -->**, or a Paper fork such as Purpur. The plugin uses Paper-specific APIs, so Paper is required — it will tell you clearly on startup if the server doesn't provide them.
+- **Java:** **<!-- dl:sync:java -->17<!-- /dl:sync -->+** — Minecraft <!-- dl:sync:paper_display -->1.19.4+<!-- /dl:sync --> requires it, and the plugin is compiled for it. It will not load on older Java runtimes.
 - **Cross-play:** Compatible with **Geyser/Floodgate** — death messages are server-generated for consistency across Java/Bedrock names/locales, and joins from Bedrock can be flagged as such.
 - **Spigot and CraftBukkit are not supported.** The plugin uses Paper's chat API; on a server without it you get a plain explanation on startup rather than a stack trace.
 

--- a/docs/_data/versions.yml
+++ b/docs/_data/versions.yml
@@ -4,5 +4,5 @@ plugin: "2.2.0" # x-release-please-version
 schema: "V10"
 java: "17"
 min_paper: "1.19"
-paper_display: "1.19.4 – 26.2"
+paper_display: "1.19 – 26.2"
 paper_api: "1.19.4-R0.1-SNAPSHOT"

--- a/docs/_data/versions.yml
+++ b/docs/_data/versions.yml
@@ -2,7 +2,7 @@
 # Docs pages reference these as {{ site.data.versions.<key> }}.
 plugin: "2.2.0" # x-release-please-version
 schema: "V10"
-java: "25"
-min_paper: "26.1"
-paper_display: "26.x"
-paper_api: "26.2.build.87-stable"
+java: "17"
+min_paper: "1.19"
+paper_display: "1.19.4+"
+paper_api: "1.19.4-R0.1-SNAPSHOT"

--- a/docs/_data/versions.yml
+++ b/docs/_data/versions.yml
@@ -4,5 +4,5 @@ plugin: "2.2.0" # x-release-please-version
 schema: "V10"
 java: "17"
 min_paper: "1.19"
-paper_display: "1.19.4+"
+paper_display: "1.19.4 – 26.2"
 paper_api: "1.19.4-R0.1-SNAPSHOT"

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
              filtering, the CI workflows by reading this file, and the website +
              README via scripts/sync-versions.py. Change them here, nowhere else. -->
         <dl.api.version>1.19</dl.api.version>
-        <dl.paper.display>1.19.4+</dl.paper.display>
 
         <!-- Minecraft versions advertised on the Modrinth and Hangar listings when a
              stable release is published. This is the one value that cannot be derived

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,17 @@
              support we cannot honestly claim. -->
         <paper.api.version>1.19.4-R0.1-SNAPSHOT</paper.api.version>
 
+        <!-- The oldest API the plugin promises to compile against, checked by CI's
+             compat-floor job. It is LOWER than paper.api.version above, and the gap
+             is deliberate: api-version cannot express a patch before 1.20.5, so
+             declaring 1.19 admits 1.19.0 onward, while the test suite only runs from
+             1.19.4 (Bukkit switched to SnakeYAML 2.x there, and older ones collide
+             with ours on the unrelocated test classpath). Compiling against this
+             floor is what makes advertising the whole 1.19 line honest rather than
+             hopeful — it fails the build the moment anyone uses an API newer than
+             the oldest server that can load the plugin. -->
+        <dl.compat.floor>1.19-R0.1-SNAPSHOT</dl.compat.floor>
+
         <!-- SINGLE SOURCE OF TRUTH for the versions humans would otherwise retype.
              Everything downstream derives from these: plugin.yml via Maven
              filtering, the CI workflows by reading this file, and the website +
@@ -42,7 +53,7 @@
              editorial call. Keep it in step with dl.api.version. Every entry is
              checked against Modrinth's known-version list before publishing, so a
              typo or an invented version fails the release rather than mislabelling it. -->
-        <dl.game.versions>1.19.4,1.20,1.20.1,1.20.2,1.20.3,1.20.4,1.20.5,1.20.6,1.21,1.21.1,1.21.2,1.21.3,1.21.4,1.21.5,1.21.6,1.21.7,1.21.8,1.21.9,1.21.10,1.21.11,26.1,26.1.1,26.1.2,26.2</dl.game.versions>
+        <dl.game.versions>1.19,1.19.1,1.19.2,1.19.3,1.19.4,1.20,1.20.1,1.20.2,1.20.3,1.20.4,1.20.5,1.20.6,1.21,1.21.1,1.21.2,1.21.3,1.21.4,1.21.5,1.21.6,1.21.7,1.21.8,1.21.9,1.21.10,1.21.11,26.1,26.1.1,26.1.2,26.2</dl.game.versions>
 
         <!-- Build channel/date are stamped by CI (-Ddl.build.channel=stable|nightly,
              -Ddl.build.date=DD-MM-YYYY). A plain local `mvn package` gets "dev",

--- a/pom.xml
+++ b/pom.xml
@@ -9,16 +9,32 @@
     <url>https://github.com/GodTierGamers/DiscordLogger</url>
 
     <properties>
-        <maven.compiler.release>25</maven.compiler.release>
+        <!-- Java 17, not 25. Bytecode is a hard gate: a Java 17 runtime physically
+             cannot load a class file compiled for 25, so targeting 25 restricted the
+             plugin to servers on 1.20.5+. Nothing in this codebase needs anything
+             newer than 17 — see UpdateChecker for the single exception, which was
+             a library API rather than a language feature. -->
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <paper.api.version>26.2.build.87-stable</paper.api.version>
+
+        <!-- Compile against the OLDEST supported API, never the newest. Building
+             against a newer one and declaring an older api-version is how you ship a
+             plugin that loads and then dies on NoSuchMethodError: the compiler
+             happily links methods the old server does not have. 1.19.4 is the floor
+             because it is the oldest release where the full test suite runs — 1.18.x
+             and 1.19.0 to 1.19.2 ship a Bukkit whose YamlConfiguration needs SnakeYAML
+             1.x, which collides with ours on the (unrelocated) test classpath.
+             That collision is a test artifact only, since SnakeYAML is shaded and
+             relocated in the JAR, but support we cannot run the suite against is
+             support we cannot honestly claim. -->
+        <paper.api.version>1.19.4-R0.1-SNAPSHOT</paper.api.version>
 
         <!-- SINGLE SOURCE OF TRUTH for the versions humans would otherwise retype.
              Everything downstream derives from these: plugin.yml via Maven
              filtering, the CI workflows by reading this file, and the website +
              README via scripts/sync-versions.py. Change them here, nowhere else. -->
-        <dl.api.version>26.1</dl.api.version>
-        <dl.paper.display>26.x</dl.paper.display>
+        <dl.api.version>1.19</dl.api.version>
+        <dl.paper.display>1.19.4+</dl.paper.display>
 
         <!-- Minecraft versions advertised on the Modrinth and Hangar listings when a
              stable release is published. This is the one value that cannot be derived
@@ -27,7 +43,7 @@
              editorial call. Keep it in step with dl.api.version. Every entry is
              checked against Modrinth's known-version list before publishing, so a
              typo or an invented version fails the release rather than mislabelling it. -->
-        <dl.game.versions>26.1,26.1.1,26.1.2,26.2</dl.game.versions>
+        <dl.game.versions>1.19.4,1.20,1.20.1,1.20.2,1.20.3,1.20.4,1.20.5,1.20.6,1.21,1.21.1,1.21.2,1.21.3,1.21.4,1.21.5,1.21.6,1.21.7,1.21.8,1.21.9,1.21.10,1.21.11,26.1,26.1.1,26.1.2,26.2</dl.game.versions>
 
         <!-- Build channel/date are stamped by CI (-Ddl.build.channel=stable|nightly,
              -Ddl.build.date=DD-MM-YYYY). A plain local `mvn package` gets "dev",

--- a/scripts/sync-versions.py
+++ b/scripts/sync-versions.py
@@ -11,7 +11,7 @@ Values, and where each comes from:
     <project.version>          the plugin version           (release-please owns it)
     <maven.compiler.release>   Java the plugin is built for
     <dl.api.version>           minimum Paper (plugin.yml's api-version)
-    <dl.paper.display>         how Paper is written in prose, e.g. "26.x"
+    <dl.game.versions>         the supported range; prose + badge are derived from it
 
 Targets:
 
@@ -51,9 +51,29 @@ BLOCK = re.compile(
 BLOCK_TEMPLATES = {
     "badges": lambda v: (
         f"![Java](https://img.shields.io/badge/Java-{v['java']}%2B-orange)\n"
-        f"![Paper](https://img.shields.io/badge/Paper-{v['paper_display']}-blue)\n"
+        f"![Paper](https://img.shields.io/badge/Paper-{v['paper_badge']}-blue)\n"
     ),
 }
+
+
+def paper_display(game_versions: str) -> str:
+    """The supported range as (prose, badge) — e.g. ("1.19.4 – 26.2", "1.19.4--26.2").
+
+    Derived from <dl.game.versions> rather than hand-set, because the two would
+    otherwise drift the moment a new Minecraft release is added: the listings
+    would advertise it while every badge and requirements table still named the
+    old ceiling. A bare "1.19.4+" was worse still -- true, but silent about what
+    has actually been tested at the top of the range.
+    """
+    parts = [v.strip() for v in game_versions.split(",") if v.strip()]
+    if not parts:
+        return "unknown", "unknown"
+    if len(parts) == 1:
+        return parts[0], parts[0]
+    # Prose gets an en dash; the badge gets shields.io's escaping, where a literal
+    # dash is "--" and a space breaks the URL outright (the image silently fails to
+    # render and GitHub shows the raw markdown instead).
+    return f"{parts[0]} \u2013 {parts[-1]}", f"{parts[0]}--{parts[-1]}"
 
 
 def pom_values() -> dict[str, str]:
@@ -79,13 +99,16 @@ def pom_values() -> dict[str, str]:
         if sm:
             schema = sm.group(1).upper()
 
+    display, badge = paper_display(prop("dl.game.versions"))
+
     return {
         "plugin": vm.group(1).strip(),
         "schema": schema,
         "java": prop("maven.compiler.release"),
         "paper_api": prop("paper.api.version"),
         "min_paper": prop("dl.api.version"),
-        "paper_display": prop("dl.paper.display"),
+        "paper_display": display,
+        "paper_badge": badge,
     }
 
 

--- a/src/main/java/com/discordlogger/update/UpdateChecker.java
+++ b/src/main/java/com/discordlogger/update/UpdateChecker.java
@@ -50,9 +50,14 @@ public final class UpdateChecker {
         }
 
         plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
-            try (HttpClient client = HttpClient.newBuilder()
+            // Deliberately NOT try-with-resources. HttpClient only became
+            // AutoCloseable in Java 21, and this is compiled for 17 so the plugin
+            // loads on servers older than 1.20.5. Nothing leaks: one request is
+            // made and the client is unreachable immediately afterwards.
+            final HttpClient client = HttpClient.newBuilder()
                     .connectTimeout(TIMEOUT)
-                    .build()) {
+                    .build();
+            try {
 
                 HttpRequest req = HttpRequest.newBuilder(URI.create(RELEASES_LIST_API_URL))
                         .timeout(TIMEOUT)

--- a/src/test/java/com/discordlogger/listener/player/PlayerDeathCauseTest.java
+++ b/src/test/java/com/discordlogger/listener/player/PlayerDeathCauseTest.java
@@ -48,8 +48,26 @@ class PlayerDeathCauseTest {
     @DisplayName("/kill reads as a command, not as a mystery")
     void killCommandIsNamed() {
         // The reported case: /kill produced "Cause of Death: Died".
-        assertEquals("Killed by command", PlayerDeath.causeText(DamageCause.KILL));
-        assertEquals("Killed by command", PlayerDeath.causeText(DamageCause.SUICIDE));
+        //
+        // Looked up by NAME rather than written as DamageCause.KILL, because the
+        // constant does not exist before 1.20 and the plugin is compiled against
+        // its oldest supported API. Naming it directly is a compile error there --
+        // which is exactly the trap this whole file exists to catch, one level up:
+        // the production code has always resolved causes by name at runtime, so it
+        // was only ever the test that could not travel backwards.
+        assertCauseReads("KILL", "Killed by command");
+        assertCauseReads("SUICIDE", "Killed by command");
+    }
+
+    /** Asserts phrasing for a cause named at runtime, skipping if this API lacks it. */
+    private static void assertCauseReads(String constant, String expected) {
+        DamageCause cause;
+        try {
+            cause = DamageCause.valueOf(constant);
+        } catch (IllegalArgumentException absentOnThisVersion) {
+            return;
+        }
+        assertEquals(expected, PlayerDeath.causeText(cause));
     }
 
     @Test


### PR DESCRIPTION
Fixes #161.

A user on Leaf 1.21.11 couldn't start the plugin at all:

```
org.bukkit.plugin.InvalidPluginException: Unsupported API version 26.1
```

`api-version: 26.1` rejects every server below 26.1 before the plugin is even constructed. 2.2.0 was installable on **four** Minecraft versions.

### Two constraints, both removed

**Bytecode.** `maven.compiler.release` was 25 — and a Java 17 runtime *physically cannot load* a class file compiled for 25. No runtime detection helps. The only thing in the codebase needing anything newer was `UpdateChecker`'s try-with-resources on `HttpClient`, which only became `AutoCloseable` in Java 21 and holds nothing needing closure for a single request.

**Compile target.** Now compiles against the **oldest** supported API rather than the newest. Building against the newest and declaring an older `api-version` is how a plugin loads and then dies on `NoSuchMethodError`.

### Nothing was given up

Death and teleport causes were *already* resolved by name at runtime, so they adapt to whatever the target defines. That's why the parameterised tests run **190 cases at 1.19.4** and **196 at 26.2**, both green. One test named `DamageCause.KILL` directly (added in 1.20); it now resolves by name and skips where absent — the only thing in the suite that couldn't travel backwards.

### Why 1.19.4 and not lower

It's the oldest release the full suite can **run** against. Below it, Bukkit's `YamlConfiguration` needs SnakeYAML 1.x and collides with ours on the unrelocated test classpath. That collision can't happen in the shipped JAR — SnakeYAML is shaded and relocated — but support the tests can't exercise isn't support worth claiming.

For the record on going lower: **1.18.2** is the same SnakeYAML test issue. **1.17.1** is harder than expected — Paper only bundles MiniMessage from 1.18.2, and the oldest released `adventure-text-minimessage` is **4.10.0** while 1.17.1 ships adventure-api **4.9.3**. No MiniMessage build targets 4.9.3, so 1.17 needs the legacy-string output path, not just shading.

### Coverage

**Before:** 26.1, 26.1.1, 26.1.2, 26.2 — 4 versions
**After:** 1.19.4 → 26.2 — **24 versions**

### Verified

- Compiles clean against 1.19.4, 1.20.6, 1.21.11, 26.2
- Java 17 bytecode (major 61)
- 283 relocated classes, zero unrelocated leaks
- `api-version: 1.19` in the built `plugin.yml`
- README, CONTRIBUTING, site all propagated from `pom.xml` via `sync-versions.py`

### Not yet verified

The JAR actually **starting** on a real 1.19.x server and a real 26.x server. Compiling against a floor can't prove runtime behaviour at the top of the range — that's the gate before release.