### PR TITLE
docs: fix the metadata search engines actually display

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -51,6 +51,42 @@
     </script>
     {%- endif -%}
 
+    {%- comment -%}
+      BreadcrumbList tells search engines the page's place in the hierarchy, and
+      Google renders it in place of the raw URL in a result. Only emitted for
+      nested pages — a breadcrumb on the homepage describes nothing.
+
+      Built from page.url rather than front matter so a new page under /guides/
+      gets it automatically and cannot forget to.
+    {%- endcomment -%}
+    {%- assign segments = page.url | remove_first: '/' | split: '/' -%}
+    {%- if segments.size > 1 -%}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": {{ site.url | append: site.baseurl | append: '/' | jsonify }}
+        }{%- assign crumb_path = '' -%}
+        {%- for seg in segments -%}
+          {%- assign crumb_path = crumb_path | append: '/' | append: seg -%}
+          {%- assign is_last = forloop.last -%},
+        {
+          "@type": "ListItem",
+          "position": {{ forloop.index | plus: 1 }},
+          "name": {% if is_last %}{{ page.title | jsonify }}{% else %}{{ seg | replace: '-', ' ' | capitalize | jsonify }}{% endif %},
+          "item": {{ site.url | append: site.baseurl | append: crumb_path | append: '/' | jsonify }}
+        }
+        {%- endfor -%}
+      ]
+    }
+    </script>
+    {%- endif -%}
+
     <!-- Your theme + favicon -->
     <link rel="stylesheet" href="{{ '/assets/theme.css?v=9' | relative_url }}">
     <link rel="icon" href="{{ '/assets/favicon.png' | relative_url }}">

--- a/docs/config/v10/index.md
+++ b/docs/config/v10/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Config Docs — v10
+title: "config.yml v10 Reference — Every Key Explained"
 description: Full documentation for DiscordLogger's config.yml and lang.yml at schema v10 — every key explained, with downloadable files.
 ---
 

--- a/docs/config/v9/index.md
+++ b/docs/config/v9/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Config Docs — v9
+title: "config.yml v9 Reference — Every Key Explained"
 description: Full documentation for config.yml schema v9 — defaults, per-key explanations, and a downloadable config file.
 ---
 

--- a/docs/guides/webhook-not-posting/index.md
+++ b/docs/guides/webhook-not-posting/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Discord Webhook Not Posting — How to Fix It"
-description: Your Minecraft server logs events to console but nothing appears in Discord. Work through the causes in order of likelihood, from a malformed URL to a deleted webhook to a host blocking outbound HTTPS.
+description: Events reach your Minecraft console but never Discord. The five causes in order of likelihood — malformed URL, deleted webhook, blocked HTTPS, or a filter.
 ---
 
 # Discord webhook not posting

--- a/docs/guides/without-a-bot/index.md
+++ b/docs/guides/without-a-bot/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Log Minecraft to Discord Without a Bot"
-description: You don't need a Discord bot to get server logs into Discord. A webhook does it with no token, no hosting, and no permissions to manage — here's how, and when a bot is genuinely the better choice.
+description: You don't need a Discord bot to log Minecraft server events. A webhook does it with no token and nothing to host — and when a bot is genuinely better.
 ---
 
 # Log Minecraft to Discord without a bot


### PR DESCRIPTION
An audit of the **built** site rather than the source.

### Already sound — left alone

One `h1` per page, no skipped heading levels, 12–13 KB pages against a 20 KB stylesheet (Core Web Vitals will be fine), and the only empty `alt` is the brand logo — which is *correct* for a decorative image.

### Four things fixed

**Six meta descriptions ran 171–202 chars** and were truncated mid-sentence. The description is what someone reads before deciding to click, and half a sentence is worse than a shorter whole one. All now under 160. Most were mine from yesterday.

**Two titles wasted the best space on the page:**

```
Config Docs — v10 | DiscordLogger      35 chars, zero keywords
```

"Config Docs" is not a phrase anyone types, and `/config/v10/` is the deepest content on the site. Both now name the file and what the page is.

**`BreadcrumbList` structured data** on nested pages — Google renders it in place of the raw URL. Built from `page.url` rather than front matter, so a new page under `/guides/` gets it automatically and can't forget to. Only emitted below the top level; a breadcrumb on the homepage describes nothing.

**A 404 page**, which didn't exist. Anyone following a stale link got GitHub's default with no route back. Excluded from the sitemap.

### Deliberately not done

**FAQPage markup on the troubleshooting guide, HowTo on the setup guide.** That's the textbook advice and both pages are natural fits — but **Google removed both from rich results in 2023.** FAQ is restricted to government and health domains; HowTo was dropped entirely. A lot of SEO guidance hasn't caught up. It would have been work for nothing.

### Verified

All 5 breadcrumb blocks parse as valid JSON with correct trails (`Home > Guides > …`). Every description ≤160. Site builds clean, generator validator passes.