### PR TITLE
fix(metrics): --check-charts missed fully-qualified chart declarations

### DIFF
--- a/scripts/export-metrics.py
+++ b/scripts/export-metrics.py
@@ -55,8 +55,15 @@ PLUGIN_ID = 33026
 API = "https://bstats.org/api/v1/plugins"
 TIMEOUT = 30
 METRICS_SRC = "src/main/java/com/discordlogger/metrics/PluginMetrics.java"
+# Matches any bStats chart constructor: every one of their classes ends in Pie,
+# Chart or Bar. Two things this must tolerate, both of which have occurred in
+# this file: a fully-qualified name (2.2.0 registered enabled_events as
+# `new org.bstats.charts.AdvancedPie(...)`) and a line break between the
+# constructor and its id. An id this misses is a chart the check silently
+# believes was never declared -- the exact blind spot the check exists to close.
 CHART_DECL = re.compile(
-    r"new\s+(?:Simple|Advanced|SingleLine|MultiLine|Drilldown)\w*\(\s*\"([^\"]+)\""
+    r"new\s+(?:[\w.]+\.)?\w*(?:Pie|Chart|Bar)\s*\(\s*\"([^\"]+)\"",
+    re.MULTILINE,
 )
 
 


### PR DESCRIPTION
The regex required a bStats chart class to appear bare after `new`, so a **fully-qualified declaration was invisible to it**:

```java
metrics.addCustomChart(new org.bstats.charts.AdvancedPie("enabled_events", () -> enabledEvents(plugin)));
```

v2.2.0 registered `enabled_events` exactly that way. The check counted **3** charts where the file declared **4**.

### Why this is the worst possible place for that bug

A chart the regex fails to see is one it reports as *absent from Java*. So it can never notice that chart missing from bStats — **which is the one thing the mode exists to detect.** It would have gone on printing "Every declared chart exists on bStats" while data was silently discarded, and the count it printed would have been wrong.

### Fix

Broadened to any bStats chart class — they all end in `Pie`, `Chart` or `Bar` — with an optional package prefix and a tolerated line break before the id.

Verified against the tagged sources:

| Source | Before | After | Expected |
|---|---|---|---|
| `v2.2.0` | 3 | **4** | 4 |
| `v2.3.0` | 33 | **33** | 33 |
| `HEAD` | 31 | **31** | 31 (two duplicates removed after 2.3.0) |

### How it surfaced

Reviewing live bStats data. `enabled_events` was reporting across all 8 servers, but the chart list said it only shipped in 2.3.0 — which exactly one server runs. The data was right; my reading of the source was wrong.