### PR TITLE
feat: check the configured webhooks still exist at startup

### DIFF
--- a/src/main/java/com/discordlogger/DiscordLogger.java
+++ b/src/main/java/com/discordlogger/DiscordLogger.java
@@ -75,6 +75,10 @@ public final class DiscordLogger extends JavaPlugin {
         // Async update check (console + Discord notice if newer version available)
         UpdateChecker.checkAsync(this);
 
+        // Confirms the configured webhooks still exist, rather than finding out from
+        // the first event that 404s. Async: it must not hold up the server starting.
+        Log.validateWebhooksAsync();
+
         // Server start log will go to console; to Discord only if webhook is valid
         events.fireServerStart();
         getLogger().info("Core loaded.");

--- a/src/main/java/com/discordlogger/log/Log.java
+++ b/src/main/java/com/discordlogger/log/Log.java
@@ -9,6 +9,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -174,6 +175,80 @@ public final class Log {
             plugin.getLogger().info("Per-event webhook routing active for "
                     + wm.size() + " categor" + (wm.size() == 1 ? "y" : "ies") + ".");
         }
+    }
+
+    /**
+     * Confirms every configured webhook still exists, once, at startup.
+     *
+     * <p>Without this, a webhook deleted in Discord is discovered by the first event
+     * that 404s — which can be hours later, looks like the plugin breaking, and loses
+     * everything in between. It happened: 345 events went into a dead webhook across
+     * three and a half hours before anything surfaced, and the only warning went to
+     * console, where nobody was watching.
+     *
+     * <p><b>Never logs a URL.</b> A webhook URL is a bearer credential, so failures
+     * name the config path that holds it and nothing else — enough to fix it, useless
+     * to anyone reading the log.
+     *
+     * <p>Deduplicated by URL: routing many categories to one channel is the common
+     * case, and probing per category would fire a burst of identical requests at
+     * Discord on every boot for no extra information.
+     */
+    public static void validateWebhooksAsync() {
+        final JavaPlugin pl = plugin;
+        if (!ready || pl == null) return;
+
+        // webhookFor(null) rather than webhookUrl: the field is only ever read through
+        // that accessor, and LogRoutingTest enforces it. Reaching past it here would
+        // have been harmless (this enumerates destinations, it does not send) but the
+        // guard cannot tell the two apart, and a rule with exceptions stops being one.
+        final Map<String, String> byUrl = new LinkedHashMap<>();
+        final String main = webhookFor(null);
+        if (main != null && !main.isBlank()) byUrl.put(main, "webhook.url");
+        for (Map.Entry<String, String> e : webhookMap.entrySet()) {
+            byUrl.putIfAbsent(e.getValue(), "log." + e.getKey() + ".webhook");
+        }
+        if (byUrl.isEmpty()) return;
+
+        pl.getServer().getScheduler().runTaskAsynchronously(pl, () -> {
+            for (Map.Entry<String, String> e : byUrl.entrySet()) {
+                describeProbe(pl, e.getValue(), DiscordWebhook.probe(e.getKey()));
+            }
+        });
+    }
+
+    /**
+     * Turns a probe status into console output, or into nothing.
+     *
+     * <p>Split out so the wording is testable without a server. The distinction that
+     * matters: 404 is the admin's problem and must be loud, while an unreachable
+     * Discord proves nothing about the webhook and must not cry wolf — a plugin that
+     * warns about a working webhook during a network blip teaches people to ignore it.
+     */
+    static void describeProbe(JavaPlugin pl, String where, int status) {
+        final String msg = probeMessage(where, status);
+        if (msg == null) return;
+        if (status == 404 || status == 401 || status == 403) pl.getLogger().warning(msg);
+        else pl.getLogger().fine(msg);
+    }
+
+    /** The message for a probe result, or null when the result is unremarkable. */
+    static String probeMessage(String where, int status) {
+        if (status == 404) {
+            return "The webhook set in " + where + " no longer exists in Discord (404)."
+                    + " Everything routed there will be discarded until it is replaced."
+                    + " Set a new one with /discordlogger webhook <url>, or edit config.yml"
+                    + " and run /discordlogger reload.";
+        }
+        if (status == 401 || status == 403) {
+            return "Discord rejected the webhook set in " + where + " (HTTP " + status
+                    + "). It may have been regenerated.";
+        }
+        if (status == 0 || status >= 500) {
+            return "Could not reach Discord to check " + where + " (status " + status
+                    + "). This says nothing about whether the webhook is valid.";
+        }
+        return null;
     }
 
     // ---- Public helpers (used by other components like UpdateChecker) ----

--- a/src/main/java/com/discordlogger/webhook/DiscordWebhook.java
+++ b/src/main/java/com/discordlogger/webhook/DiscordWebhook.java
@@ -212,6 +212,32 @@ public final class DiscordWebhook {
         }
     }
 
+    /**
+     * Asks Discord whether a webhook still exists, without posting anything.
+     *
+     * <p>A GET on a webhook URL returns 200 with its JSON while it lives and 404 once
+     * it has been deleted in Discord. That distinction is the whole point: a deleted
+     * webhook is otherwise only discovered when the first real event 404s, which in
+     * production meant 345 messages posted into a dead webhook across three and a half
+     * hours before anyone noticed.
+     *
+     * <p>Returns the raw status so the caller can tell "gone" (404) from "could not
+     * ask" (0, or a 5xx) — those need different wording, since only one of them is
+     * the admin's problem.
+     */
+    public static int probe(String url) {
+        try {
+            HttpClient client = HttpClient.newBuilder().connectTimeout(TIMEOUT).build();
+            HttpRequest req = HttpRequest.newBuilder(URI.create(url))
+                    .timeout(TIMEOUT)
+                    .GET()
+                    .build();
+            return client.send(req, HttpResponse.BodyHandlers.discarding()).statusCode();
+        } catch (Exception unreachable) {
+            return 0;
+        }
+    }
+
     /** Reads a numeric header and scales it (headers are in seconds; we work in millis). */
     private static Long headerAsLong(HttpResponse<String> res, String name, double scale) {
         return res.headers().firstValue(name)

--- a/src/test/java/com/discordlogger/log/LogRedactionTest.java
+++ b/src/test/java/com/discordlogger/log/LogRedactionTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -72,5 +74,48 @@ class LogRedactionTest {
                 "plain HTTP would put the token on the wire in clear");
         assertFalse(Log.isValidWebhookUrl(""));
         assertFalse(Log.isValidWebhookUrl(null));
+    }
+
+    // ------------------------------------------------- startup webhook validation
+
+    @Test
+    @DisplayName("a deleted webhook is reported, and says how to fix it")
+    void deletedWebhookIsLoud() {
+        String msg = Log.probeMessage("webhook.url", 404);
+        assertNotNull(msg);
+        assertTrue(msg.contains("no longer exists"), msg);
+        assertTrue(msg.contains("/discordlogger webhook"), msg);
+    }
+
+    @Test
+    @DisplayName("an unreachable Discord does not accuse the webhook")
+    void unreachableDoesNotCryWolf() {
+        // The failure mode this guards: warning that a perfectly good webhook is dead
+        // every time the network blips teaches admins to ignore the warning that matters.
+        for (int status : new int[]{0, 500, 502, 503}) {
+            String msg = Log.probeMessage("webhook.url", status);
+            assertNotNull(msg, "status " + status);
+            assertTrue(msg.contains("says nothing about whether the webhook is valid"),
+                    "status " + status + ": " + msg);
+        }
+    }
+
+    @Test
+    @DisplayName("a healthy webhook produces no output at all")
+    void healthyIsSilent() {
+        assertNull(Log.probeMessage("webhook.url", 200));
+        assertNull(Log.probeMessage("webhook.url", 204));
+    }
+
+    @Test
+    @DisplayName("no probe message ever contains a webhook URL")
+    void probeMessagesNeverLeakTheUrl() {
+        // The message names the config path, never the credential it holds.
+        for (int status : new int[]{0, 200, 401, 403, 404, 500}) {
+            String msg = Log.probeMessage("log.player.join.webhook", status);
+            if (msg == null) continue;
+            assertFalse(msg.contains("discord.com"), msg);
+            assertFalse(msg.contains("https://"), msg);
+        }
     }
 }


### PR DESCRIPTION
Closes the gap the live metrics exposed: **345 events went into a dead webhook across 3½ hours** before anything surfaced, and the only warning went to console where nobody was watching.

A deleted webhook was previously discovered by the first event that 404'd. Now it's discovered at startup.

### How

`Log.validateWebhooksAsync()` GETs each configured webhook once on boot. Discord returns 200 while a webhook lives and 404 once deleted — no auth needed, nothing posted.

### Three deliberate behaviours

**It never logs a URL.** A webhook URL is a bearer credential, so failures name the *config path* holding it — `webhook.url`, `log.player.join.webhook` — and nothing else. Enough to fix it, useless to anyone reading the log. A test asserts no probe message can contain `https://`.

**It never accuses the webhook when Discord is unreachable.** Status 0 and 5xx say nothing about validity. A plugin that warns a working webhook is dead on every network blip teaches admins to ignore the warning that matters.

**It deduplicates by URL.** Routing many categories to one channel is the common case; probing per category would fire a burst of identical requests at Discord on every boot for no extra information.

### The test suite caught me

My first version read the `webhookUrl` field directly to enumerate destinations. `LogRoutingTest.everySendSiteResolvesARoute` failed it:

```
these read webhookUrl directly instead of webhookFor(category), so they would
ignore per-event routing ==> expected: <[]> but was: <[202: ...]>
```

Technically a false positive — this enumerates, it doesn't send. But the guard can't distinguish those, and a rule with exceptions stops being one, so it now goes through `webhookFor(null)` like everything else.

### Scope

No config key, so **no schema bump**. One GET per distinct webhook at startup, async so it can't delay the server coming up.

213 tests green (+4), and `mvn package` builds clean.