### PR TITLE
fix(metrics): proxy_mode reported every Paper server as proxied

### DIFF
--- a/src/main/java/com/discordlogger/metrics/PluginMetrics.java
+++ b/src/main/java/com/discordlogger/metrics/PluginMetrics.java
@@ -228,19 +228,41 @@ public final class PluginMetrics {
      */
     private static String proxyMode() {
         try {
-            if (Bukkit.spigot().getConfig().getBoolean("settings.bungeecord", false)) {
-                return "BungeeCord or Velocity";
-            }
+            boolean velocity = false;
             final File paperGlobal = new File("config/paper-global.yml");
             if (paperGlobal.isFile()) {
-                final YamlConfiguration y = YamlConfiguration.loadConfiguration(paperGlobal);
-                if (y.getBoolean("proxies.velocity.enabled", false)) return "Velocity";
-                if (y.getBoolean("proxies.bungee-cord.online-mode", false)) return "BungeeCord";
+                velocity = YamlConfiguration.loadConfiguration(paperGlobal)
+                        .getBoolean("proxies.velocity.enabled", false);
             }
-            return "None";
+            return proxyModeOf(
+                    Bukkit.spigot().getConfig().getBoolean("settings.bungeecord", false),
+                    velocity);
         } catch (Throwable t) {
             return UNKNOWN;
         }
+    }
+
+    /**
+     * The proxy verdict, split out from the file reading so it can be tested.
+     *
+     * <p><strong>Do not reintroduce a check on {@code proxies.bungee-cord.online-mode}.</strong>
+     * That key ships as {@code true} in every {@code paper-global.yml} and only means
+     * anything when {@code settings.bungeecord} is already on, so reading it alone
+     * reported "BungeeCord" for every default Paper server. The chart showed 100% of
+     * servers proxied while bStats' own {@code onlineMode} put the ceiling at a
+     * quarter — a proxied backend must run offline-mode, and most of these were online.
+     *
+     * @param bungeeFlag  {@code settings.bungeecord} from spigot.yml
+     * @param velocityOn  {@code proxies.velocity.enabled} from paper-global.yml
+     */
+    static String proxyModeOf(boolean bungeeFlag, boolean velocityOn) {
+        // Modern forwarding is the one unambiguous signal, so it wins outright.
+        if (velocityOn) return "Velocity";
+        // Velocity's legacy forwarding is configured through the same spigot.yml flag
+        // BungeeCord uses, so this genuinely cannot tell them apart. Say so rather
+        // than guessing — a wrong attribution is worse than a vague one.
+        if (bungeeFlag) return "BungeeCord or Velocity";
+        return "None";
     }
 
     // --------------------------------------------------------------- config health

--- a/src/test/java/com/discordlogger/metrics/PluginMetricsTest.java
+++ b/src/test/java/com/discordlogger/metrics/PluginMetricsTest.java
@@ -113,4 +113,32 @@ class PluginMetricsTest {
         assertNotEquals("discord", PluginMetrics.langSection("discord.death.causes.void"));
         assertNotEquals("discord", PluginMetrics.langSection("discord.death.description"));
     }
+
+    // ------------------------------------------------------------------ proxyMode
+
+    @Test
+    @DisplayName("a default Paper server is not reported as proxied")
+    void defaultPaperServerIsNotProxied() {
+        // The regression this pins: proxies.bungee-cord.online-mode ships as true
+        // everywhere, so reading it made every stock Paper server claim BungeeCord.
+        assertEquals("None", PluginMetrics.proxyModeOf(false, false));
+    }
+
+    @Test
+    @DisplayName("modern Velocity forwarding is named exactly")
+    void velocityIsNamed() {
+        assertEquals("Velocity", PluginMetrics.proxyModeOf(false, true));
+    }
+
+    @Test
+    @DisplayName("the spigot.yml flag cannot tell BungeeCord from legacy Velocity")
+    void bungeeFlagStaysAmbiguous() {
+        assertEquals("BungeeCord or Velocity", PluginMetrics.proxyModeOf(true, false));
+    }
+
+    @Test
+    @DisplayName("modern Velocity wins over the ambiguous flag")
+    void velocityBeatsTheAmbiguousFlag() {
+        assertEquals("Velocity", PluginMetrics.proxyModeOf(true, true));
+    }
 }


### PR DESCRIPTION
`proxyMode()` fell through to this:

```java
if (y.getBoolean("proxies.bungee-cord.online-mode", false)) return "BungeeCord";
```

**That key ships as `true` in every `paper-global.yml`.** It only means anything when `settings.bungeecord` is already on — which the method checks first — so reading it alone made a stock, unproxied Paper server report "BungeeCord".

### The data disproved it internally

| Chart | Says |
|---|---|
| `proxy_mode` | **6 of 6** servers behind a proxy |
| `onlineMode` (bStats default) | only **3 of 12** running offline |

A proxied backend *must* run offline-mode. So the true ceiling was a quarter, not everything — and `None` could essentially never be returned on Paper.

### Why it mattered beyond a wrong pie slice

The **Velocity** item in TODO.md cites proxy adoption as its justification. This chart made it look universal when at most a quarter of servers could possibly be proxied. A roadmap decision was resting on it.

### The fix

Drops the bad check. What's left:

- `proxies.velocity.enabled` → **Velocity** (modern forwarding, unambiguous, wins outright)
- `settings.bungeecord` → **BungeeCord or Velocity** (Velocity's *legacy* forwarding uses the same spigot.yml flag, so these genuinely can't be told apart — a vague answer beats a confidently wrong one)
- otherwise → **None**

Splits the verdict into `proxyModeOf(boolean, boolean)` so it's testable without a server, the same way `ConfigMigrator.decide` is. Four tests, including one pinning that a default Paper server reads as `None`.

213 tests green (was 209).

**Note on continuity:** existing "BungeeCord" tallies stay on bStats as a stub, and the corrected data starts fresh once this ships. The chart is only 6 servers deep, so now is the cheapest time.