### PR TITLE
fix(metrics): the store recorded blank rows and a wrong denominator

### DIFF
--- a/.github/metrics-store.md
+++ b/.github/metrics-store.md
@@ -20,7 +20,7 @@ that never happens is the one left until "later".
 | `series` | outer slice for drilldowns, line name for line charts, else empty |
 | `label` | slice name — or, for line charts, **the sample's own bStats timestamp** |
 | `value` | servers reporting that slice |
-| `servers_reporting` | total servers reporting **that chart** at that poll; empty for line charts |
+| `servers_reporting` | servers reporting **that chart** at that poll; empty for line charts. Sum of slices for simple/drilldown pies, largest slice for advanced pies — see below |
 
 ## ⚠️ `servers_reporting` is the denominator. Use it.
 
@@ -44,6 +44,15 @@ newer: `colors_customised`, `command_filter_state`, `commands_used`,
 You do not have to remember that list — `servers_reporting` carries it in the data.
 A poll where `release_channel` sums to 11 while `vanish_plugin` sums to 5 is telling
 you the second figure covers five servers, not eleven.
+
+### Advanced pies count differently
+
+A simple or drilldown pie puts each server in exactly one slice, so its slices sum
+to the server count. An **advanced pie** lets one server contribute to many slices
+at once — `enabled_events` summed to **201** across 13 servers — so a sum there is a
+total, not a population. `servers_reporting` therefore holds the *largest slice* for
+those, which is a lower bound on how many servers reported and in practice within
+one of the truth.
 
 ## How each chart type is stored
 

--- a/scripts/export-metrics.py
+++ b/scripts/export-metrics.py
@@ -231,7 +231,15 @@ def append_snapshot(meta: dict, plugin_id: int, out_dir: str) -> int:
                 rows.append([stamp, cid, ctype, series, label, value, ""])
                 added_line += 1
         else:
-            total = sum(int(v) for _, _, v in flat if v.isdigit())
+            vals = [int(v) for _, _, v in flat if v.isdigit()]
+            # How many servers a chart represents depends on whether its slices are
+            # mutually exclusive. A simple or drilldown pie puts each server in
+            # exactly one slice, so the sum IS the server count. An advanced pie lets
+            # one server contribute to many slices at once -- enabled_events summed to
+            # 201 across 13 servers -- so the sum is a total, not a population. The
+            # largest slice is the honest figure there: a lower bound on how many
+            # servers reported, and within one of the truth in practice.
+            total = max(vals, default=0) if ctype == "advanced_pie" else sum(vals)
             for series, label, value in flat:
                 rows.append([stamp, cid, ctype, series, label, value, total])
                 added_pie += 1

--- a/scripts/export-metrics.py
+++ b/scripts/export-metrics.py
@@ -100,12 +100,24 @@ def flatten(chart: dict, data: Any) -> list[tuple[str, str, str]]:
                 if isinstance(inner, list) and len(inner) >= 2:
                     rows.append((outer.get("name", ""), str(inner[0]), str(inner[1])))
 
+    elif ctype.endswith("map"):
+        # Map charts are the odd one out: [{"code": "DE", "value": 3}, ...] rather
+        # than the {name, y} every other chart uses. Falling through to the pie
+        # branch produced a row with no label and no value -- 149 of them before
+        # this was caught, which is also why the value is asserted below.
+        for entry in data or []:
+            if isinstance(entry, dict) and entry.get("code") is not None:
+                rows.append(("", str(entry["code"]), str(entry.get("value", ""))))
+
     else:  # simple_pie / advanced_pie -- [{"name": ..., "y": ...}, ...]
         for slice_ in data or []:
             if isinstance(slice_, dict):
                 rows.append(("", str(slice_.get("name", "")), str(slice_.get("y", ""))))
 
-    return rows
+    # A row with no value carries nothing and silently breaks any sum over the
+    # column. Dropping it here keeps an unrecognised chart shape from quietly
+    # filling the store with blanks the way simple_map did.
+    return [r for r in rows if r[1] != "" and r[2] != ""]
 
 
 def declared_charts(src: str) -> set[str]:


### PR DESCRIPTION
Found while reviewing the first day of collected data.

bStats map charts return a different shape from everything else:

```json
[{"code":"AU","value":1},{"code":"DE","value":3}]
```

Every other chart uses `{name, y}`. So `locationMap` fell through to the pie branch and produced rows with **no label and no value** — 149 of them reached the store, and they break any sum over the `value` column.

### Fix

Adds the map branch, plus a guard that drops any row still ending up with an empty label or value.

**The guard matters more than the branch.** Without it, an unrecognised chart shape fills the store with blanks silently — which is exactly how this got in. Failing to record something is recoverable on the next poll; recording nothing while claiming to have recorded is not.

### No history lost

`locationMap` duplicates the `location` pie, which carries the same figures as country names and recorded correctly throughout. The blank rows are identifiable by `chart_id` and can be ignored or cleaned from the branch — say the word if you want them purged.

Verified: `blanks now: 0`, and map rows land as `locationMap,simple_map,,AU,1,13`.