### PR TITLE
docs: record the API floors, the metrics, and close out finished TODO items

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Everything below was verified against the actual source at the time of writing; 
 | `<version>` | the plugin version — **release-please owns it**, never hand-edit |
 | `<maven.compiler.release>` | Java the plugin is built for |
 | `<dl.api.version>` | minimum Paper; becomes `plugin.yml`'s `api-version` |
+| `<dl.compat.floor>` | the oldest API the build promises to compile against; CI's `compat-floor` job enforces it |
 | `<dl.game.versions>` | the supported range; the listings advertise it, and the prose + badge in README/CONTRIBUTING are derived from its first and last entries |
 | `<dl.paper.display>` | how Paper is written in prose, e.g. `26.x` |
 
@@ -157,6 +158,20 @@ Stable releases are mirrored onto two listings, because that is where server own
 
 **The publish is re-runnable.** `release-please.yml` takes a `workflow_dispatch` with a `tag` input, so a listing that failed can be retried against an existing release without cutting a new one. Before that existed, `publish-listings` could only run as a side effect of the release commit — which is how v2.2.0 ended up published on Hangar, absent from Modrinth, and unrecoverable without faking a release.
 
+### Metrics
+
+33 bStats charts in `metrics/PluginMetrics.java`, with runtime tallies in `metrics/Counters.java`.
+
+**The line: configuration state, plugin presence and server software — never a player.** No names, UUIDs, IPs, message content, coordinates or world names. Counts are buckets, not exact numbers; `bucket()` has a test asserting it never returns the bare figure, so a chart cannot become a fingerprint by accident. `commands_used` is a `Set` for the same reason — fifty `/reload`s are indistinguishable from one.
+
+**Counter reads are destructive.** bStats sums each submission across every server, so a running total would re-count everything already reported. `take*` returns the delta and resets.
+
+**Source builds report**, tagged `dev` by `release_channel`. They were excluded once on the theory that a developer's machine skews every chart; bStats identifies a server by an id in `plugins/bStats/config.yml`, per data directory, so rebuild cycles against one test server are one server. Excluding them only understated the totals.
+
+**`command_filter_state` is the one with teeth.** It reports `Reduced` when a command the plugin ships in `filters.ignored_commands` has been removed — `/login` and `/msg` are in there because command logging posts lines verbatim. Tested, including the trap where a *longer* list is still `Reduced`.
+
+**Adding a chart means updating the disclosure.** The README and setup guide both enumerate what is collected. That list is a promise, not decoration.
+
 **Download counting.** The README badge is shields.io's stock `github/downloads/.../total`, which counts GitHub Release assets. Hangar traffic is already inside that number — its versions are `externalUrl` links to the GitHub asset — so only Modrinth's own tally is missing. There used to be a combined endpoint badge written by `publish-listings.py --badge` and committed by `downloads-badge.yml`; it was removed because the commit pushed straight to `main` and branch protection rejects that, so it failed every single day and the number froze. A badge that silently stops updating is worse than one that undercounts by a known amount.
 
 **Two secrets must exist** or the corresponding platform is skipped with a notice (a lagging listing is recoverable; a release job dying after tagging is not): `MODRINTH_TOKEN` (PAT, "Create versions" **plus one read scope** — either "Read analytics" or "Read user info") and `HANGAR_API_KEY` (create_version permission). Both are repository **Actions** secrets — the job declares no `environment:`, so environment secrets would not resolve.
@@ -173,6 +188,10 @@ Modrinth answers both "expired" and "wrong scopes" with a bare 401, so the failu
 The downloads badge does **not** use analytics — Modrinth's public project endpoint already exposes the total with no auth at all. Analytics would only be needed for time-series or per-version breakdowns.
 
 Modrinth PATs expire. `check-listing-credentials.yml` runs `publish-listings.py --check-auth` weekly so a dead token is caught by a failed scheduled run rather than by a release that has already tagged. Note that `--dry-run` makes no authenticated call at all and proves nothing about the tokens; `--check-auth` is the mode that does.
+
+**Three floors exist and are deliberately different numbers.** `api-version: 1.19` admits 1.19.0 onward, because api-version cannot express a patch before 1.20.5. `<dl.compat.floor>` is 1.19.0 and CI compiles against it on every Java change — without that job, using an API added in 1.19.1+ would compile, test, ship, and only then `NoSuchMethodError` on the servers the listings promise. `<paper.api.version>` is 1.19.4 because that is the oldest release the *test suite* can run against: below it, Bukkit's `YamlConfiguration` wants SnakeYAML 1.x and collides with ours on the unrelocated test classpath. That collision cannot happen in the shipped JAR, where SnakeYAML is shaded and relocated.
+
+**Dependabot is told to ignore `paper-api`** in `.github/dependabot.yml`. It is not a dependency to keep current — it is the oldest server the plugin promises to run on, pinned low on purpose. A bot bumping it to the newest build silently undoes the whole arrangement.
 
 `<dl.game.versions>` in `pom.xml` is the Minecraft version list both listings advertise. It's the one value that can't be derived — `api-version` is a floor, not a list — so it's validated against Modrinth's known-version API before publishing; a typo fails the release rather than mislabelling it.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,7 +6,7 @@ A tour of how DiscordLogger is actually built — for contributors, curious user
 
 ## What DiscordLogger is
 
-A Paper server plugin (Java 25) that watches server events and posts them to a Discord channel over a webhook, either as rich embeds or plain Markdown text. It ships two versioned files — `config.yml` (what to log, where, and how it looks) and `lang.yml` (every string it says) — both of which migrate themselves forward automatically. It checks for updates in a way that's aware of which release channel it's running on, and is accompanied by a Jekyll website (this `docs/` folder) with an interactive config generator.
+A Paper server plugin (Java 17 bytecode, running on Paper 1.19 through 26.x) that watches server events and posts them to a Discord channel over a webhook, either as rich embeds or plain Markdown text. It ships two versioned files — `config.yml` (what to log, where, and how it looks) and `lang.yml` (every string it says) — both of which migrate themselves forward automatically. It checks for updates in a way that's aware of which release channel it's running on, and is accompanied by a Jekyll website (this `docs/` folder) with an interactive config generator.
 
 ## How a request flows through the plugin at startup
 
@@ -18,7 +18,7 @@ A Paper server plugin (Java 25) that watches server events and posts them to a D
 4. **`NightlyNotice`** activates (a no-op unless this is a nightly build).
 5. **Runtime config is applied** — the webhook URL and time format are read, `Lang` loads the language file, `Filters` builds its immutable snapshot, and `Log.init(...)` is called. A missing or invalid webhook doesn't disable the plugin; it just runs in a "degraded," console-only mode until an admin fixes it and runs `/discordlogger reload`.
 6. **Every listener registers**, unconditionally — whether an event actually gets logged is decided *inside* each listener by reading the config live, every time. This is what lets `/discordlogger reload` work without needing to re-register anything.
-7. Commands are wired up, anonymous [bStats](https://bstats.org) metrics start (skipped entirely for local dev builds), an async update check fires, and the plugin announces server start.
+7. Commands are wired up, anonymous [bStats](https://bstats.org) metrics start — source builds included, tagged as such — an async update check fires (skipped for source builds, since nagging someone about updates to the code they are editing is noise), and the plugin announces server start.
 
 ## The pieces that do the actual work
 
@@ -60,6 +60,8 @@ The invariant tying the generator to all of this: **generate, change nothing, an
 ## The website and the config generator
 
 The site is a fairly plain Jekyll project deployed straight from `main` via GitHub Pages — docs changes go live the moment they're merged, independent of when the plugin itself releases.
+
+Alongside the reference pages there is `docs/guides/`, which exists for a different reason: reference pages are read by people who have already chosen the plugin, and guides are written for the question someone types before they have. Each one targets a measured query the site ranked nowhere for. They are documentation first — the DiscordSRV comparison says plainly that DiscordSRV is the better choice for a chat bridge, and the without-a-bot page has a section on what you give up — because a page that only lists advantages earns neither a link nor a reader.
 
 The interesting part is the **config generator**, which is deliberately built so that old plugin versions keep generating exactly the config they always did, forever, even as new config schemas get added. It's split into a small, stable *loader* (`docs/assets/js/generator.js`) and fully self-contained *bundles*, one per config schema (`docs/assets/configs/v9/generator.js`, `v10/generator.js`, and so on). A visitor picks the plugin version they downloaded — not a config schema, since nobody knows that off the top of their head — and the loader silently resolves which schema that version uses and hands off to the matching bundle. The rule that keeps this maintainable: once a newer schema's folder exists, the older one is never edited again. Bug fixes only ever land in the newest schema; a folder gets copied forward, not refactored in place.
 

--- a/TODO.md
+++ b/TODO.md
@@ -88,14 +88,6 @@ Nothing here adds a feature. All of it is the difference between an admin diagno
   - Note: Discord creates a **new webhook on every authorization**, so running the flow repeatedly accumulates webhooks in the channel. The UI has to say so.
   - Requires a Discord application (client ID + secret) registered by the project owner, and a registered redirect URI.
 
-- **Verify the domain in Google Search Console.** *Do this before writing any of the pages below.* The site does not surface in search even for its own domain name, which is consistent with it not being indexed at all. If that is the case, no amount of content fixes it, and every page written first is wasted effort. Ten minutes, and it is diagnostic: it says whether the problem is indexation or authority. **Requires the project owner's account.**
-
-- **Write the pages people actually search for.** Measured 2026-08-03: DiscordLogger ranks #1 and #2 for *"minecraft plugin log server events to discord webhook paper"* — as SpigotMC and GitHub. The docs site appears nowhere. For *"how to log minecraft chat to discord without a bot"* the plugin does not appear at all, despite that being precisely what it is. Three pages, in order of intent:
-
-  - **Log Minecraft to Discord without a bot** — the differentiator the plugin owns and ranks nowhere for.
-  - **DiscordSRV vs DiscordLogger** — comparison queries convert, and "I only want logging, not a chat bridge" is a real search. Be fair to DiscordSRV; it is a different product, not a worse one.
-  - **Discord webhook not posting — troubleshooting** — the symptom→cause table already exists in the setup guide, buried where nobody searching will find it.
-
 - **Search visibility (ongoing)** — the technical groundwork is in place (sitemap, canonicals, structured data, per-page titles and descriptions), and the Modrinth/Hangar listing bodies were rewritten for 2.2.0. What's left is the slow part: the pages above, listings on the sites Minecraft admins browse, and monitoring real queries once Search Console is connected. This item stays open indefinitely; it isn't a task with a finish line.
 
 - **Let the config generator skip the webhook step.** It currently refuses to advance without a valid, confirmed URL, so there is no way to build a config before you have created the webhook — which is the order many people would rather work in.


### PR DESCRIPTION
Three documentation gaps, found by checking rather than assuming.

**`AGENTS.md` had nothing about the compile floor.** It documented `paper.api.version` but not `<dl.compat.floor>` or the `compat-floor` CI job — so the three floors read as one number that had been set inconsistently:

| | Version | Why |
|---|---|---|
| Loads on | 1.19.0 | `api-version` can't express a patch before 1.20.5 |
| Compiles against | 1.19.0 | `dl.compat.floor`, enforced in CI |
| Tests run at | 1.19.4 | Bukkit wants SnakeYAML 1.x below it |

Also records that Dependabot ignores `paper-api`, because **a pinned-low dependency looks identical to a stale one** from the outside.

**`AGENTS.md` had nothing about metrics**, despite 33 charts. Now covers the line that's never crossed, why counter reads are destructive, why source builds report, and that adding a chart means updating the disclosure — that list is a promise, not decoration.

**`ARCHITECTURE.md` didn't mention `docs/guides/`**, which exists for a different reason than the reference pages and would otherwise look like stray content.

**TODO:** removed Search Console verification and the content pages — both done. The file is only trustworthy if finished work leaves it.