### PR TITLE
fix(metrics): drop two charts that duplicate bStats defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,9 @@ Stable releases are mirrored onto two listings, because that is where server own
 
 ### Metrics
 
-33 bStats charts in `metrics/PluginMetrics.java`, with runtime tallies in `metrics/Counters.java`.
+31 bStats charts in `metrics/PluginMetrics.java`, with runtime tallies in `metrics/Counters.java`.
+
+**Check bStats' defaults before adding a chart.** It already collects `bukkitName`, `onlineMode`, `bukkitVersion`, `javaVersion`, `playerAmount`, `coreCount` and the OS fields on its own. A `server_fork` and an `online_mode` chart were added here and removed again once it turned out `bukkitName` *is* `Bukkit.getName()` — the same value under a second name, on every server, forever.
 
 **The line: configuration state, plugin presence and server software — never a player.** No names, UUIDs, IPs, message content, coordinates or world names. Counts are buckets, not exact numbers; `bucket()` has a test asserting it never returns the bare figure, so a chart cannot become a fingerprint by accident. `commands_used` is a `Set` for the same reason — fifty `/reload`s are indistinguishable from one.
 

--- a/src/main/java/com/discordlogger/metrics/PluginMetrics.java
+++ b/src/main/java/com/discordlogger/metrics/PluginMetrics.java
@@ -99,7 +99,6 @@ public final class PluginMetrics {
 
             // ---------------------------------------------------------------- environment
             metrics.addCustomChart(new SimplePie("release_channel", BuildInfo::channel));
-            metrics.addCustomChart(new SimplePie("server_fork", PluginMetrics::serverFork));
             metrics.addCustomChart(new SimplePie("config_schema", () -> configSchema(plugin)));
             metrics.addCustomChart(new DrilldownPie("mc_version_by_schema",
                     () -> drilldown(minecraftVersion(), configSchema(plugin))));
@@ -108,8 +107,6 @@ public final class PluginMetrics {
 
             // ----------------------------------------------------------- companion plugins
             metrics.addCustomChart(new SimplePie("proxy_mode", PluginMetrics::proxyMode));
-            metrics.addCustomChart(new SimplePie("online_mode",
-                    () -> Bukkit.getOnlineMode() ? "Online" : "Offline"));
             metrics.addCustomChart(new SimplePie("floodgate",
                     () -> present(installed("floodgate") || installed("Geyser-Spigot"))));
             metrics.addCustomChart(new SimplePie("placeholderapi",
@@ -178,21 +175,10 @@ public final class PluginMetrics {
 
     // ------------------------------------------------------------------ environment
 
-    /**
-     * The server implementation name — Paper, Purpur, Pufferfish, Leaf, and so on.
-     *
-     * <p>bStats reports "Server Software" already, but forks frequently identify as
-     * their upstream there. Issue #161 arrived from Leaf, which is exactly the kind
-     * of fork that would otherwise be invisible.
-     */
-    private static String serverFork() {
-        try {
-            final String name = Bukkit.getName();
-            return (name == null || name.isBlank()) ? UNKNOWN : name;
-        } catch (Throwable t) {
-            return UNKNOWN;
-        }
-    }
+    // NOTE: no server_fork or online_mode chart here. bStats 3.2.1 already collects
+    // bukkitName (which IS Bukkit.getName(), so forks like Purpur and Leaf show up
+    // there correctly) and onlineMode as default charts. Adding our own duplicated
+    // the same values under a second name.
 
     /** "1.21.11" from whatever shape this server reports its version in. */
     private static String minecraftVersion() {


### PR DESCRIPTION
`server_fork` and `online_mode` both re-sent data bStats already collects.

Checking `bstats-bukkit:3.2.1` directly, its default payload includes:

```
bukkitName  bukkitVersion  onlineMode  javaVersion
playerAmount  coreCount  osName  osArch  osVersion
```

**`bukkitName` *is* `Bukkit.getName()`** — the exact call `server_fork` made. So every server was sending the same two values twice, under two names, indefinitely.

My reasoning for `server_fork` was that forks report as their upstream in the default chart. That was an assumption and it's wrong — Purpur and Leaf show up correctly there already.

**33 charts → 31.** No behaviour change beyond less redundant traffic; 202 tests still green.

`AGENTS.md` gains a line telling the next person to check bStats' defaults first — the full list is right there in the jar, and this was avoidable by looking.

Credit where due: caught by @LVCHLANN while creating the charts on bstats.org, not by me.