### PR TITLE
chore: stop Dependabot bumping the Paper API floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,18 @@ updates:
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
+    ignore:
+      # paper-api is NOT a dependency to keep current -- it is the oldest server
+      # the plugin promises to run on, and it is pinned low on purpose. The plugin
+      # compiles against the FLOOR so the compiler refuses anything a 1.19 server
+      # would not have; bumping it to the newest build would let newer APIs link
+      # silently and then NoSuchMethodError on the versions the listings advertise.
+      #
+      # Dependabot cannot know that, so it opened #162 to "update" 26.2.build.87 to
+      # 26.2.build.111 -- correct for a normal dependency, wrong for this one.
+      # Raising the floor is a deliberate decision that also moves api-version and
+      # dl.game.versions, so it belongs in a human PR, not an automated bump.
+      - dependency-name: "io.papermc.paper:paper-api"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Dependabot opened #162 to bump `paper-api` from `26.2.build.87-stable` to `26.2.build.111-stable`. That's correct behaviour for a normal dependency and **wrong for this one**.

`paper-api` is not a dependency to keep current — it's the **oldest server the plugin promises to run on**, pinned low on purpose so the compiler refuses any API a 1.19 server wouldn't have.

Merging #162 would point the compile target back at the newest API while `plugin.yml` still declares `api-version: 1.19` — the "loads, then dies on `NoSuchMethodError`" trap that #164 exists to prevent.

Raising the floor is a deliberate decision that moves `api-version` and `dl.game.versions` along with it, so it belongs in a human PR. Every other Maven dependency still gets bumped as before — this is a single `dependency-name` ignore, not a blanket one.

**#162 should be closed** — Dependabot will do it automatically once this lands.