### PR TITLE
fix(death): make /kill read as a command on Paper 1.19

### DIFF
--- a/src/main/java/com/discordlogger/event/EventRegistry.java
+++ b/src/main/java/com/discordlogger/event/EventRegistry.java
@@ -16,6 +16,8 @@ public final class EventRegistry {
         PluginManager pm = plugin.getServer().getPluginManager();
 
         // Player events
+        // Inert on 1.20+, where the server distinguishes /kill from a void death.
+        pm.registerEvents(new KillCommandTracker(), plugin);
         pm.registerEvents(new PlayerJoin(plugin), plugin);
         pm.registerEvents(new PlayerQuit(plugin), plugin);
         pm.registerEvents(new PlayerChat(plugin), plugin);

--- a/src/main/java/com/discordlogger/listener/player/KillCommandTracker.java
+++ b/src/main/java/com/discordlogger/listener/player/KillCommandTracker.java
@@ -1,0 +1,154 @@
+package com.discordlogger.listener.player;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+import org.bukkit.event.server.ServerCommandEvent;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Makes {@code /kill} read as a command on servers too old to say so themselves.
+ *
+ * <p>{@code DamageCause.KILL} arrived in Minecraft 1.20. Before that the server
+ * reports {@code /kill} as {@code VOID} — the same cause as genuinely falling out
+ * of the world — so a death by command was logged as "Fell into the void". The
+ * plugin was reporting exactly what it was told; the server simply could not
+ * distinguish the two.
+ *
+ * <p>This watches for the command and lets {@link PlayerDeath} correlate a `VOID`
+ * death against it, which is the same trick the moderation listeners use: watch
+ * the command, then confirm against what actually happened.
+ *
+ * <h2>It does nothing on 1.20 and newer</h2>
+ *
+ * <p>{@link #ACTIVE} is false wherever {@code KILL} exists, and then nothing is
+ * recorded and nothing is consulted. Correlation is a workaround for missing
+ * information, so running it where the information exists could only ever turn a
+ * correct answer into a guess.
+ */
+public final class KillCommandTracker implements Listener {
+
+    /**
+     * How long after the command a `VOID` death still counts as caused by it.
+     *
+     * <p>The damage and the death happen in the same tick as the command, so this
+     * only has to survive one tick (50ms) plus whatever the server is behind by.
+     * Deliberately short: the longer the window, the more likely a genuine void
+     * death nearby gets mislabelled, and being wrong is worse than being vague.
+     */
+    private static final long WINDOW_MS = 250L;
+
+    /** Recorded when a selector was used and the victim cannot be named up front. */
+    private static final String ANY_PLAYER = "*";
+
+    /** False on 1.20+, where the server distinguishes KILL from VOID by itself. */
+    static final boolean ACTIVE = !killCauseExists();
+
+    /** Lower-cased victim name (or {@link #ANY_PLAYER}) to when the command ran. */
+    private static final Map<String, Long> PENDING = new ConcurrentHashMap<>();
+
+    private static boolean killCauseExists() {
+        try {
+            EntityDamageEvent.DamageCause.valueOf("KILL");
+            return true;
+        } catch (IllegalArgumentException absentBefore120) {
+            return false;
+        }
+    }
+
+    // ------------------------------------------------------------------ capture
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerCommand(PlayerCommandPreprocessEvent e) {
+        if (!ACTIVE) return;
+        record(targetOf(e.getMessage()), e.getPlayer().getName());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onServerCommand(ServerCommandEvent e) {
+        // Console has no self to kill, so a bare "/kill" from it targets nobody.
+        if (!ACTIVE) return;
+        record(targetOf("/" + e.getCommand()), null);
+    }
+
+    /**
+     * @param target  what {@link #targetOf} returned, or null when not a kill
+     * @param selfName the sender's own name, used when the command had no target
+     */
+    private static void record(String target, String selfName) {
+        if (target == null) return;
+        final String who = target.isEmpty() ? selfName : target;
+        if (who == null) return;                       // bare /kill from console
+        PENDING.put(who.toLowerCase(Locale.ROOT), System.currentTimeMillis());
+    }
+
+    // ------------------------------------------------------------------- query
+
+    /**
+     * True when this player was the target of {@code /kill} a moment ago.
+     *
+     * <p>Consuming: a record is only good for the one death it explains, so a
+     * second void death seconds later is reported honestly as a void death.
+     */
+    static boolean wasKilledByCommand(Player victim) {
+        if (!ACTIVE || victim == null) return false;
+        final long now = System.currentTimeMillis();
+        prune(now);
+        return consume(victim.getName().toLowerCase(Locale.ROOT), now)
+                || consume(ANY_PLAYER, now);
+    }
+
+    private static boolean consume(String key, long now) {
+        final Long at = PENDING.get(key);
+        if (at == null || now - at > WINDOW_MS) return false;
+        PENDING.remove(key);
+        return true;
+    }
+
+    /** Entries only ever matter for a quarter of a second, so drop the rest. */
+    private static void prune(long now) {
+        PENDING.entrySet().removeIf(entry -> now - entry.getValue() > WINDOW_MS);
+    }
+
+    // ------------------------------------------------------------------ parsing
+
+    /**
+     * The target of a {@code /kill}, or null when the line is not one.
+     *
+     * <p>Returns an empty string for a bare {@code /kill}, meaning "the sender",
+     * and {@link #ANY_PLAYER} for a selector, which cannot be resolved from the
+     * text alone. A selector is treated as matching whoever dies next inside the
+     * window — within 250ms of a {@code /kill @a} that is what happened.
+     *
+     * <p>Split out from the listener so it can be tested without a server, since
+     * the awkward cases are all textual: plugin prefixes, trailing spaces, and
+     * commands that merely start with the letters "kill".
+     */
+    static String targetOf(String rawWithSlash) {
+        if (rawWithSlash == null) return null;
+        // Trim BEFORE stripping the slash: a leading space would otherwise leave
+        // the slash attached and the verb would never match.
+        String raw = rawWithSlash.trim();
+        if (raw.startsWith("/")) raw = raw.substring(1).trim();
+        if (raw.isEmpty()) return null;
+
+        final String[] parts = raw.split("\\s+");
+        String verb = parts[0].toLowerCase(Locale.ROOT);
+
+        // "/minecraft:kill" and "/essentials:kill" are the same command.
+        final int colon = verb.indexOf(':');
+        if (colon >= 0) verb = verb.substring(colon + 1);
+
+        // Exact match only -- "/killall" and "/killchest" are other plugins' commands.
+        if (!verb.equals("kill")) return null;
+
+        if (parts.length < 2) return "";                       // bare /kill = self
+        return parts[1].startsWith("@") ? ANY_PLAYER : parts[1];
+    }
+}

--- a/src/main/java/com/discordlogger/listener/player/PlayerDeath.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerDeath.java
@@ -94,6 +94,16 @@ public final class PlayerDeath implements Listener {
             return Lang.text("discord.death.slain-by-mob", "killer", mobName(damager));
         }
 
+        // Before 1.20 the server reports /kill as VOID, indistinguishable from
+        // genuinely falling out of the world. KillCommandTracker watches the command
+        // so the two can be told apart; on 1.20+ it is inert and this never fires.
+        if (last != null
+                && last.getCause() == EntityDamageEvent.DamageCause.VOID
+                && KillCommandTracker.wasKilledByCommand(victim)) {
+            final String byCommand = Lang.text("discord.death.causes.kill");
+            if (byCommand != null && !byCommand.isBlank()) return byCommand;
+        }
+
         final String text = last == null ? null : causeText(last.getCause());
         // Only reached when there is no damage cause at all, or Paper has added one
         // we do not know yet. causeTextIsExhaustive() in the tests fails on the latter.

--- a/src/test/java/com/discordlogger/listener/player/KillCommandTrackerTest.java
+++ b/src/test/java/com/discordlogger/listener/player/KillCommandTrackerTest.java
@@ -1,0 +1,91 @@
+package com.discordlogger.listener.player;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Parsing for the /kill correlation.
+ *
+ * <p>The window and the map need a live server, but the parsing is where the
+ * mistakes are: a plugin prefix, a selector, or another plugin's command that
+ * merely begins with the same letters. Getting any of those wrong mislabels a
+ * genuine void death as a command kill, which is worse than the bug this fixes.
+ */
+class KillCommandTrackerTest {
+
+    @Test
+    @DisplayName("a named target is returned as-is")
+    void namedTarget() {
+        assertEquals("Steve", KillCommandTracker.targetOf("/kill Steve"));
+        assertEquals("Steve", KillCommandTracker.targetOf("kill Steve"));
+        assertEquals("Steve", KillCommandTracker.targetOf("  /kill   Steve  "));
+    }
+
+    @Test
+    @DisplayName("a bare /kill means the sender")
+    void bareKillMeansSelf() {
+        assertEquals("", KillCommandTracker.targetOf("/kill"));
+        assertEquals("", KillCommandTracker.targetOf("/kill   "));
+    }
+
+    @Test
+    @DisplayName("a selector matches whoever dies in the window")
+    void selectorsBecomeWildcard() {
+        for (String sel : new String[]{"@a", "@p", "@s", "@e[type=player]"}) {
+            assertEquals("*", KillCommandTracker.targetOf("/kill " + sel), sel);
+        }
+    }
+
+    @Test
+    @DisplayName("a plugin prefix is the same command")
+    void pluginPrefixStripped() {
+        assertEquals("Steve", KillCommandTracker.targetOf("/minecraft:kill Steve"));
+        assertEquals("Steve", KillCommandTracker.targetOf("/essentials:kill Steve"));
+        assertEquals("", KillCommandTracker.targetOf("/minecraft:kill"));
+    }
+
+    @Test
+    @DisplayName("commands that merely start with 'kill' are not /kill")
+    void doesNotMatchOtherCommands() {
+        // The trap: prefix-matching here would attribute someone's void death to
+        // whatever /killall or /killchest happened to run a moment earlier.
+        assertNull(KillCommandTracker.targetOf("/killall"));
+        assertNull(KillCommandTracker.targetOf("/killchest Steve"));
+        assertNull(KillCommandTracker.targetOf("/kills"));
+        assertNull(KillCommandTracker.targetOf("/skill Steve"));
+    }
+
+    @Test
+    @DisplayName("non-commands and rubbish return null rather than throwing")
+    void handlesJunk() {
+        assertNull(KillCommandTracker.targetOf(null));
+        assertNull(KillCommandTracker.targetOf(""));
+        assertNull(KillCommandTracker.targetOf("/"));
+        assertNull(KillCommandTracker.targetOf("   "));
+        assertNull(KillCommandTracker.targetOf("/gamemode creative"));
+    }
+
+    @Test
+    @DisplayName("the tracker is inert on servers that report KILL themselves")
+    void inactiveWhereTheServerKnows() {
+        // Compiled against 1.19.4, where DamageCause.KILL does not exist -- so the
+        // correlation is ACTIVE here. On a 1.20+ server the same code sees KILL and
+        // switches itself off, which is the property that stops it guessing where
+        // the server already has the answer.
+        boolean killExists;
+        try {
+            org.bukkit.event.entity.EntityDamageEvent.DamageCause.valueOf("KILL");
+            killExists = true;
+        } catch (IllegalArgumentException e) {
+            killExists = false;
+        }
+        assertEquals(!killExists, KillCommandTracker.ACTIVE,
+                "the tracker must be active exactly when the server cannot tell them apart");
+        assertFalse(KillCommandTracker.wasKilledByCommand(null),
+                "a null victim must never be reported as killed by command");
+    }
+}


### PR DESCRIPTION
Reported while testing the backport: on 1.19, `/kill` logged as **"Fell into the void"**.

### Not a regression

`DamageCause.KILL` arrived in **1.20**. Before that the server reports `/kill` as `VOID` — literally the same cause as falling out of the world. The plugin was reporting exactly what it was told and had no way to distinguish them.

Affects `1.19` → `1.19.4`, five of the 28 supported versions.

### The fix

`KillCommandTracker` watches for the command and lets `PlayerDeath` correlate a `VOID` death against it — the same trick the moderation listeners already use: watch the command, then confirm against what actually happened.

**It switches itself off on 1.20+.** `ACTIVE` is false wherever `KILL` exists, so nothing is recorded and nothing consulted. Correlation is a workaround for missing information; running it where the information exists could only turn a correct answer into a guess.

### Kept narrow on purpose

A false positive mislabels a *genuine* void death, which is worse than the bug:

- **250ms window** — command, damage and death land in the same tick
- **Records are consumed** — a second void death seconds later reads honestly
- **Only `VOID` deaths** are ever reconsidered
- **Exact verb match** — `/killall` and `/killchest` are other plugins' commands, and prefix-matching would attribute a void death to whichever ran last

### Tested

Parsing is split out and tested without a server, because that's where the mistakes live: plugin prefixes (`/minecraft:kill`), selectors (`/kill @a`), leading whitespace.

**The whitespace case was a real bug the tests caught** — the slash was stripped before trimming, so `"  /kill Steve"` never matched.

Mutation-checked: changing `equals("kill")` to `startsWith("kill")` fails `doesNotMatchOtherCommands`. 209 tests green.