### PR TITLE
fix(seo): stop robots.txt blocking the generator's own assets

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -87,9 +87,9 @@
     </script>
     {%- endif -%}
 
-    <!-- Your theme + favicon -->
+    <!-- Stylesheet. The favicons are declared together further down; there is no
+         /assets/favicon.png and a link to one 404'd on every page. -->
     <link rel="stylesheet" href="{{ '/assets/theme.css?v=9' | relative_url }}">
-    <link rel="icon" href="{{ '/assets/favicon.png' | relative_url }}">
     <meta name="color-scheme" content="light dark">
 
     <!-- Site-wide version awareness: fills version numbers and applies BETA badges to

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -5,7 +5,4 @@ sitemap: false
 User-agent: *
 Allow: /
 
-# Build output and machine-readable data that adds nothing to search results.
-Disallow: /assets/configs/
-
 Sitemap: {{ site.url }}/sitemap.xml


### PR DESCRIPTION
`Disallow: /assets/configs/` blocked exactly the files the config generator fetches at runtime:

```
/assets/configs/registry.json          ← the loader's first fetch
/assets/configs/v10/generator.js       ← the bundle itself
/assets/configs/v10/options.json
/assets/configs/v10/config.template.yml
/assets/configs/v10/lang.template.yml
```

**Google renders JavaScript.** It loaded `/generator/`, ran the loader, the loader asked for `registry.json`, robots.txt forbade it, and the bundle never ran. The page indexed as a heading, one paragraph and an empty `<div>`.

The generator is the thing no competitor has, and it was the page most damaged by this.

The comment claimed the directory *"adds nothing to search results"* — reasonable-sounding and wrong. Google's guidance is explicit about never blocking CSS or JS needed to render.

### Now

```
User-agent: *
Allow: /

Sitemap: https://discordlogger.godtiergamers.xyz/sitemap.xml
```

Nothing on a 17-page static docs site needs blocking. The `Sitemap` directive is what keeps discovery independent of whether the Search Console submission ever succeeds.

Deliberately absent: `Crawl-delay` (Google ignores it), bad-bot blocklists (robots.txt is advisory; anything malicious ignores it).

### Also

Removed a dead `<link rel="icon" href="/assets/favicon.png">`, found by checking that every referenced asset actually exists. **That file has never existed** — the tag 404'd on all 17 pages. The real favicons are declared five lines below and are unaffected.

Verified: no `Disallow` rules remain, all five generator fetches are crawlable, every referenced asset resolves, favicons intact.