### PR TITLE
docs: add five guides for features that had no page

### DIFF
--- a/docs/guides/bedrock-geyser/index.md
+++ b/docs/guides/bedrock-geyser/index.md
@@ -1,0 +1,83 @@
+---
+layout: default
+title: "Discord Logging for Geyser Servers"
+description: DiscordLogger flags Bedrock players on join and builds death messages server-side, so they read identically for Java and Bedrock players.
+---
+
+# Logging on a Geyser server
+
+Cross-play servers create two problems for logging. DiscordLogger handles both.
+
+---
+
+## Death messages read the same for everyone
+
+Most plugins relay the death message the *client* produced, which is localised —
+so a Bedrock player or a non-English client produces different text for the same
+death, and your channel becomes inconsistent.
+
+DiscordLogger builds death messages **server-side from the damage cause**, then
+looks the wording up in [`lang.yml`](/guides/translate/). Same death, same
+sentence, every time, whatever the player is running.
+
+The cause is its own embed field, so it stays readable even when the sentence is
+short.
+
+---
+
+## Bedrock players are flagged on join
+
+If the server runs Geyser with Floodgate, joins from Bedrock get a **Platform**
+field:
+
+```yaml
+log:
+  player:
+    join:
+      enabled: true
+      show_platform: true      # default
+```
+
+**It never says "Java".** Only Bedrock is flagged, and only when there's positive
+evidence. On a server without Floodgate every player would otherwise be labelled
+Java, which would be a guess presented as a fact.
+
+---
+
+## How detection works, and why it's belt-and-braces
+
+Two independent signals, **OR'd rather than chained**:
+
+1. **Floodgate's API**, when Floodgate is installed
+2. **The UUID shape** — Floodgate issues UUIDs whose most significant bits are zero
+
+Either one is enough. That matters behind a proxy: a backend server's player
+registry doesn't necessarily know a player the proxy handshook, so Floodgate's
+API can answer "no" for someone whose UUID is plainly Floodgate's.
+
+An earlier version returned the API's answer directly and **real Bedrock players
+went unflagged on Velocity networks** because of exactly that. The signals are
+OR'd now, and there's a test pinning it.
+
+---
+
+## Setup notes
+
+**`softdepend`, not `depend`.** The plugin runs perfectly without Floodgate — the
+Platform field simply never appears. Nothing to configure.
+
+**Floodgate must be named in `plugin.yml`** for its API to be reachable, because
+Paper gives each plugin its own classloader. That's already done; it's mentioned
+only because a missing `softdepend` is what caused detection to silently fall
+back to the UUID guess once before.
+
+**Bedrock usernames often carry a prefix** — Floodgate's default is `.`. That
+prefix appears in logs as part of the name, which is usually what you want.
+
+---
+
+## Next
+
+- **[Setup guide](/setup/)** — from install to first message
+- **[What gets logged](/guides/what-gets-logged/)** — all nineteen events
+- **[Translate](/guides/translate/)** — reword the death causes

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -25,6 +25,26 @@ Longer answers to the questions people actually arrive with.
     <h3><a href="/guides/webhook-not-posting/">Webhook not posting</a></h3>
     <p>Events reach console but never Discord. The five causes, in order of likelihood, and how console tells you which one you have.</p>
   </div>
+  <div class="dl-card">
+    <h3><a href="/guides/staff-channel/">Private staff channel</a></h3>
+    <p>Route bans and kicks somewhere private while chat stays public. Any event can have its own webhook.</p>
+  </div>
+  <div class="dl-card">
+    <h3><a href="/guides/reduce-spam/">Reduce logging spam</a></h3>
+    <p>Fourteen filters, matched to the noise each one actually solves.</p>
+  </div>
+  <div class="dl-card">
+    <h3><a href="/guides/translate/">Translate every message</a></h3>
+    <p>All 79 strings live in <code>lang.yml</code>. Reword or translate without touching code.</p>
+  </div>
+  <div class="dl-card">
+    <h3><a href="/guides/bedrock-geyser/">Geyser and Bedrock</a></h3>
+    <p>Death messages that read the same for everyone, and Bedrock players flagged on join.</p>
+  </div>
+  <div class="dl-card">
+    <h3><a href="/guides/upgrading/">Upgrading</a></h3>
+    <p>What happens to your config when you drop in a new JAR — and what to do if it looks wrong.</p>
+  </div>
 </div>
 
 ## Also useful

--- a/docs/guides/reduce-spam/index.md
+++ b/docs/guides/reduce-spam/index.md
@@ -1,0 +1,157 @@
+---
+layout: default
+title: "Reduce Discord Logging Spam from Minecraft"
+description: Your Discord channel is drowning in teleports and chat. The fourteen DiscordLogger filters, matched to the noise they actually solve.
+---
+
+# Reduce logging spam
+
+A logging channel nobody reads is the same as no logging channel. If yours has
+become a wall of teleports, this is how to quieten it without turning things off
+wholesale.
+
+Fourteen filters, grouped by the complaint they solve.
+
+---
+
+## "Teleports never stop"
+
+The most common one by a distance, and usually not really teleports at all —
+Minecraft moves a player a block or two and reports it as one.
+
+Three causes are **already excluded by default**: `EXIT_BED`, `DISMOUNT`,
+`SPECTATE`.
+
+**If you run Essentials, add `PLUGIN`.** `/home`, `/warp`, `/spawn` and `/tpa`
+all arrive that way and are usually the entire remaining problem:
+
+```yaml
+filters:
+  ignored_teleport_causes:
+    - EXIT_BED
+    - DISMOUNT
+    - SPECTATE
+    - PLUGIN
+  minimum_teleport_distance: 50    # ignore short hops entirely
+```
+
+---
+
+## "Chat is too busy"
+
+```yaml
+filters:
+  minimum_chat_length: 3                # skips "hi", "?", "."
+  ignored_chat_containing:
+    - "buy gold"
+```
+
+`minimum_chat_length` counts characters, not words. Three is enough to kill
+one-word spam without losing real conversation.
+
+---
+
+## "Command logging is unusable"
+
+`/login`, `/register`, `/msg` and similar are filtered **by default** — command
+logging posts lines exactly as typed, so without that you'd publish passwords and
+private messages. Don't remove those; add to them.
+
+If you only care about staff commands, invert it with the allow-list:
+
+```yaml
+filters:
+  only_log_commands:
+    - ban
+    - kick
+    - op
+    - gamemode
+```
+
+With anything in `only_log_commands`, **only** those are logged and everything
+else is ignored.
+
+---
+
+## "One player floods everything"
+
+A bot account, a staff alt, or an AFK farm:
+
+```yaml
+filters:
+  ignored_players:
+    - AFKBot
+    - 069a79f4-44e9-4726-a5be-fca90e38aaf5   # names or UUIDs
+  exempt_permission: "discordlogger.exempt"   # or a permission node
+```
+
+The permission version is usually better for staff — it follows the rank rather
+than a list you have to maintain.
+
+---
+
+## "A whole world is noise"
+
+Creative plots, minigame worlds, a testing world:
+
+```yaml
+filters:
+  ignored_worlds:
+    - creative_plots
+    - minigames
+```
+
+---
+
+## "Advancements are constant"
+
+Recipe unlocks and tab roots are already skipped. To cut more, a trailing `*`
+matches a whole tab:
+
+```yaml
+filters:
+  ignored_advancements:
+    - "minecraft:husbandry/*"
+```
+
+---
+
+## "Deaths in the void world"
+
+A parkour course or a void map produces the same death over and over:
+
+```yaml
+filters:
+  ignored_death_causes:
+    - VOID
+    - FALL
+```
+
+---
+
+## "Every creeper gets a message"
+
+```yaml
+filters:
+  minimum_explosion_blocks: 5
+  ignored_explosion_sources:
+    - CREEPER
+```
+
+A creeper going off in mid air destroys nothing and is rarely worth a line.
+
+---
+
+## The alternative: split rather than filter
+
+If the problem is *volume* rather than *irrelevance*, don't filter — **route**.
+Send chat to its own channel and the noise stops competing with what you actually
+watch for. See [moderation logs in a private channel](/guides/staff-channel/).
+
+---
+
+## Next
+
+- **[Configuration reference](/config/)** — every filter, with defaults
+- **[Config generator](/generator/)** — set all fourteen with a form
+- **[What gets logged](/guides/what-gets-logged/)** — what each event posts

--- a/docs/guides/staff-channel/index.md
+++ b/docs/guides/staff-channel/index.md
@@ -1,0 +1,109 @@
+---
+layout: default
+title: "Moderation Logs in a Private Discord Channel"
+description: Route bans, kicks and op changes to a private channel while chat and joins stay public — any DiscordLogger event can have its own webhook.
+---
+
+# Send moderation logs to a private channel
+
+Chat and joins are fine in a public channel. Bans, kicks and op changes usually
+aren't — they name players, carry reasons, and are nobody's business but staff's.
+
+**Any event can have its own webhook**, so this is a per-event setting rather
+than an all-or-nothing choice.
+
+---
+
+## The idea
+
+A Discord webhook posts to exactly one channel. That's normally a limitation;
+here it's the mechanism. Make a second webhook in your staff channel, put it on
+the moderation events, and leave everything else pointing at the main one.
+
+---
+
+## Setup
+
+**1. Create a webhook in your staff channel.** Right-click it → **Edit Channel**
+→ **Integrations** → **Webhooks** → **New Webhook** → **Copy Webhook URL**.
+
+**2. Put it on the moderation events** in `config.yml`:
+
+```yaml
+log:
+  moderation:
+    ban:
+      enabled: true
+      color: "#FF0000"
+      webhook: "https://discord.com/api/webhooks/…staff…"
+    kick:
+      enabled: true
+      color: "#FF0000"
+      webhook: "https://discord.com/api/webhooks/…staff…"
+    op:
+      enabled: true
+      color: "#FF0000"
+      webhook: "https://discord.com/api/webhooks/…staff…"
+```
+
+**3. Leave everything else alone.** An empty `webhook:` means "use the main one":
+
+```yaml
+log:
+  player:
+    chat:
+      enabled: true
+      webhook: ""          # public channel
+```
+
+**4. Reload.**
+
+```
+/discordlogger reload
+```
+
+The [config generator](/generator/) does the same thing with a form, if you'd
+rather not hand-edit — step 6 is per-event channels.
+
+---
+
+## A split that works well
+
+| Channel | Events |
+|---|---|
+| **#server-log** (public) | join, quit, chat, advancement, server start/stop |
+| **#staff-log** (private) | ban, unban, kick, op, deop, whitelist, console commands |
+| **#grief-log** (private) | explosions, deaths with coordinates, teleports |
+
+Console commands belong with staff, not in public — an admin running
+`/give` or `/gamemode` isn't something a public channel needs, and console
+commands can contain things you'd rather not broadcast.
+
+---
+
+## Why this doesn't slow anything down
+
+Each destination gets **its own queue and its own worker**, so a busy chat
+channel can't delay the staff log behind it. Discord rate-limits per webhook, and
+using several means each has its own budget rather than sharing one.
+
+If chat is heavy enough to hit a limit, moderation still lands immediately.
+
+---
+
+## Every URL is a credential
+
+Each webhook URL can post to its channel as your server. A staff webhook leaking
+is worse than a public one, because the channel it posts to is one people trust.
+
+DiscordLogger never echoes a URL back, redacts it from command logging, and keeps
+it out of tab-completion. If one leaks, delete that webhook in Discord and make a
+new one — nothing else needs cleaning up.
+
+---
+
+## Next
+
+- **[Configuration reference](/config/)** — every key
+- **[What gets logged](/guides/what-gets-logged/)** — all nineteen events
+- **[Reduce logging spam](/guides/reduce-spam/)** — the filters, if a channel is too noisy

--- a/docs/guides/translate/index.md
+++ b/docs/guides/translate/index.md
@@ -1,0 +1,108 @@
+---
+layout: default
+title: "Translate DiscordLogger's Messages"
+description: Every string the plugin says lives in lang.yml. Translate it, reword it, or match your server's tone — no code, no rebuild.
+---
+
+# Translate and reword every message
+
+Every string DiscordLogger says lives in `lang.yml` — 79 of them. Change any and
+run `/discordlogger reload`. No rebuild, no code.
+
+---
+
+## Two sections that are not interchangeable
+
+```yaml
+chat:      # shown IN GAME  — MiniMessage formatting
+discord:   # posted TO DISCORD — plain text, Discord Markdown
+```
+
+**A `<green>` tag in the `discord:` section is posted as the literal characters
+`<green>`.** Discord renders Markdown, not MiniMessage. Getting this backwards is
+the single most common mistake.
+
+| Section | Formatting that works |
+|---|---|
+| `chat:` | `<red>`, `<bold>`, `<gradient:red:blue>`, `<#ff8800>` |
+| `discord:` | `**bold**`, `*italic*`, `` `code` ``, `~~strike~~` |
+
+---
+
+## Placeholders
+
+Written `{player}`, `{message}`, `{killer}`, and replaced before sending. Each
+message lists the ones it accepts, and **they are not interchangeable** —
+`{player}` only works where the plugin has a player to put there.
+
+A misspelled placeholder is left in the message rather than blanked, so a typo
+shows up as `{palyer} joined` instead of a sentence with a hole in it. That's
+deliberate: a visible mistake is a fixable one.
+
+You can also delete a placeholder entirely:
+
+```yaml
+player-join: "{player} joined"     ->  "Steve joined"
+player-join: "Someone joined"      ->  "Someone joined"
+```
+
+---
+
+## Translating
+
+Work through `discord:` first — that's what your community sees. `chat:` is
+staff-facing and matters less.
+
+```yaml
+discord:
+  player-join: "{player} a rejoint le serveur"
+  player-quit: "{player} a quitté le serveur"
+  player-chat: "**{player}**: {message}"
+  death:
+    description: "{player} est mort"
+    cause-field: "Cause de la mort"
+    causes:
+      fall: "Est tombé de haut"
+      lava: "A essayé de nager dans la lave"
+```
+
+The death causes are the bulk of it — 33 of the 79 keys. They're also the most
+rewarding, because they're the messages people actually read.
+
+---
+
+## If you break something
+
+| What you did | What happens |
+|---|---|
+| Deleted a message | Falls back to the English inside the JAR |
+| Deleted a whole key | You see the key name, e.g. `chat.reload-ok` |
+| Deleted the file | Written again on next start |
+| Broke the YAML | Parse error logged on start, falls back to English |
+
+Nothing is unrecoverable. Check indentation first — it must be spaces, never
+tabs.
+
+---
+
+## Console messages stay English
+
+Deliberately. They're not in `lang.yml`, so that searching an error or pasting it
+into a support thread still matches what everyone else sees.
+
+---
+
+## Your file survives updates
+
+`lang.yml` carries a schema version and is migrated forward exactly like
+`config.yml` — your wording is transplanted into the new file, comments and all,
+and the old one is kept as `lang.old.yml`. New messages arrive in English for you
+to translate; nothing you wrote is reset.
+
+---
+
+## Next
+
+- **[Configuration reference](/config/)** — every key in both files
+- **[Config generator](/generator/)** — edit all 79 messages in your browser
+- **[What gets logged](/guides/what-gets-logged/)** — which message goes with which event

--- a/docs/guides/upgrading/index.md
+++ b/docs/guides/upgrading/index.md
@@ -1,0 +1,111 @@
+---
+layout: default
+title: "Upgrading DiscordLogger Safely"
+description: Drop in the new JAR and restart. Your settings are migrated forward one schema version at a time, comments preserved, and the old file is always kept.
+---
+
+# Upgrading
+
+Drop in the new JAR and restart. That's the whole procedure.
+
+This page exists because "will this reset my config" is a fair thing to worry
+about, and the honest answer is longer than "no".
+
+---
+
+## What actually happens
+
+On start, the plugin works out which schema version your files are, and if
+they're older than the one it ships:
+
+1. **Backs up** — `config.old.yml` and `lang.old.yml`, next to the originals
+2. **Migrates forward one version at a time** — v8 to v10 goes through v9, never straight across
+3. **Transplants your values** into the new file's structure, keeping every comment, blank line and piece of ASCII art
+4. **Adds new keys at their defaults** — nothing you changed is reset
+5. **Says so in console**, naming both versions
+
+Only forward. A config from a **newer** build is never downgraded — it tells you
+and changes nothing, because rewriting it against an older default would drop
+keys the newer schema added, and that's data loss rather than a migration.
+
+---
+
+## How it knows which version you're on
+
+Two independent ways:
+
+- **What the file declares** — `config-version` and the trailer comment
+- **What the file *is*** — the set of keys actually present
+
+A declaration can be edited or deleted. A shape can't lie. **When they disagree,
+the shape wins**, so a hand-mangled version marker degrades to a correct guess
+rather than a wrong migration.
+
+---
+
+## Coming from 2.1.x
+
+2.2.0 moved config schema v9 to v10, which is the largest change so far. Two
+kinds of key moved, and both are handled automatically:
+
+```yaml
+# v9
+log:
+  player:
+    join: true
+embeds:
+  colors:
+    player:
+      join: "#57F287"
+
+# v10
+log:
+  player:
+    join:
+      enabled: true
+      color: "#57F287"
+      webhook: ""
+```
+
+Colours moved from `embeds.colors.*` into the event itself, and each event became
+a section so it could carry its own webhook. One rename to be aware of: v9's
+`embeds.colors.moderation.whitelist` becomes
+`log.moderation.whitelist_edit.color`.
+
+You also gain `lang.yml`, fourteen filters, per-event routing and the Bedrock
+indicator — all at their defaults, so nothing changes until you want it to.
+
+---
+
+## If it goes wrong
+
+**Compare against the backup.** `config.old.yml` is exactly what you had.
+
+**Start clean** if you'd rather:
+
+```
+/discordlogger regen confirm
+```
+
+That rebuilds `config.yml` from the current default and backs up your existing
+one first. Your settings are *not* carried over — it's the "start again" button,
+not a repair.
+
+**Check the console message.** It names the versions it migrated between, which
+is the fastest way to tell whether migration even ran.
+
+---
+
+## Downgrading
+
+Supported in the sense that nothing breaks: the older plugin sees a config newer
+than it understands, tells you, and ignores keys it doesn't recognise rather than
+overwriting them. Your file is left alone.
+
+---
+
+## Next
+
+- **[Configuration reference](/config/)** — every key, per schema version
+- **[Config generator](/generator/)** — rebuild both files from scratch
+- **[Webhook not posting?](/guides/webhook-not-posting/)** — if logging stops after an upgrade


### PR DESCRIPTION
The site documented every feature in the config reference and none of them anywhere someone would find by *searching*. These five cover the things DiscordLogger is genuinely better at, written for the question rather than the key.

| Guide | Covers |
|---|---|
| `/guides/staff-channel/` | Per-event routing — the headline feature, previously findable only by reading a YAML table |
| `/guides/reduce-spam/` | The fourteen filters, grouped by the **complaint each solves** rather than listed alphabetically. People search the symptom, not the setting |
| `/guides/translate/` | `lang.yml`, including the mistake everyone makes: MiniMessage tags in the `discord:` section post as literal characters |
| `/guides/bedrock-geyser/` | Why death messages are server-side, and why detection ORs two signals instead of trusting Floodgate's API alone |
| `/guides/upgrading/` | What migration actually does, plus the v9→v10 key moves for anyone on 2.1.x |

### Accuracy over promotion

- The **upgrade** page says downgrading leaves your file alone, rather than pretending it's unsupported
- The **Geyser** page explains the plugin never labels anyone "Java", because that would be a guess presented as a fact
- The **spam** page says plainly *not* to remove the default command filters, because command logging posts lines verbatim

### Verified

Every page has a breadcrumb, a unique title ≤60, a description ≤160, and 2–3 inbound internal links. **Every internal link across all 17 pages resolves to a real file.** Site is now 17 pages, up from 7 this morning.