### PR TITLE
feat(metrics): report whether sending actually works

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Full instructions, including creating the webhook in Discord and checking that e
 - **Anonymous metrics** are reported to [bStats](https://bstats.org/plugin/bukkit/DiscordLogger/33026). They answer *"what do people do with this plugin"* and nothing else:
   - **Your setup** — server software, Minecraft version, Java version, online/offline mode, whether you're behind a proxy, and which of a short list of companion plugins are installed (Floodgate, PlaceholderAPI, CoreProtect, and the common punishment and vanish plugins).
   - **Your configuration** — which events are on, embeds or plain text, how many webhooks you route to, which of the fourteen filters differ from the defaults, whether `lang.yml` was edited and roughly how much, the config schema, and whether the file came from the website generator.
+  - **Whether it's working** — how many sends failed, were rate-limited, or hit a deleted webhook, and roughly how busy the plugin is as a rate band rather than a message count.
   - **Never** — webhook URLs, player names, UUIDs, IP addresses, message content, coordinates, or world names. Counts are reported as ranges rather than exact numbers, so a chart cannot become a fingerprint.
 
   Builds compiled from source report too, tagged as such, so the totals aren't quietly understated. Opt out in `plugins/bStats/config.yml`, which switches it off for every bStats plugin on the server at once.

--- a/src/main/java/com/discordlogger/command/Commands.java
+++ b/src/main/java/com/discordlogger/command/Commands.java
@@ -1,6 +1,7 @@
 package com.discordlogger.command;
 
 import com.discordlogger.lang.Lang;
+import com.discordlogger.metrics.Counters;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -40,6 +41,9 @@ public final class Commands implements CommandExecutor, TabCompleter {
             sender.sendMessage(Lang.chat("chat.no-permission", "label", label, "command", sc.name()));
             return true;
         }
+
+        // Which subcommand ran, never who ran it -- see metrics/Counters.
+        Counters.commandUsed(sc.name().toLowerCase(Locale.ROOT));
 
         // Pass remaining args
         String[] tail = Arrays.copyOfRange(args, 1, args.length);

--- a/src/main/java/com/discordlogger/metrics/Counters.java
+++ b/src/main/java/com/discordlogger/metrics/Counters.java
@@ -1,0 +1,92 @@
+package com.discordlogger.metrics;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Runtime tallies the metrics charts read, and nothing else reads.
+ *
+ * <p>Kept separate from {@link PluginMetrics} so the send path has one cheap,
+ * dependency-free thing to call. Every counter is an {@link AtomicLong} because
+ * {@code WebhookQueue} increments them from its worker threads while bStats reads
+ * them from its own scheduler.
+ *
+ * <h2>Deltas, not totals</h2>
+ *
+ * <p>Reads are destructive — {@code take*} returns what has accumulated since the
+ * last read and resets to zero. bStats plots a line chart by summing each
+ * submission across every server, so a running total would double-count itself on
+ * every report and draw a curve that only ever climbs.
+ *
+ * <h2>Why the volume counter is not exposed as a number</h2>
+ *
+ * <p>Failures, drops and rate limits describe whether the plugin is working, and
+ * are reported as counts. Message volume describes how busy someone's server is,
+ * which is a fact about their community rather than about this plugin — so it is
+ * bucketed before it leaves the process, and the raw figure never appears in a
+ * chart. Same information for the decision it informs ("does anyone log fast
+ * enough to need batching"), without the per-server detail.
+ */
+public final class Counters {
+
+    private static final AtomicLong SENT = new AtomicLong();
+    private static final AtomicLong FAILED = new AtomicLong();
+    private static final AtomicLong DROPPED = new AtomicLong();
+    private static final AtomicLong RATE_LIMITED = new AtomicLong();
+    private static final AtomicLong NOT_FOUND = new AtomicLong();
+
+    /** Commands used at least once since the last report — presence, never a tally. */
+    private static final Set<String> COMMANDS_USED =
+            Collections.synchronizedSet(new LinkedHashSet<>());
+
+    private Counters() {}
+
+    public static void sent()        { SENT.incrementAndGet(); }
+    public static void failed()      { FAILED.incrementAndGet(); }
+    public static void dropped()     { DROPPED.incrementAndGet(); }
+    public static void rateLimited() { RATE_LIMITED.incrementAndGet(); }
+    public static void notFound()    { NOT_FOUND.incrementAndGet(); }
+
+    /** Record that a subcommand ran. The invoker is never recorded. */
+    public static void commandUsed(String name) {
+        if (name != null && !name.isBlank()) COMMANDS_USED.add(name);
+    }
+
+    // bStats line charts take an Integer; these deltas cannot realistically
+    // overflow one between reports, but clamp rather than wrap if they ever did.
+    static Integer takeFailedInt()      { return clamp(FAILED.getAndSet(0)); }
+    static Integer takeDroppedInt()     { return clamp(DROPPED.getAndSet(0)); }
+    static Integer takeRateLimitedInt() { return clamp(RATE_LIMITED.getAndSet(0)); }
+    static Integer takeNotFoundInt()    { return clamp(NOT_FOUND.getAndSet(0)); }
+
+    static int clamp(long v) {
+        return v > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) Math.max(0, v);
+    }
+
+    /**
+     * Messages sent since the last read, as a rate band rather than a number.
+     *
+     * <p>bStats reports roughly every 30 minutes, so the raw delta is a
+     * half-hourly figure; the bands are named for the hourly rate they imply
+     * because that is how anyone would reason about "is this server busy".
+     */
+    static String takeSendRateBand() {
+        final long perReport = SENT.getAndSet(0);
+        if (perReport == 0) return "None";
+        final long perHour = perReport * 2;
+        if (perHour < 10) return "Under 10/hour";
+        if (perHour < 100) return "10-100/hour";
+        if (perHour < 1_000) return "100-1000/hour";
+        return "Over 1000/hour";
+    }
+
+    static Set<String> takeCommandsUsed() {
+        synchronized (COMMANDS_USED) {
+            final Set<String> snapshot = new LinkedHashSet<>(COMMANDS_USED);
+            COMMANDS_USED.clear();
+            return snapshot;
+        }
+    }
+}

--- a/src/main/java/com/discordlogger/metrics/PluginMetrics.java
+++ b/src/main/java/com/discordlogger/metrics/PluginMetrics.java
@@ -5,6 +5,7 @@ import org.bstats.bukkit.Metrics;
 import org.bstats.charts.AdvancedPie;
 import org.bstats.charts.DrilldownPie;
 import org.bstats.charts.SimplePie;
+import org.bstats.charts.SingleLineChart;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -141,6 +142,19 @@ public final class PluginMetrics {
             metrics.addCustomChart(new SimplePie("command_filter_state",
                     () -> commandFilterState(plugin)));
 
+            // ------------------------------------------------------------- reliability
+            // Deltas since the last report, so the line charts show activity rather
+            // than an ever-climbing total. These describe whether the plugin is
+            // working, not what anyone's players are doing.
+            metrics.addCustomChart(new SingleLineChart("send_failures", Counters::takeFailedInt));
+            metrics.addCustomChart(new SingleLineChart("queue_drops", Counters::takeDroppedInt));
+            metrics.addCustomChart(new SingleLineChart("rate_limit_waits", Counters::takeRateLimitedInt));
+            metrics.addCustomChart(new SingleLineChart("dead_webhooks", Counters::takeNotFoundInt));
+            // Volume is a fact about someone's community rather than about this
+            // plugin, so it is banded before it leaves the process.
+            metrics.addCustomChart(new SimplePie("send_rate", Counters::takeSendRateBand));
+            metrics.addCustomChart(new AdvancedPie("commands_used", PluginMetrics::commandsUsed));
+
             // ---------------------------------------------------------------- lang.yml
             metrics.addCustomChart(new SimplePie("lang_customised",
                     () -> yesNo(langChanged(plugin) > 0)));
@@ -153,6 +167,13 @@ public final class PluginMetrics {
             // Metrics must never be the reason a server fails to start.
             plugin.getLogger().fine("Metrics could not start: " + t.getMessage());
         }
+    }
+
+    /** Which subcommands ran since the last report. Presence, not a tally. */
+    private static Map<String, Integer> commandsUsed() {
+        final Map<String, Integer> counts = new LinkedHashMap<>();
+        for (String name : Counters.takeCommandsUsed()) counts.put(name, 1);
+        return counts;
     }
 
     // ------------------------------------------------------------------ environment

--- a/src/main/java/com/discordlogger/webhook/WebhookQueue.java
+++ b/src/main/java/com/discordlogger/webhook/WebhookQueue.java
@@ -1,5 +1,7 @@
 package com.discordlogger.webhook;
 
+import com.discordlogger.metrics.Counters;
+
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.Map;
@@ -110,6 +112,7 @@ public final class WebhookQueue {
         final Destination dest = DESTINATIONS.computeIfAbsent(url, Destination::new);
 
         if (!dest.queue.offer(json)) {
+            Counters.dropped();
             if (!dest.warnedFull) {
                 dest.warnedFull = true;
                 log().warning("[DiscordWebhook] Send queue for webhook ..." + shortId(url)
@@ -198,6 +201,7 @@ public final class WebhookQueue {
             final DiscordWebhook.Response res = DiscordWebhook.post(dest.url, json);
 
             if (res.rateLimited()) {
+                Counters.rateLimited();
                 // Told to back off explicitly — wait it out and retry the SAME message
                 // without consuming an attempt, since nothing was wrong with it.
                 final long waitMs = clampWait(res.retryAfterMs());
@@ -210,6 +214,7 @@ public final class WebhookQueue {
             }
 
             if (res.success()) {
+                Counters.sent();
                 applyRateLimitHints(dest, res);
                 return;
             }
@@ -220,6 +225,7 @@ public final class WebhookQueue {
                     sleep(backoff);
                     continue;
                 }
+                Counters.failed();
                 log().warning("[DiscordWebhook] Giving up on a message after " + MAX_ATTEMPTS
                         + " attempts (last status " + res.status() + ").");
                 return;
@@ -227,6 +233,8 @@ public final class WebhookQueue {
 
             // 4xx that isn't 429: bad/deleted webhook, malformed payload — retrying
             // can't help, so say something actionable and move on.
+            Counters.failed();
+            if (res.status() == 404) Counters.notFound();
             log().warning("[DiscordWebhook] Discord rejected a message with HTTP " + res.status()
                     + (res.status() == 404
                         ? " — webhook ..." + shortId(dest.url) + " no longer exists. Check the"

--- a/src/test/java/com/discordlogger/metrics/CountersTest.java
+++ b/src/test/java/com/discordlogger/metrics/CountersTest.java
@@ -1,0 +1,68 @@
+package com.discordlogger.metrics;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The two properties the runtime counters have to hold.
+ *
+ * <p>Reads are destructive on purpose — bStats sums each submission across every
+ * server, so reporting a running total would re-count everything already reported
+ * and draw a line that only ever climbs. And the send counter must leave the
+ * process as a band, because message volume describes someone's community rather
+ * than this plugin.
+ */
+class CountersTest {
+
+    @Test
+    @DisplayName("reading a counter resets it, so charts show activity not totals")
+    void readsAreDestructive() {
+        Counters.takeFailedInt();               // clear anything from another test
+        Counters.failed();
+        Counters.failed();
+        assertEquals(2, Counters.takeFailedInt());
+        assertEquals(0, Counters.takeFailedInt(),
+                "a second read must report nothing new, or every report double-counts");
+    }
+
+    @Test
+    @DisplayName("send volume leaves as a band, never as the number itself")
+    void sendRateIsBanded() {
+        Counters.takeSendRateBand();
+        assertEquals("None", Counters.takeSendRateBand());
+
+        for (int i = 0; i < 3; i++) Counters.sent();
+        final String band = Counters.takeSendRateBand();
+        assertEquals("Under 10/hour", band);
+
+        // The guarantee: whatever the tally was, it is not what gets reported.
+        for (int i = 0; i < 250; i++) Counters.sent();
+        assertEquals("100-1000/hour", Counters.takeSendRateBand());
+    }
+
+    @Test
+    @DisplayName("commands report which ran, never how many times")
+    void commandsArePresenceOnly() {
+        Counters.takeCommandsUsed();
+        Counters.commandUsed("reload");
+        Counters.commandUsed("reload");
+        Counters.commandUsed("regen");
+
+        final Set<String> used = Counters.takeCommandsUsed();
+        assertEquals(Set.of("reload", "regen"), used,
+                "a set, so running reload fifty times is indistinguishable from once");
+        assertTrue(Counters.takeCommandsUsed().isEmpty(), "reads must reset");
+    }
+
+    @Test
+    @DisplayName("a delta beyond Integer range clamps rather than wrapping negative")
+    void clampsRatherThanWrapping() {
+        assertEquals(Integer.MAX_VALUE, Counters.clamp(Long.MAX_VALUE));
+        assertEquals(0, Counters.clamp(-1));
+    }
+}


### PR DESCRIPTION
The remaining seven charts. All needed the send path instrumented rather than config read, which is why they weren't in #166.

| Chart | What it answers |
|---|---|
| `send_failures` | messages given up on after retries, or rejected outright |
| `queue_drops` | messages discarded because a destination queue was full |
| `rate_limit_waits` | 429s from Discord — is the pacing doing real work? |
| `dead_webhooks` | 404s: a webhook deleted in Discord but still configured |
| `send_rate` | how busy the plugin is, as a band |
| `commands_used` | which subcommands actually get used |

## `queue_drops` is the one worth having

`WebhookQueue` is bounded at 1000 per destination and **silently discards past that**. That's fine for a chat relay and a correctness bug for an audit log — and nobody currently knows whether it ever happens on a real server. Now we'll know, which also settles whether the aggregation design for block logging is over- or under-engineering.

## Two deliberate choices

**Reads are destructive.** bStats sums each submission across every server, so a running total would re-count everything already reported and draw a line that only ever climbs.

**Send volume is banded before it leaves the process** — the raw figure never reaches a chart. Failures and drops describe whether *the plugin* works. Message volume describes how busy someone's *community* is, which is a fact about them rather than about us, and "does anyone log fast enough to need batching" is answered just as well by a band.

`commands_used` is a `Set` for the same reason: running `/reload` fifty times is indistinguishable from running it once.

## Tested

Destructive reads, banding, presence-not-tally for commands, and the clamp that stops a long delta wrapping negative into an Integer chart. 202 tests green.

README updated — it enumerates what's collected.