### PR TITLE
fix(metrics): webhook_configured reported "Not installed"

### DIFF
--- a/src/main/java/com/discordlogger/metrics/PluginMetrics.java
+++ b/src/main/java/com/discordlogger/metrics/PluginMetrics.java
@@ -120,7 +120,7 @@ public final class PluginMetrics {
 
             // -------------------------------------------------------------- config health
             metrics.addCustomChart(new SimplePie("webhook_configured",
-                    () -> present(isWebhookSet(plugin))));
+                    () -> configured(isWebhookSet(plugin))));
             metrics.addCustomChart(new SimplePie("config_origin", () -> configOrigin(plugin)));
             metrics.addCustomChart(new SimplePie("migrated_from", () -> migratedFrom(plugin)));
             metrics.addCustomChart(new SimplePie("config_ahead_of_build",
@@ -545,6 +545,18 @@ public final class PluginMetrics {
 
     private static String present(boolean b) {
         return b ? "Installed" : "Not installed";
+    }
+
+    /**
+     * Whether a setting has been filled in — not whether something is installed.
+     *
+     * <p>Distinct from {@link #present(boolean)} because the two answer different
+     * questions and share no vocabulary. A webhook is configured or it isn't; it
+     * is never "installed", and a chart reading "Not installed" invites the
+     * reader to conclude the plugin isn't there at all.
+     */
+    private static String configured(boolean b) {
+        return b ? "Configured" : "Not configured";
     }
 
     private static String yesNo(boolean b) {


### PR DESCRIPTION
The chart reused `present()` — the helper written for **companion-plugin presence** — so a server with no webhook set rendered on bStats as:

```
webhook_configured:  Not installed = 1
```

### Why that's worse than just clumsy wording

A webhook isn't *installed*. It's configured or it isn't. And "Not installed" on a chart named `webhook_configured` reads most naturally as **the plugin itself being absent** — the exact opposite of what the data means, since only an installed plugin can report anything at all.

### Fix

Adds `configured()` returning `Configured` / `Not configured`, kept **separate** from `present()` rather than parameterising one helper. The two answer different questions and share no vocabulary — collapsing them is what produced the wrong label to begin with.

`present()` now covers only the three charts that genuinely are plugin presence: Floodgate, PlaceholderAPI, CoreProtect.

### On the data discontinuity

Renaming a slice starts a *new* one on bStats rather than relabelling the old, so the pre-fix "Not installed" tallies stay behind as a stub.

Doing it now because **exactly one server currently reports this chart** — 7 of 8 are still on 2.2.0, which predates it. The discontinuity will never be cheaper than it is today.

Found while reviewing live bStats data. 209 tests green.