### PR TITLE
feat(metrics): measure what people do with the plugin, not who uses it

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,12 @@ Full instructions, including creating the webhook in Discord and checking that e
 
 - **Your webhook URL is a credential.** Anyone holding it can post to that channel as your server. The plugin never echoes it back, redacts it from command logging, and keeps it out of tab-completion. The [config generator](https://discordlogger.godtiergamers.xyz/generator/) runs entirely in your browser — it sends your webhook to Discord and nowhere else.
 - **Command logging posts commands verbatim**, which is why `/login`, `/register`, `/msg` and similar ship in `filters.ignored_commands` by default. Removing them publishes passwords and private messages to your channel.
-- **Anonymous metrics** are reported to [bStats](https://bstats.org/plugin/bukkit/DiscordLogger/33026): config schema version, release channel, whether embeds are on, and which event types are enabled — alongside the server/Java/plugin version data bStats collects for every plugin. No webhook URLs, player names, or message content. Builds compiled from source report too, tagged as such, so the totals aren't quietly understated. Opt out in `plugins/bStats/config.yml`, which switches it off for every bStats plugin on the server at once.
+- **Anonymous metrics** are reported to [bStats](https://bstats.org/plugin/bukkit/DiscordLogger/33026). They answer *"what do people do with this plugin"* and nothing else:
+  - **Your setup** — server software, Minecraft version, Java version, online/offline mode, whether you're behind a proxy, and which of a short list of companion plugins are installed (Floodgate, PlaceholderAPI, CoreProtect, and the common punishment and vanish plugins).
+  - **Your configuration** — which events are on, embeds or plain text, how many webhooks you route to, which of the fourteen filters differ from the defaults, whether `lang.yml` was edited and roughly how much, the config schema, and whether the file came from the website generator.
+  - **Never** — webhook URLs, player names, UUIDs, IP addresses, message content, coordinates, or world names. Counts are reported as ranges rather than exact numbers, so a chart cannot become a fingerprint.
+
+  Builds compiled from source report too, tagged as such, so the totals aren't quietly understated. Opt out in `plugins/bStats/config.yml`, which switches it off for every bStats plugin on the server at once.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Full instructions, including creating the webhook in Discord and checking that e
 
 - **Your webhook URL is a credential.** Anyone holding it can post to that channel as your server. The plugin never echoes it back, redacts it from command logging, and keeps it out of tab-completion. The [config generator](https://discordlogger.godtiergamers.xyz/generator/) runs entirely in your browser — it sends your webhook to Discord and nowhere else.
 - **Command logging posts commands verbatim**, which is why `/login`, `/register`, `/msg` and similar ship in `filters.ignored_commands` by default. Removing them publishes passwords and private messages to your channel.
-- **Anonymous metrics** are reported to [bStats](https://bstats.org/plugin/bukkit/DiscordLogger/33026): config schema version, release channel, whether embeds are on, and which event types are enabled — alongside the server/Java/plugin version data bStats collects for every plugin. No webhook URLs, player names, or message content. Local development builds don't report at all. Opt out in `plugins/bStats/config.yml`, which switches it off for every bStats plugin on the server at once.
+- **Anonymous metrics** are reported to [bStats](https://bstats.org/plugin/bukkit/DiscordLogger/33026): config schema version, release channel, whether embeds are on, and which event types are enabled — alongside the server/Java/plugin version data bStats collects for every plugin. No webhook URLs, player names, or message content. Builds compiled from source report too, tagged as such, so the totals aren't quietly understated. Opt out in `plugins/bStats/config.yml`, which switches it off for every bStats plugin on the server at once.
 
 ---
 

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -137,11 +137,16 @@ without permission doesn't appear.
 `PLUGIN` to `filters.ignored_teleport_causes` if you use Essentials, since `/home`,
 `/warp` and `/spawn` all arrive that way.
 
-**The plugin reports anonymous metrics** to [bStats](https://bstats.org/plugin/bukkit/DiscordLogger/33026):
-which config schema you're on, your release channel, whether embeds are enabled, and
-which event types are switched on — plus the server, Java and plugin versions bStats
-collects for every plugin. No webhook URLs, no player names, no message content. Turn
-it off in `plugins/bStats/config.yml`, which covers every bStats plugin at once.
+**The plugin reports anonymous metrics** to [bStats](https://bstats.org/plugin/bukkit/DiscordLogger/33026).
+They describe your *setup*, never your players: server and Java version, online or
+offline mode, whether you run behind a proxy, which companion plugins are installed,
+which events and filters you've changed from the defaults, whether you edited
+`lang.yml`, and where your config came from.
+
+Never collected: webhook URLs, player names, UUIDs, IP addresses, message content,
+coordinates, or world names. Counts are reported as ranges rather than exact numbers.
+
+Turn it off in `plugins/bStats/config.yml`, which covers every bStats plugin at once.
 
 ---
 

--- a/src/main/java/com/discordlogger/metrics/PluginMetrics.java
+++ b/src/main/java/com/discordlogger/metrics/PluginMetrics.java
@@ -2,15 +2,24 @@ package com.discordlogger.metrics;
 
 import com.discordlogger.update.BuildInfo;
 import org.bstats.bukkit.Metrics;
+import org.bstats.charts.AdvancedPie;
+import org.bstats.charts.DrilldownPie;
 import org.bstats.charts.SimplePie;
+import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -20,19 +29,33 @@ import java.util.regex.Pattern;
  * <p>Opting out is handled by bStats itself through {@code plugins/bStats/config.yml},
  * which covers every bStats plugin on the server at once — that's where admins
  * already expect the switch to be, so this plugin deliberately adds no config key
- * of its own. (A key would also open config schema v10, which should be opened by
- * a deliberate schema change rather than by metrics.)
+ * of its own.
  *
- * <p>The charts exist to answer questions that actually change decisions:
+ * <h2>What is measured, and what is not</h2>
+ *
+ * <p>Every chart here reports <b>configuration state, plugin presence, or server
+ * software</b>. Nothing reports a player. No names, no UUIDs, no IP addresses, no
+ * message content, no coordinates, no world names. The question these answer is
+ * "what do people do with this plugin", never "who is on this server".
+ *
+ * <p>Values are deliberately <b>booleans and buckets rather than counts</b> wherever
+ * a count would work. "Two filters differ from default" answers the question;
+ * "47 chat messages filtered this hour" starts describing a specific community's
+ * behaviour without naming anyone. The first is measurement, the second is residue.
+ *
+ * <h2>Why each group exists</h2>
  * <ul>
- *   <li><b>Config schema</b> — when is it safe to stop supporting an old schema?
- *       The generator freezes a bundle per schema forever, so this is the number
- *       that says whether anyone would notice.</li>
- *   <li><b>Release channel</b> — is the nightly channel used enough to be worth
- *       maintaining?</li>
- *   <li><b>Output mode</b> — embeds vs plain text, i.e. where formatting effort
- *       is worth spending.</li>
- *   <li><b>Enabled events</b> — which log types are actually switched on.</li>
+ *   <li><b>Environment</b> — which server software, Minecraft version and schema
+ *       combinations exist in the wild. The schema one decides when a frozen
+ *       generator bundle can finally be retired.</li>
+ *   <li><b>Companion plugins</b> — whether the integrations being considered
+ *       (proxy support, PlaceholderAPI, punishment plugins, vanish) have an
+ *       audience, and how many servers are silently getting nothing from
+ *       moderation logging because their punishments bypass the vanilla ban list.</li>
+ *   <li><b>Feature usage</b> — which of the fourteen filters, the routing, and the
+ *       language file are actually used, versus shipped and ignored.</li>
+ *   <li><b>Config lifecycle</b> — did setup ever complete, was the config built by
+ *       the website generator, and which old schema did it migrate from.</li>
  * </ul>
  */
 public final class PluginMetrics {
@@ -43,35 +66,227 @@ public final class PluginMetrics {
     private static final Pattern SCHEMA_RE =
             Pattern.compile("CONFIG\\s+VERSION\\s+(V\\d+)", Pattern.CASE_INSENSITIVE);
 
+    private static final String YES = "Yes";
+    private static final String NO = "No";
+    private static final String UNKNOWN = "Unknown";
+
+    /**
+     * Punishment plugins that keep their own database instead of Bukkit's ban list.
+     * On a server running any of these, the moderation listeners verify a ban by
+     * checking {@code Bukkit.getBanList()}, find nothing, and log nothing — so this
+     * chart measures how many installs silently get no moderation logging at all.
+     */
+    private static final List<String> PUNISHMENT_PLUGINS =
+            List.of("LiteBans", "LibertyBans", "AdvancedBan", "BanManager", "CMI");
+
+    /** Vanish implementations. A vanished admin joining is currently announced anyway. */
+    private static final List<String> VANISH_PLUGINS =
+            List.of("PremiumVanish", "SuperVanish", "Essentials", "CMI");
+
     private PluginMetrics() {}
 
     /** Call once from onEnable, after {@link BuildInfo#load}. */
     public static void start(JavaPlugin plugin) {
-        // Source builds DO report, and the release_channel chart separates them as
-        // "dev". They used to be excluded on the theory that a developer's machine
-        // would skew every chart, but that reasoning does not survive contact with
-        // how bStats identifies a server: the id lives in plugins/bStats/config.yml,
-        // per server directory, so fifty rebuild-and-restart cycles against one test
-        // server are one server, not fifty. Excluding them instead understated the
-        // server count and made "how many people build from source" unanswerable --
-        // a question that can only be answered by counting.
-        //
-        // The cost is real but small: a test server with deliberately odd settings
-        // lands in the config-shaped charts like any other unusual server. Filtering
-        // by channel is what that chart is for.
-
+        // Source builds DO report, and release_channel separates them as "dev".
+        // They used to be excluded on the theory that a developer's machine would
+        // skew every chart, but bStats identifies a server by an id in
+        // plugins/bStats/config.yml — per server directory — so fifty rebuild cycles
+        // against one test server are one server, not fifty. Excluding them only
+        // understated the totals and made "how many build from source" unanswerable.
         try {
             final Metrics metrics = new Metrics(plugin, PLUGIN_ID);
 
-            metrics.addCustomChart(new SimplePie("config_schema", () -> configSchema(plugin)));
+            // ---------------------------------------------------------------- environment
             metrics.addCustomChart(new SimplePie("release_channel", BuildInfo::channel));
+            metrics.addCustomChart(new SimplePie("server_fork", PluginMetrics::serverFork));
+            metrics.addCustomChart(new SimplePie("config_schema", () -> configSchema(plugin)));
+            metrics.addCustomChart(new DrilldownPie("mc_version_by_schema",
+                    () -> drilldown(minecraftVersion(), configSchema(plugin))));
+            metrics.addCustomChart(new DrilldownPie("mc_version_by_java",
+                    () -> drilldown(minecraftVersion(), javaMajor())));
+
+            // ----------------------------------------------------------- companion plugins
+            metrics.addCustomChart(new SimplePie("proxy_mode", PluginMetrics::proxyMode));
+            metrics.addCustomChart(new SimplePie("online_mode",
+                    () -> Bukkit.getOnlineMode() ? "Online" : "Offline"));
+            metrics.addCustomChart(new SimplePie("floodgate",
+                    () -> present(installed("floodgate") || installed("Geyser-Spigot"))));
+            metrics.addCustomChart(new SimplePie("placeholderapi",
+                    () -> present(installed("PlaceholderAPI"))));
+            metrics.addCustomChart(new SimplePie("coreprotect",
+                    () -> present(installed("CoreProtect"))));
+            metrics.addCustomChart(new SimplePie("punishment_plugin",
+                    () -> firstInstalled(PUNISHMENT_PLUGINS)));
+            metrics.addCustomChart(new SimplePie("vanish_plugin",
+                    () -> firstInstalled(VANISH_PLUGINS)));
+
+            // -------------------------------------------------------------- config health
+            metrics.addCustomChart(new SimplePie("webhook_configured",
+                    () -> present(isWebhookSet(plugin))));
+            metrics.addCustomChart(new SimplePie("config_origin", () -> configOrigin(plugin)));
+            metrics.addCustomChart(new SimplePie("migrated_from", () -> migratedFrom(plugin)));
+            metrics.addCustomChart(new SimplePie("config_ahead_of_build",
+                    () -> yesNo(configAheadOfBuild(plugin))));
+
+            // -------------------------------------------------------------- feature usage
             metrics.addCustomChart(new SimplePie("output_mode", () ->
                     plugin.getConfig().getBoolean("embeds.enabled", true) ? "Embeds" : "Plain text"));
-            metrics.addCustomChart(new org.bstats.charts.AdvancedPie("enabled_events", () -> enabledEvents(plugin)));
+            metrics.addCustomChart(new AdvancedPie("enabled_events", () -> enabledEvents(plugin)));
+            metrics.addCustomChart(new AdvancedPie("enabled_options", () -> enabledOptions(plugin)));
+            metrics.addCustomChart(new SimplePie("colors_customised",
+                    () -> yesNo(anyDiffers(plugin, "log", "color"))));
+            metrics.addCustomChart(new SimplePie("routing_used", () -> routingUsed(plugin)));
+            metrics.addCustomChart(new AdvancedPie("routed_events", () -> routedEvents(plugin)));
+            metrics.addCustomChart(new AdvancedPie("filters_modified", () -> filtersModified(plugin)));
+            metrics.addCustomChart(new SimplePie("command_filter_state",
+                    () -> commandFilterState(plugin)));
+
+            // ---------------------------------------------------------------- lang.yml
+            metrics.addCustomChart(new SimplePie("lang_customised",
+                    () -> yesNo(langChanged(plugin) > 0)));
+            metrics.addCustomChart(new SimplePie("lang_keys_changed",
+                    () -> bucket(langChanged(plugin))));
+            metrics.addCustomChart(new AdvancedPie("lang_sections_changed",
+                    () -> langSectionsChanged(plugin)));
 
         } catch (Throwable t) {
             // Metrics must never be the reason a server fails to start.
             plugin.getLogger().fine("Metrics could not start: " + t.getMessage());
+        }
+    }
+
+    // ------------------------------------------------------------------ environment
+
+    /**
+     * The server implementation name — Paper, Purpur, Pufferfish, Leaf, and so on.
+     *
+     * <p>bStats reports "Server Software" already, but forks frequently identify as
+     * their upstream there. Issue #161 arrived from Leaf, which is exactly the kind
+     * of fork that would otherwise be invisible.
+     */
+    private static String serverFork() {
+        try {
+            final String name = Bukkit.getName();
+            return (name == null || name.isBlank()) ? UNKNOWN : name;
+        } catch (Throwable t) {
+            return UNKNOWN;
+        }
+    }
+
+    /** "1.21.11" from whatever shape this server reports its version in. */
+    private static String minecraftVersion() {
+        try {
+            final Matcher m = Pattern.compile("\\(MC: ([^)]+)\\)").matcher(Bukkit.getVersion());
+            if (m.find()) return m.group(1).trim();
+            return Bukkit.getBukkitVersion().split("-")[0];
+        } catch (Throwable t) {
+            return UNKNOWN;
+        }
+    }
+
+    private static String javaMajor() {
+        try {
+            final String v = System.getProperty("java.version", "");
+            final String major = v.startsWith("1.") ? v.substring(2, 3) : v.split("[.\\-+]")[0];
+            return major.isBlank() ? UNKNOWN : major;
+        } catch (Throwable t) {
+            return UNKNOWN;
+        }
+    }
+
+    // ----------------------------------------------------------- companion plugins
+
+    private static boolean installed(String name) {
+        try {
+            return Bukkit.getPluginManager().getPlugin(name) != null;
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    /** The first of {@code names} that is installed, or "None". */
+    private static String firstInstalled(List<String> names) {
+        for (String n : names) {
+            if (installed(n)) return n;
+        }
+        return "None";
+    }
+
+    /**
+     * Whether this backend sits behind a proxy.
+     *
+     * <p>Worth having as its own chart because {@code online_mode} alone cannot
+     * distinguish a proxied backend from a Geyser server or a cracked one — all
+     * three run offline. Crossed against floodgate, the offline population resolves.
+     */
+    private static String proxyMode() {
+        try {
+            if (Bukkit.spigot().getConfig().getBoolean("settings.bungeecord", false)) {
+                return "BungeeCord or Velocity";
+            }
+            final File paperGlobal = new File("config/paper-global.yml");
+            if (paperGlobal.isFile()) {
+                final YamlConfiguration y = YamlConfiguration.loadConfiguration(paperGlobal);
+                if (y.getBoolean("proxies.velocity.enabled", false)) return "Velocity";
+                if (y.getBoolean("proxies.bungee-cord.online-mode", false)) return "BungeeCord";
+            }
+            return "None";
+        } catch (Throwable t) {
+            return UNKNOWN;
+        }
+    }
+
+    // --------------------------------------------------------------- config health
+
+    private static boolean isWebhookSet(JavaPlugin plugin) {
+        final String url = plugin.getConfig().getString("webhook.url", "");
+        return url != null && url.startsWith("https://");
+    }
+
+    /**
+     * Where this config came from, read from the trailer the file carries: shipped
+     * with the JAR, built by the website generator, or downloaded whole from the
+     * docs site. The only measure of whether the generator earns its keep.
+     */
+    private static String configOrigin(JavaPlugin plugin) {
+        final String trailer = trailerOf(new File(plugin.getDataFolder(), "config.yml"));
+        if (trailer == null) return UNKNOWN;
+        final String t = trailer.toUpperCase();
+        if (t.contains("GENERATED ON WEBSITE")) return "Website generator";
+        if (t.contains("DOWNLOADED FROM WEBSITE")) return "Website download";
+        if (t.contains("SHIPPED WITH")) return "Shipped with plugin";
+        return UNKNOWN;
+    }
+
+    /**
+     * The schema the previous config was on, read from the backup the migrator
+     * leaves behind. Says which old schemas are still being upgraded from, which is
+     * what decides when a frozen generator bundle can stop being maintained.
+     */
+    private static String migratedFrom(JavaPlugin plugin) {
+        final File old = new File(plugin.getDataFolder(), "config.old.yml");
+        if (!old.isFile()) return "Never migrated";
+        final String schema = schemaIn(old);
+        return schema == null ? UNKNOWN : schema;
+    }
+
+    /** A config newer than the running build — i.e. someone downgraded the plugin. */
+    private static boolean configAheadOfBuild(JavaPlugin plugin) {
+        try {
+            final String onDisk = configSchema(plugin);
+            final String shipped = shippedSchema(plugin);
+            if (onDisk == null || shipped == null) return false;
+            return schemaNumber(onDisk) > schemaNumber(shipped);
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    private static int schemaNumber(String v) {
+        try {
+            return Integer.parseInt(v.replaceAll("\\D", ""));
+        } catch (Exception e) {
+            return -1;
         }
     }
 
@@ -81,16 +296,45 @@ public final class PluginMetrics {
      * into a migration yet, and the on-disk value is the one worth measuring.
      */
     private static String configSchema(JavaPlugin plugin) {
-        try {
-            final File file = new File(plugin.getDataFolder(), "config.yml");
-            if (!file.isFile()) return "Unknown";
-            final String text = Files.readString(file.toPath(), StandardCharsets.UTF_8);
-            final Matcher m = SCHEMA_RE.matcher(text);
-            return m.find() ? m.group(1).toUpperCase() : "Unknown";
+        final String s = schemaIn(new File(plugin.getDataFolder(), "config.yml"));
+        return s == null ? UNKNOWN : s;
+    }
+
+    private static String shippedSchema(JavaPlugin plugin) {
+        try (InputStream in = plugin.getResource("config.yml")) {
+            if (in == null) return null;
+            final Matcher m = SCHEMA_RE.matcher(new String(in.readAllBytes(), StandardCharsets.UTF_8));
+            return m.find() ? m.group(1).toUpperCase() : null;
         } catch (Exception e) {
-            return "Unknown";
+            return null;
         }
     }
+
+    private static String schemaIn(File file) {
+        try {
+            if (!file.isFile()) return null;
+            final Matcher m = SCHEMA_RE.matcher(Files.readString(file.toPath(), StandardCharsets.UTF_8));
+            return m.find() ? m.group(1).toUpperCase() : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String trailerOf(File file) {
+        try {
+            if (!file.isFile()) return null;
+            final List<String> lines = Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
+            for (int i = lines.size() - 1; i >= 0; i--) {
+                final String line = lines.get(i).trim();
+                if (!line.isEmpty()) return line;
+            }
+            return null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    // --------------------------------------------------------------- feature usage
 
     /**
      * Every enabled {@code log.<category>.<event>} toggle, counted once each.
@@ -99,25 +343,213 @@ public final class PluginMetrics {
      */
     private static Map<String, Integer> enabledEvents(JavaPlugin plugin) {
         final Map<String, Integer> counts = new HashMap<>();
-        final ConfigurationSection log = plugin.getConfig().getConfigurationSection("log");
-        if (log == null) return counts;
+        forEachEvent(plugin, (path, section) -> {
+            final boolean on = section != null && section.getBoolean("enabled", false);
+            if (on) counts.put(path, 1);
+        });
+        return counts;
+    }
 
+    /** Per-event sub-options, plus the format toggles that sit outside {@code log}. */
+    private static Map<String, Integer> enabledOptions(JavaPlugin plugin) {
+        final Map<String, Integer> counts = new HashMap<>();
+        if (plugin.getConfig().getBoolean("log.player.death.show_coords", false)) {
+            counts.put("death coordinates", 1);
+        }
+        if (plugin.getConfig().getBoolean("log.player.join.show_platform", true)) {
+            counts.put("Bedrock indicator", 1);
+        }
+        if (plugin.getConfig().getBoolean("format.nicknames", true)) {
+            counts.put("nicknames", 1);
+        }
+        return counts;
+    }
+
+    /** How many distinct destinations this server splits its logs across. */
+    private static String routingUsed(JavaPlugin plugin) {
+        final int extra = routedEvents(plugin).size();
+        if (extra == 0) return "One webhook";
+        if (extra <= 2) return "Two or three webhooks";
+        return "Four or more webhooks";
+    }
+
+    /** Which events carry their own webhook. The URLs themselves are never read. */
+    private static Map<String, Integer> routedEvents(JavaPlugin plugin) {
+        final Map<String, Integer> counts = new HashMap<>();
+        forEachEvent(plugin, (path, section) -> {
+            final String hook = section == null ? null : section.getString("webhook", "");
+            if (hook != null && !hook.isBlank()) counts.put(path, 1);
+        });
+        return counts;
+    }
+
+    /** Which filters differ from what the plugin ships — never their contents. */
+    private static Map<String, Integer> filtersModified(JavaPlugin plugin) {
+        final Map<String, Integer> counts = new HashMap<>();
+        final YamlConfiguration bundled = bundledConfig(plugin);
+        final ConfigurationSection live = plugin.getConfig().getConfigurationSection("filters");
+        if (bundled == null || live == null) return counts;
+
+        for (String key : live.getKeys(false)) {
+            final Object mine = live.get(key);
+            final Object theirs = bundled.get("filters." + key);
+            if (!Objects.equals(String.valueOf(mine), String.valueOf(theirs))) {
+                counts.put(key, 1);
+            }
+        }
+        return counts;
+    }
+
+    /**
+     * Whether the command deny-list still protects what it ships to protect.
+     *
+     * <p>{@code /login}, {@code /register} and {@code /msg} are in it by default
+     * because command logging posts the line exactly as typed. A server that has
+     * emptied or shortened that list is publishing passwords and private messages
+     * to Discord, and this is the only way to find out how often that happens.
+     */
+    private static String commandFilterState(JavaPlugin plugin) {
+        final YamlConfiguration bundled = bundledConfig(plugin);
+        if (bundled == null) return UNKNOWN;
+        final List<String> mine = plugin.getConfig().getStringList("filters.ignored_commands");
+        final List<String> theirs = bundled.getStringList("filters.ignored_commands");
+
+        return commandFilterState(mine, theirs);
+    }
+
+    /**
+     * The classification itself, split out so it can be tested without a server.
+     *
+     * <p>"Reduced" is the answer that matters: it means at least one command the
+     * plugin ships in the deny-list has been taken out, and command logging posts
+     * lines exactly as typed. Getting this backwards would hide the single case
+     * worth knowing about.
+     */
+    static String commandFilterState(List<String> mine, List<String> shipped) {
+        if (mine == null || mine.isEmpty()) return "Emptied";
+        if (shipped == null || shipped.isEmpty()) return UNKNOWN;
+        if (!mine.containsAll(shipped)) return "Reduced";
+        return mine.size() > shipped.size() ? "Extended" : "Default";
+    }
+
+    /** True when any {@code log.*.*.<leaf>} differs from the shipped default. */
+    private static boolean anyDiffers(JavaPlugin plugin, String root, String leaf) {
+        final YamlConfiguration bundled = bundledConfig(plugin);
+        if (bundled == null) return false;
+        final boolean[] differs = {false};
+        forEachEvent(plugin, (path, section) -> {
+            if (differs[0] || section == null) return;
+            final Object mine = section.get(leaf);
+            final Object theirs = bundled.get(root + "." + path + "." + leaf);
+            if (mine != null && !Objects.equals(String.valueOf(mine), String.valueOf(theirs))) {
+                differs[0] = true;
+            }
+        });
+        return differs[0];
+    }
+
+    // -------------------------------------------------------------------- lang.yml
+
+    /** How many messages differ from the shipped wording. Never which text. */
+    private static int langChanged(JavaPlugin plugin) {
+        return langDiff(plugin).size();
+    }
+
+    /** Which top-level sections were reworded — chat, discord, or the death causes. */
+    private static Map<String, Integer> langSectionsChanged(JavaPlugin plugin) {
+        final Map<String, Integer> counts = new LinkedHashMap<>();
+        for (String key : langDiff(plugin)) {
+            counts.merge(langSection(key), 1, Integer::sum);
+        }
+        return counts;
+    }
+
+    /** Which part of lang.yml a key belongs to. Split out to be testable. */
+    static String langSection(String key) {
+        if (key == null) return "other";
+        if (key.startsWith("discord.death.causes.")) return "death causes";
+        if (key.startsWith("discord.death.")) return "death embed";
+        if (key.startsWith("discord.")) return "discord";
+        if (key.startsWith("chat.")) return "chat";
+        return "other";
+    }
+
+    /** The set of lang keys whose value differs from the bundled default. */
+    private static List<String> langDiff(JavaPlugin plugin) {
+        final List<String> changed = new java.util.ArrayList<>();
+        try {
+            final File onDisk = new File(plugin.getDataFolder(), "lang.yml");
+            if (!onDisk.isFile()) return changed;
+            final YamlConfiguration mine = YamlConfiguration.loadConfiguration(onDisk);
+            final YamlConfiguration theirs = bundledYaml(plugin, "lang.yml");
+            if (theirs == null) return changed;
+
+            for (String key : theirs.getKeys(true)) {
+                if (theirs.isConfigurationSection(key)) continue;
+                if (key.equals("config-version")) continue;
+                if (!Objects.equals(mine.get(key), theirs.get(key))) changed.add(key);
+            }
+        } catch (Throwable ignored) {
+            // A malformed lang.yml is the user's problem, not a reason to fail metrics.
+        }
+        return changed;
+    }
+
+    // ---------------------------------------------------------------------- shared
+
+    private interface EventVisitor {
+        void accept(String path, ConfigurationSection section);
+    }
+
+    /** Walks {@code log.<category>.<event>}, handing each one its section. */
+    private static void forEachEvent(JavaPlugin plugin, EventVisitor visitor) {
+        final ConfigurationSection log = plugin.getConfig().getConfigurationSection("log");
+        if (log == null) return;
         for (String category : log.getKeys(false)) {
             final ConfigurationSection section = log.getConfigurationSection(category);
             if (section == null) continue;
             for (String event : section.getKeys(false)) {
-                // Schema v10 made each event a section (enabled + color); older
-                // shapes stored a bare boolean. Read both so a config that failed
-                // to migrate still reports something truthful.
-                final ConfigurationSection eventSec = section.getConfigurationSection(event);
-                final boolean on = eventSec != null
-                        ? eventSec.getBoolean("enabled", false)
-                        : section.getBoolean(event, false);
-                if (on) {
-                    counts.put(category + "." + event, 1);
-                }
+                visitor.accept(category + "." + event, section.getConfigurationSection(event));
             }
         }
-        return counts;
+    }
+
+    private static YamlConfiguration bundledConfig(JavaPlugin plugin) {
+        return bundledYaml(plugin, "config.yml");
+    }
+
+    private static YamlConfiguration bundledYaml(JavaPlugin plugin, String resource) {
+        try (InputStream in = plugin.getResource(resource)) {
+            if (in == null) return null;
+            return YamlConfiguration.loadConfiguration(
+                    new InputStreamReader(in, StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static Map<String, Map<String, Integer>> drilldown(String outer, String inner) {
+        final Map<String, Map<String, Integer>> map = new HashMap<>();
+        final Map<String, Integer> entry = new HashMap<>();
+        entry.put(inner, 1);
+        map.put(outer, entry);
+        return map;
+    }
+
+    private static String present(boolean b) {
+        return b ? "Installed" : "Not installed";
+    }
+
+    private static String yesNo(boolean b) {
+        return b ? YES : NO;
+    }
+
+    /** Buckets rather than an exact count — the shape of the answer, not a fingerprint. */
+    static String bucket(int n) {
+        if (n == 0) return "None";
+        if (n <= 5) return "1-5";
+        if (n <= 20) return "6-20";
+        if (n <= 50) return "21-50";
+        return "50+";
     }
 }

--- a/src/main/java/com/discordlogger/metrics/PluginMetrics.java
+++ b/src/main/java/com/discordlogger/metrics/PluginMetrics.java
@@ -47,12 +47,18 @@ public final class PluginMetrics {
 
     /** Call once from onEnable, after {@link BuildInfo#load}. */
     public static void start(JavaPlugin plugin) {
-        // A developer's local build would otherwise show up as a real server and
-        // skew every chart. Only shipped artifacts report.
-        if (BuildInfo.isDev()) {
-            plugin.getLogger().fine("Metrics disabled for a local/dev build.");
-            return;
-        }
+        // Source builds DO report, and the release_channel chart separates them as
+        // "dev". They used to be excluded on the theory that a developer's machine
+        // would skew every chart, but that reasoning does not survive contact with
+        // how bStats identifies a server: the id lives in plugins/bStats/config.yml,
+        // per server directory, so fifty rebuild-and-restart cycles against one test
+        // server are one server, not fifty. Excluding them instead understated the
+        // server count and made "how many people build from source" unanswerable --
+        // a question that can only be answered by counting.
+        //
+        // The cost is real but small: a test server with deliberately odd settings
+        // lands in the config-shaped charts like any other unusual server. Filtering
+        // by channel is what that chart is for.
 
         try {
             final Metrics metrics = new Metrics(plugin, PLUGIN_ID);

--- a/src/test/java/com/discordlogger/metrics/PluginMetricsTest.java
+++ b/src/test/java/com/discordlogger/metrics/PluginMetricsTest.java
@@ -1,0 +1,116 @@
+package com.discordlogger.metrics;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * The decisions inside the metrics that are worth being sure about.
+ *
+ * <p>Most of this class reads Bukkit state and cannot be exercised without a
+ * server. These three can, and they are the ones where a wrong answer would
+ * matter: a misclassified command filter hides the case worth knowing about, an
+ * exact count where a bucket belongs is a privacy regression rather than a bug,
+ * and a lang key falling into the wrong section quietly makes a chart lie.
+ */
+class PluginMetricsTest {
+
+    // ---------------------------------------------------------- command filter
+
+    private static final List<String> SHIPPED =
+            List.of("login", "register", "changepassword", "unregister",
+                    "msg", "tell", "whisper", "w", "r", "reply");
+
+    @Test
+    @DisplayName("an untouched deny-list reads as Default")
+    void defaultList() {
+        assertEquals("Default", PluginMetrics.commandFilterState(SHIPPED, SHIPPED));
+    }
+
+    @Test
+    @DisplayName("adding commands reads as Extended, not Reduced")
+    void extendedList() {
+        final List<String> mine = new java.util.ArrayList<>(SHIPPED);
+        mine.add("vote");
+        assertEquals("Extended", PluginMetrics.commandFilterState(mine, SHIPPED));
+    }
+
+    @Test
+    @DisplayName("removing a shipped command reads as Reduced — the case that matters")
+    void reducedList() {
+        // This is the whole point of the chart. /login is in the deny-list because
+        // command logging posts the line exactly as typed; taking it out publishes
+        // passwords to Discord. Reporting that as anything else would hide it.
+        final List<String> mine = new java.util.ArrayList<>(SHIPPED);
+        mine.remove("login");
+        assertEquals("Reduced", PluginMetrics.commandFilterState(mine, SHIPPED));
+    }
+
+    @Test
+    @DisplayName("a list that is longer but missing a shipped entry is still Reduced")
+    void reducedBeatsExtended() {
+        // Size alone must not decide it: someone can add five commands and remove
+        // /login, and the removal is the part worth reporting.
+        final List<String> mine = new java.util.ArrayList<>(SHIPPED);
+        mine.remove("login");
+        mine.addAll(List.of("vote", "buy", "shop", "kit", "warp"));
+        assertNotEquals("Extended", PluginMetrics.commandFilterState(mine, SHIPPED));
+        assertEquals("Reduced", PluginMetrics.commandFilterState(mine, SHIPPED));
+    }
+
+    @Test
+    @DisplayName("an emptied list is called Emptied, not Reduced")
+    void emptiedList() {
+        assertEquals("Emptied", PluginMetrics.commandFilterState(List.of(), SHIPPED));
+        assertEquals("Emptied", PluginMetrics.commandFilterState(null, SHIPPED));
+    }
+
+    // ------------------------------------------------------------------ buckets
+
+    @Test
+    @DisplayName("counts are reported as ranges, never as the number itself")
+    void bucketsNeverLeakTheCount() {
+        assertEquals("None", PluginMetrics.bucket(0));
+        assertEquals("1-5", PluginMetrics.bucket(1));
+        assertEquals("1-5", PluginMetrics.bucket(5));
+        assertEquals("6-20", PluginMetrics.bucket(6));
+        assertEquals("6-20", PluginMetrics.bucket(20));
+        assertEquals("21-50", PluginMetrics.bucket(21));
+        assertEquals("50+", PluginMetrics.bucket(51));
+        assertEquals("50+", PluginMetrics.bucket(4_000));
+
+        // The guarantee, stated as a test: no bucket is ever the bare number, so a
+        // chart cannot become a fingerprint by accident.
+        for (int n : new int[]{1, 7, 33, 99}) {
+            assertNotEquals(String.valueOf(n), PluginMetrics.bucket(n),
+                    "bucket(" + n + ") returned the exact count");
+        }
+    }
+
+    // ------------------------------------------------------------ lang sections
+
+    @Test
+    @DisplayName("lang keys land in the section a reader would expect")
+    void langSections() {
+        assertEquals("chat", PluginMetrics.langSection("chat.reload-ok"));
+        assertEquals("discord", PluginMetrics.langSection("discord.player-join"));
+        assertEquals("death embed", PluginMetrics.langSection("discord.death.cause-field"));
+        assertEquals("death causes", PluginMetrics.langSection("discord.death.causes.fall"));
+        assertEquals("other", PluginMetrics.langSection("config-version"));
+        assertEquals("other", PluginMetrics.langSection(null));
+    }
+
+    @Test
+    @DisplayName("death causes are not swallowed by the broader discord prefix")
+    void deathCausesBeatDiscordPrefix() {
+        // Ordering trap: every death key also starts with "discord.", so a naive
+        // chain reports all 33 causes as plain "discord" and the chart loses the
+        // distinction it exists to draw.
+        assertNotEquals("discord", PluginMetrics.langSection("discord.death.causes.void"));
+        assertNotEquals("discord", PluginMetrics.langSection("discord.death.description"));
+    }
+}


### PR DESCRIPTION
Two things, in one branch because the second only makes sense once the first lands.

## 1. Source builds now report

They were excluded entirely (`if (BuildInfo.isDev()) return;`) on the theory that a developer's machine would skew every chart. That doesn't survive contact with how bStats identifies a server — **the id lives in `plugins/bStats/config.yml`, per server directory.** Fifty rebuild-and-restart cycles against one test server are *one* server. The inflation it guarded against doesn't happen.

What it did instead was understate the server count and make *"how many people build from source"* unanswerable. `release_channel` already reports `stable`/`nightly`/`dev`, so they were always separable — just absent.

The **update check** stays disabled for source builds. Different concern, and nagging someone about updates to code they're editing is noise.

## 2. Twenty-one new charts

| Group | Charts | Question it settles |
|---|---|---|
| Environment | server fork, MC×schema, MC×Java | When can a frozen generator bundle retire? Which forks exist? (#161 came from Leaf) |
| Companions | proxy mode, online mode, Floodgate, PlaceholderAPI, CoreProtect, punishment plugin, vanish plugin | Does Velocity have an audience? Is PlaceholderAPI worth building? **How many servers get no moderation logging at all** because their punishments bypass Bukkit's ban list? |
| Config health | webhook configured, config origin, migrated from, config ahead | Do installs finish? Is the generator used? |
| Feature usage | routing depth, routed events, filters modified, colours, sub-options, command filter state | Which of the fourteen filters earn their keep? |
| `lang.yml` | edited, how much, which sections | Does anyone customise messages? |

**`proxy_mode` earns its place next to `online_mode`** because offline alone can't separate a proxied backend from Geyser from cracked. Crossed with `floodgate`, the offline population resolves.

**`config_origin`** reads the trailer the file already carries (`SHIPPED WITH` vs `GENERATED ON WEBSITE`) — the only way to measure whether the generator is used.

## Privacy

Configuration state, plugin presence, server software. **Nothing reports a player** — no names, UUIDs, IPs, message content, coordinates, or world names.

**Counts are buckets, never exact numbers.** "Two filters differ from default" answers the question; an exact tally starts describing a specific community without naming anyone. There's a test asserting `bucket()` never returns the bare count.

## The one with teeth

`command_filter_state` reports **Reduced** when a command the plugin ships in the deny-list has been removed. `/login` and `/msg` are in there because command logging posts lines exactly as typed — a shortened list means passwords going to Discord.

Tested, including the trap where a *longer* list is still `Reduced`, because size must not decide it. Verified by mutation: disabling the check fails exactly the two tests that should.

198 tests green. README and setup guide updated — both enumerate what's collected, and that list had to grow.