### PR TITLE
docs: add the three guides people actually search for

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -4,6 +4,9 @@
 - title: Setup
   url: /setup/
 
+- title: Guides
+  url: /guides/
+
 - title: Config Generator
   url: /generator/
 

--- a/docs/guides/discordsrv-alternative/index.md
+++ b/docs/guides/discordsrv-alternative/index.md
@@ -1,0 +1,112 @@
+---
+layout: default
+title: "DiscordSRV vs DiscordLogger — Which Do You Need?"
+description: DiscordSRV is a two-way chat bridge with a bot. DiscordLogger is one-way logging over a webhook. An honest comparison of what each does, and which one fits what you're actually trying to do.
+---
+
+# DiscordSRV vs DiscordLogger
+
+These get compared a lot, and they shouldn't really compete — they solve
+different problems and overlap on one feature. This page is here because
+"I only want the logging part" is a real thing people search for.
+
+**Short version:** if you want players chatting between Discord and Minecraft,
+use [DiscordSRV](https://www.spigotmc.org/resources/discordsrv.18494/). If you
+want a record of what happens on your server, in Discord, without running a bot,
+that's what [DiscordLogger](/) is for.
+
+---
+
+## What each one is
+
+**DiscordSRV** is a full Discord integration. It runs a bot, bridges chat in both
+directions, links Minecraft accounts to Discord accounts, syncs roles, and can
+run commands from Discord. It's mature, widely used, and the standard answer for
+Minecraft ↔ Discord integration.
+
+**DiscordLogger** posts server events to a Discord channel over a webhook. It
+sends; it never reads. No bot, no token, no account linking.
+
+---
+
+## Side by side
+
+| | DiscordLogger | DiscordSRV |
+|---|---|---|
+| Setup | One webhook URL | Bot application, invite, token |
+| Discord → Minecraft chat | ❌ | ✅ |
+| Minecraft → Discord chat | ✅ | ✅ |
+| Account linking / role sync | ❌ | ✅ |
+| Commands from Discord | ❌ | ✅ |
+| Moderation logging | ✅ every action, with who and why | Partial |
+| Per-event channel routing | ✅ any event to its own channel | Limited |
+| Deaths with cause and coordinates | ✅ | Basic |
+| Config migration between versions | ✅ automatic, comments preserved | Manual |
+| Browser config generator | ✅ | ❌ |
+| Every message customisable | ✅ `lang.yml` | Partial |
+
+---
+
+## Pick DiscordSRV if…
+
+- You want players to talk to each other across Discord and Minecraft
+- You want Discord roles tied to in-game ranks or purchases
+- You want staff to run commands from Discord
+- You want one plugin covering everything Discord-related
+
+It does all of that well and DiscordLogger does none of it.
+
+---
+
+## Pick DiscordLogger if…
+
+- You want an **audit trail**, not a chat room — who was banned, by whom, and why
+- You don't want to run a bot, manage a token, or register an application
+- You want **different events in different channels** — moderation somewhere
+  private, chat somewhere public
+- You want to filter aggressively: ignore specific commands, players, worlds,
+  teleport causes, death causes
+- You're on a **whitelisted, staff-run or managed server** where the question is
+  usually "who did that" rather than "what's everyone saying"
+
+---
+
+## Can you run both?
+
+Yes, and some people do — DiscordSRV for chat, DiscordLogger for the moderation
+audit trail in a private channel.
+
+The thing to watch is **double-posting chat**. If both are relaying player chat
+to Discord, turn chat off in one of them. In DiscordLogger that's one line:
+
+```yaml
+log:
+  player:
+    chat:
+      enabled: false
+```
+
+Everything else — moderation, deaths, explosions, server lifecycle — doesn't
+overlap.
+
+---
+
+## The honest summary
+
+DiscordSRV is a bigger, more capable plugin with far more users, and if you want
+a bridge you should use it.
+
+DiscordLogger is narrower on purpose. It does logging, and because that's all it
+does, it does it in more depth: every moderation action verified before it's
+logged, fourteen filters, per-event channels, and a config that migrates itself
+forward when you update.
+
+Not needing a bot isn't a limitation here — it's the point.
+
+---
+
+## Next
+
+- **[Setup guide](/setup/)** — five minutes, one webhook
+- **[Log to Discord without a bot](/guides/without-a-bot/)** — why a webhook is enough
+- **[Config generator](/generator/)** — build your config in the browser

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,30 @@
+---
+layout: default
+title: "Guides — Minecraft Discord Logging"
+description: Practical guides for logging a Minecraft server to Discord — running without a bot, choosing between DiscordLogger and DiscordSRV, and fixing a webhook that isn't posting.
+---
+
+# Guides
+
+Longer answers to the questions people actually arrive with.
+
+<div class="dl-cards">
+  <div class="dl-card">
+    <h3><a href="/guides/without-a-bot/">Log to Discord without a bot</a></h3>
+    <p>Most guides start by telling you to register a bot application. For logging you don't need one — and here's the honest trade-off of what a webhook can and can't do.</p>
+  </div>
+  <div class="dl-card">
+    <h3><a href="/guides/discordsrv-alternative/">DiscordSRV vs DiscordLogger</a></h3>
+    <p>They solve different problems and overlap on one feature. Which one fits what you're actually trying to do — and how to run both without double-posting.</p>
+  </div>
+  <div class="dl-card">
+    <h3><a href="/guides/webhook-not-posting/">Webhook not posting</a></h3>
+    <p>Events reach console but never Discord. The five causes, in order of likelihood, and how console tells you which one you have.</p>
+  </div>
+</div>
+
+## Also useful
+
+- **[Setup guide](/setup/)** — install to first message in about five minutes
+- **[Configuration reference](/config/)** — every key in `config.yml` and `lang.yml`
+- **[Config generator](/generator/)** — build both files in your browser

--- a/docs/guides/webhook-not-posting/index.md
+++ b/docs/guides/webhook-not-posting/index.md
@@ -1,0 +1,156 @@
+---
+layout: default
+title: "Discord Webhook Not Posting — How to Fix It"
+description: Your Minecraft server logs events to console but nothing appears in Discord. Work through the causes in order of likelihood, from a malformed URL to a deleted webhook to a host blocking outbound HTTPS.
+---
+
+# Discord webhook not posting
+
+Events show up in console but never reach Discord. Almost always one of five
+things, and console tells you which.
+
+**Start here:** does the event appear in your server console?
+
+- **Yes, but not in Discord** → the webhook is the problem. Work down this page.
+- **No, not even in console** → the event is switched off or filtered. Jump to
+  [nothing in console](#nothing-appears-in-console-either).
+
+That split matters because DiscordLogger logs every event to console whether or
+not Discord accepted it. If console is silent, Discord was never the issue.
+
+---
+
+## 1. The URL didn't save, or has stray characters
+
+The most common cause by a distance. Check `plugins/DiscordLogger/config.yml`:
+
+```yaml
+webhook:
+  url: "https://discord.com/api/webhooks/1234567890/AbCdEf…"
+```
+
+Things that break it:
+
+- **Stray quotes** — a URL pasted inside quotes that are already there
+- **A trailing space** before the closing quote
+- **A line break** in the middle, from a terminal that wrapped it
+- **The channel URL instead of the webhook URL.** `discord.com/channels/…` is the
+  page you were looking at. A webhook URL contains `/api/webhooks/`.
+
+Avoid the whole class of problem by setting it in game instead — nothing to edit
+and it reloads for you:
+
+```
+/discordlogger webhook https://discord.com/api/webhooks/…
+```
+
+---
+
+## 2. The webhook was deleted in Discord
+
+Console shows a **404**.
+
+Webhooks die when someone deletes them, or when the channel they belong to is
+deleted. The URL keeps its shape, so nothing looks wrong until you check.
+
+Recreate it: **Edit Channel → Integrations → Webhooks → New Webhook → Copy
+Webhook URL**, then set it again.
+
+---
+
+## 3. Your host is blocking outbound HTTPS
+
+Console shows a **timeout** rather than an error code.
+
+Some hosts firewall outbound connections by default. Discord's API is on
+`discord.com` over 443. If you can't reach it, nothing will help until that's
+opened — ask your host to allow outbound HTTPS.
+
+Quick check from the server box:
+
+```bash
+curl -I https://discord.com/api/webhooks
+```
+
+No response means it's the network, not the plugin.
+
+---
+
+## 4. The event is turned off
+
+Every event has its own toggle:
+
+```yaml
+log:
+  player:
+    join:
+      enabled: true
+```
+
+If `enabled` is `false`, nothing is sent and nothing is logged. The
+[configuration reference](/config/) lists all of them.
+
+---
+
+## 5. A filter is catching it
+
+This is the one people miss, because it looks identical to "broken".
+
+Some commands are filtered **by default** — `/login`, `/register`, `/msg` and
+similar — because command logging posts the line exactly as typed, which would
+publish passwords and private messages to your channel. That's deliberate.
+
+Other filters that silently suppress events:
+
+| Filter | Suppresses |
+|---|---|
+| `filters.ignored_players` | everything from those players |
+| `filters.exempt_permission` | everything from anyone holding it |
+| `filters.ignored_worlds` | everything in those worlds |
+| `filters.minimum_chat_length` | short chat messages |
+| `filters.ignored_teleport_causes` | teleports, including bed and dismount by default |
+| `filters.minimum_explosion_blocks` | small explosions |
+
+---
+
+## Nothing appears in console either
+
+Then it isn't the webhook. In order:
+
+1. **Is the plugin enabled?** `/plugins` should show DiscordLogger in green.
+2. **Did it fail to load?** Look for `Unsupported API version` — that means the
+   plugin is newer than your server. Check the
+   [supported versions](/downloads/).
+3. **Are you on Paper?** Spigot and CraftBukkit are not supported; the plugin
+   says so plainly on startup rather than failing with a stack trace.
+4. **Is the event filtered or disabled?** See above.
+
+---
+
+## Moderation events specifically
+
+Bans, kicks and op changes only log **when they actually succeeded**. A failed
+attempt from someone without permission doesn't appear — that's intended, so the
+channel is a record of what happened rather than what was attempted.
+
+Worth knowing: if you use a punishment plugin such as LiteBans or LibertyBans,
+those keep their own database rather than the vanilla ban list, so moderation
+logging may not detect them. That's a known gap rather than a misconfiguration.
+
+---
+
+## Still stuck
+
+Console is the source of truth — it always says what happened. If you're stuck,
+[open an issue](https://github.com/GodTierGamers/DiscordLogger/issues/new/choose)
+with the console output.
+
+**Redact your webhook URL first.** It's a credential, and an issue is public.
+
+---
+
+## Next
+
+- **[Setup guide](/setup/)** — from scratch, including creating the webhook
+- **[Configuration reference](/config/)** — every key explained
+- **[Config generator](/generator/)** — rebuild your config cleanly

--- a/docs/guides/without-a-bot/index.md
+++ b/docs/guides/without-a-bot/index.md
@@ -1,0 +1,119 @@
+---
+layout: default
+title: "Log Minecraft to Discord Without a Bot"
+description: You don't need a Discord bot to get server logs into Discord. A webhook does it with no token, no hosting, and no permissions to manage — here's how, and when a bot is genuinely the better choice.
+---
+
+# Log Minecraft to Discord without a bot
+
+Most guides for getting Minecraft server events into Discord start by telling you
+to create a bot application, invite it to your server, and keep a token secret
+forever. For **logging** — joins, chat, deaths, bans — none of that is necessary.
+
+A **webhook** does the same job with no bot, no token to rotate, no application to
+register, and no third-party service in the middle.
+
+---
+
+## Bot vs webhook, honestly
+
+| | Webhook | Bot |
+|---|---|---|
+| Setup | Copy a URL from a channel | Register an app, invite it, manage a token |
+| Posts to Discord | ✅ | ✅ |
+| Reads from Discord | ❌ | ✅ |
+| Two-way chat | ❌ | ✅ |
+| Account linking, roles | ❌ | ✅ |
+| Runs when your server is down | ❌ | ❌ |
+| Something extra to keep online | No | Sometimes |
+
+The line is simple: **a webhook can only send.** If everything you want is
+"things that happen on my server should appear in a Discord channel", that's all
+you need, and the bot is overhead you'll maintain forever for features you don't
+use.
+
+If you want players to chat *from* Discord *into* Minecraft, or link accounts to
+Discord roles, you need a bot — and [DiscordSRV](https://www.spigotmc.org/resources/discordsrv.18494/)
+is the mature, well-supported choice for that. It's a different tool, not a worse
+one.
+
+---
+
+## Why people assume they need a bot
+
+Three reasons, all understandable and all wrong for this use case:
+
+**Most tutorials are about chat bridges.** Two-way chat genuinely does need a bot,
+so that's what the popular guides cover — and logging gets treated as a feature of
+a bridge rather than a thing you can do on its own.
+
+**Webhooks look limited.** They are limited, deliberately. A webhook URL can post
+to exactly one channel and do nothing else. That constraint is the security
+feature: there's no token that can read your messages or manage your server.
+
+**"Bot" sounds more capable.** For sending messages it isn't. The same embed, the
+same colours, the same avatars — Discord renders a webhook message identically.
+
+---
+
+## What this looks like in practice
+
+[DiscordLogger](/) is a Paper plugin that does exactly this. One webhook URL and
+you're done:
+
+```
+/discordlogger webhook https://discord.com/api/webhooks/…
+```
+
+That's the whole setup. No application, no token, no invite, no permissions
+dialog. The plugin posts joins, quits, chat, commands, deaths, advancements,
+teleports, gamemode changes, server start and stop, explosions, and every
+moderation action — as rich embeds or plain text.
+
+**Each event can go to its own channel.** Moderation to a private staff channel,
+chat to a public one — because a webhook is per-channel, you just use more than
+one.
+
+The **[setup guide](/setup/)** walks through creating the webhook in Discord and
+checking that events arrive. The **[config generator](/generator/)** builds your
+whole configuration in the browser if you'd rather not edit YAML.
+
+---
+
+## What you give up
+
+Worth being straight about, because a page that only lists advantages isn't
+useful:
+
+- **No two-way chat.** Discord messages will not appear in game.
+- **No account linking or role sync.**
+- **No commands from Discord.** You can't run `/ban` from your phone.
+- **Nothing is logged while the server is down.** A webhook is pushed *by* your
+  server, so if it's offline, there's nothing to push. That's true of bots hosted
+  on the same machine too.
+
+If none of those matter to you, the bot is doing nothing for you.
+
+---
+
+## Treat the URL like a password
+
+The one thing to be careful about. Anyone holding a webhook URL can post to that
+channel as your server — so don't paste it into a screenshot, a public issue, or
+a stream.
+
+DiscordLogger never echoes it back, redacts it from command logging, and keeps it
+out of tab-completion, precisely because the obvious ways to leak it are the ones
+people hit.
+
+If a URL does leak, delete the webhook in Discord and make a new one. There's no
+token to revoke and nothing else to clean up — another small advantage of not
+having a bot.
+
+---
+
+## Next
+
+- **[Setup guide](/setup/)** — create the webhook and verify it works
+- **[Config generator](/generator/)** — build your config in the browser
+- **[Configuration reference](/config/)** — every option explained

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,6 +85,23 @@ Discord channel.
   <a class="dl-cta dl-cta--primary" href="/generator/">Open the generator</a>
 </div>
 
+## Guides
+
+<div class="dl-cards">
+  <div class="dl-card">
+    <h3><a href="/guides/without-a-bot/">Log to Discord without a bot</a></h3>
+    <p>You don't need a bot application or a token. What a webhook does, and what it doesn't.</p>
+  </div>
+  <div class="dl-card">
+    <h3><a href="/guides/discordsrv-alternative/">DiscordSRV vs DiscordLogger</a></h3>
+    <p>A bridge and an audit log solve different problems. Which one you actually want.</p>
+  </div>
+  <div class="dl-card">
+    <h3><a href="/guides/webhook-not-posting/">Webhook not posting?</a></h3>
+    <p>Console shows the event but Discord doesn't. Five causes, in order of likelihood.</p>
+  </div>
+</div>
+
 ## Get started
 
 1. **[Download](/downloads/)** the JAR and drop it into `plugins/`.


### PR DESCRIPTION
### The problem, measured

DiscordLogger ranks **#1 and #2** for *"minecraft plugin log server events to discord webhook paper"* — as SpigotMC and GitHub. The docs site appears **nowhere**.

For *"how to log minecraft chat to discord without a bot"* the plugin doesn't appear at all, despite that being precisely what it is.

The technical groundwork was already done — sitemap, canonicals, structured data, per-page titles. What was missing was pages that answer a question someone *types*, rather than pages that describe a product to someone who already found it.

### Three pages

| Page | Why |
|---|---|
| [`/guides/without-a-bot/`](https://discordlogger.godtiergamers.xyz/guides/without-a-bot/) | The differentiator you own and rank nowhere for |
| [`/guides/discordsrv-alternative/`](https://discordlogger.godtiergamers.xyz/guides/discordsrv-alternative/) | "I only want the logging part" is a real search |
| [`/guides/webhook-not-posting/`](https://discordlogger.godtiergamers.xyz/guides/webhook-not-posting/) | The symptom table from the setup guide, freed from the middle of a page nobody searching will read |

All written to be **useful rather than to rank**. The comparison is fair to DiscordSRV — it's a bigger, more capable plugin and the page says so. The without-a-bot page has a section on what you give up. A page that only lists advantages isn't worth reading and won't earn a link.

### Internal linking is the real work

Word count isn't what's missing; discoverability is. The homepage is the one page confirmed indexed, so it now links all three. **Guides** is in the site-wide nav via a `/guides/` index, and the guides cross-link each other.

Every guide has **3–4 inbound internal links** rather than sitting orphaned in a sitemap waiting to be found.

### Verified

All four pages build, carry correct canonicals, appear in the sitemap with production URLs, and **every internal link resolves to a real file**.