### PR TITLE
fix(commands): strip Bukkit's plugin:command duplicates from tab-completion

### DIFF
--- a/src/main/java/com/discordlogger/DiscordLogger.java
+++ b/src/main/java/com/discordlogger/DiscordLogger.java
@@ -1,5 +1,6 @@
 package com.discordlogger;
 
+import com.discordlogger.command.CommandVisibility;
 import com.discordlogger.command.Commands;
 import com.discordlogger.command.Regen;
 import com.discordlogger.command.Reload;
@@ -66,6 +67,10 @@ public final class DiscordLogger extends JavaPlugin {
             Commands router = new Commands(new Reload(this), new Webhook(this), new Regen(this));
             getCommand("discordlogger").setExecutor(router);
             getCommand("discordlogger").setTabCompleter(router);
+            // Strips Bukkit's plugin:command duplicates from tab-completion, and
+            // hides the command from players who hold none of its permissions.
+            getServer().getPluginManager().registerEvents(
+                    new CommandVisibility(this, router), this);
         }
 
         // Anonymous usage metrics (bstats.org). Opt out via plugins/bStats/config.yml.

--- a/src/main/java/com/discordlogger/command/CommandVisibility.java
+++ b/src/main/java/com/discordlogger/command/CommandVisibility.java
@@ -1,0 +1,109 @@
+package com.discordlogger.command;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerCommandSendEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Keeps this plugin's noise out of a player's tab-completion.
+ *
+ * <h2>Why the plugin's own tab completer cannot fix this</h2>
+ *
+ * <p>Two different completions look identical in game. Typing {@code /discordlogger }
+ * and pressing tab completes <em>arguments</em>, which {@link Commands#onTabComplete}
+ * handles and has always handled correctly. Pressing tab before that space completes
+ * <em>command names</em>, and the plugin is never consulted — the server answers from
+ * its own registry.
+ *
+ * <p>That registry holds more than was asked for. Bukkit registers every plugin
+ * command a second time under a {@code plugin:command} alias, so a command declared
+ * once with two aliases produces six entries, and the player is offered
+ * {@code discordlogger:discordlogger}, {@code discordlogger:dlogger} and
+ * {@code discordlogger:dlog} beside the three real ones.
+ *
+ * <p>{@link PlayerCommandSendEvent} is the only place this can be corrected: it fires
+ * as the command list is sent and its collection can be removed from.
+ *
+ * <h2>Removing an entry does not remove the command</h2>
+ *
+ * <p>This affects suggestions only. {@code /discordlogger:reload} still runs, which is
+ * the point of the namespaced form — it exists so a command can still be reached when
+ * two plugins claim the same name. Hiding it costs nothing and keeps it available for
+ * the one case it was designed for.
+ */
+public final class CommandVisibility implements Listener {
+
+    private final Commands router;
+
+    /** {@code "discordlogger:"} — every namespaced alias this plugin owns starts with it. */
+    private final String namespace;
+
+    /** {@code discordlogger}, {@code dlogger}, {@code dlog} — read from plugin.yml. */
+    private final Set<String> labels;
+
+    public CommandVisibility(JavaPlugin plugin, Commands router) {
+        this.router = router;
+        this.namespace = plugin.getName().toLowerCase(Locale.ROOT) + ":";
+        this.labels = declaredLabels(plugin);
+    }
+
+    /**
+     * Every name this plugin's commands answer to, taken from plugin.yml.
+     *
+     * <p>Read rather than hard-coded so adding an alias stays a one-line descriptor
+     * change. A hard-coded list would drift silently, and the symptom — one stray
+     * {@code discordlogger:} entry reappearing in tab-complete — is exactly the kind
+     * nobody reports.
+     */
+    private static Set<String> declaredLabels(JavaPlugin plugin) {
+        final Set<String> out = new HashSet<>();
+        for (Map.Entry<String, Map<String, Object>> e
+                : plugin.getDescription().getCommands().entrySet()) {
+            out.add(e.getKey().toLowerCase(Locale.ROOT));
+            final Object aliases = e.getValue().get("aliases");
+            if (aliases instanceof List<?> list) {
+                for (Object a : list) out.add(String.valueOf(a).toLowerCase(Locale.ROOT));
+            } else if (aliases != null) {
+                out.add(String.valueOf(aliases).toLowerCase(Locale.ROOT));
+            }
+        }
+        return out;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onCommandSend(PlayerCommandSendEvent e) {
+        final boolean usable = router.isUsableBy(e.getPlayer());
+        e.getCommands().removeIf(entry -> isNoise(entry, namespace, labels, usable));
+    }
+
+    /**
+     * Whether an entry should be dropped from this player's command list.
+     *
+     * <p>Pure so the decision can be tested without a server, and deliberately narrow
+     * in two ways. It only ever touches <em>this</em> plugin's entries — another
+     * plugin's namespaced aliases are its business, and a plugin that quietly edits
+     * them is a plugin nobody can debug. And it matches the suffix against the
+     * declared labels rather than dropping everything under the namespace, so an
+     * unrelated command that happens to start with {@code discordlogger:} survives.
+     *
+     * @param usable whether the player can run any subcommand; when false the plain
+     *               names go too, since a command offering nothing is the same noise
+     *               in a friendlier hat
+     */
+    static boolean isNoise(String entry, String namespace, Set<String> labels, boolean usable) {
+        if (entry == null) return false;
+        final String s = entry.toLowerCase(Locale.ROOT);
+        if (s.startsWith(namespace)) {
+            return labels.contains(s.substring(namespace.length()));
+        }
+        return !usable && labels.contains(s);
+    }
+}

--- a/src/main/java/com/discordlogger/command/Commands.java
+++ b/src/main/java/com/discordlogger/command/Commands.java
@@ -77,6 +77,23 @@ public final class Commands implements CommandExecutor, TabCompleter {
         return sc.tabComplete(sender, tail);
     }
 
+    /**
+     * Whether this sender can run anything at all.
+     *
+     * <p>The root command is deliberately ungated — gating it would lock a
+     * {@code regen}-only admin out of the whole command — so "can use this plugin"
+     * is not a single permission but "holds at least one subcommand's". Used by
+     * {@link CommandVisibility} to keep the command out of tab-completion for
+     * players it would do nothing for.
+     */
+    public boolean isUsableBy(CommandSender sender) {
+        for (Subcommand sc : subs.values()) {
+            final String perm = sc.permission();
+            if (perm == null || perm.isBlank() || sender.hasPermission(perm)) return true;
+        }
+        return false;
+    }
+
     private void sendHelp(CommandSender sender, String label) {
         sender.sendMessage(Lang.chat("chat.help-header"));
         for (Subcommand sc : subs.values()) {

--- a/src/test/java/com/discordlogger/command/CommandVisibilityTest.java
+++ b/src/test/java/com/discordlogger/command/CommandVisibilityTest.java
@@ -1,0 +1,83 @@
+package com.discordlogger.command;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The tab-completion filter. Pure decisions only — the event itself needs a server.
+ */
+class CommandVisibilityTest {
+
+    private static final String NS = "discordlogger:";
+    private static final Set<String> LABELS = Set.of("discordlogger", "dlogger", "dlog");
+
+    private static boolean noise(String entry, boolean usable) {
+        return CommandVisibility.isNoise(entry, NS, LABELS, usable);
+    }
+
+    @Test
+    @DisplayName("the plugin:command duplicates go, for everyone")
+    void namespacedDuplicatesAreDropped() {
+        // The reported symptom: these three were offered beside the real commands.
+        for (String e : new String[]{
+                "discordlogger:discordlogger", "discordlogger:dlogger", "discordlogger:dlog"}) {
+            assertTrue(noise(e, true), e + " should be hidden from an op");
+            assertTrue(noise(e, false), e + " should be hidden from a normal player");
+        }
+    }
+
+    @Test
+    @DisplayName("the real commands survive for someone who can use them")
+    void realCommandsSurviveForPrivileged() {
+        assertFalse(noise("discordlogger", true));
+        assertFalse(noise("dlogger", true));
+        assertFalse(noise("dlog", true));
+    }
+
+    @Test
+    @DisplayName("a player who can run nothing is not offered the command")
+    void hiddenEntirelyWithoutPermission() {
+        assertTrue(noise("discordlogger", false));
+        assertTrue(noise("dlogger", false));
+        assertTrue(noise("dlog", false));
+    }
+
+    @Test
+    @DisplayName("other plugins are left completely alone")
+    void otherPluginsUntouched() {
+        // Editing another plugin's entries makes its behaviour unexplainable from
+        // its own source, which is worse than the noise this fixes.
+        for (String e : new String[]{
+                "essentials:home", "minecraft:kill", "worldedit:/set", "home", "kill"}) {
+            assertFalse(noise(e, true), e);
+            assertFalse(noise(e, false), e);
+        }
+    }
+
+    @Test
+    @DisplayName("an unrelated command under our namespace is left alone")
+    void onlyDeclaredLabelsAreMatched() {
+        // Matching the whole namespace rather than the declared labels would hide
+        // anything another plugin registered there.
+        assertFalse(noise("discordlogger:somethingelse", true));
+        assertFalse(noise("discordlogger:somethingelse", false));
+    }
+
+    @Test
+    @DisplayName("matching ignores case")
+    void caseInsensitive() {
+        assertTrue(noise("DiscordLogger:DLog", true));
+        assertTrue(noise("DLOGGER", false));
+    }
+
+    @Test
+    @DisplayName("a null entry is not an error")
+    void nullIsSafe() {
+        assertFalse(noise(null, true));
+    }
+}


### PR DESCRIPTION
Typing `/discordlogger` and pressing tab offered this:

```
discordlogger   discordlogger:discordlogger   discordlogger:dlogger   discordlogger:dlog   dlogger   dlog
```

### The plugin's completer was never involved

Two different completions look identical in game:

| You type | Tab completes | Who answers |
|---|---|---|
| `/discordlogger ` (with space) | **arguments** | `Commands.onTabComplete` — always worked correctly |
| `/discordlogger` (no space) | **command names** | the server, from its own registry |

Bukkit registers every plugin command a second time under a `plugin:command` alias, so one command with two aliases becomes **six** entries. No amount of fixing `onTabComplete` could have touched this.

`PlayerCommandSendEvent` is the only place it can be corrected — it fires as the list is sent, and its collection can be removed from.

**Removing an entry does not remove the command.** `/discordlogger:reload` still runs, which is exactly what the namespaced form is for: reaching a command when two plugins claim the same name. Nothing is lost by not *suggesting* it.

### Also hides the command from players who can't use it

Per your pick. `Commands` already filters help and argument-completion by permission, so an unprivileged player was being offered a command that does nothing for them. Ops are unaffected — all three subcommands are op-default.

### Two deliberate limits, both tested

- **Only this plugin's entries.** `essentials:home`, `minecraft:kill`, `worldedit:/set` are untouched. A plugin that quietly edits another's command list makes that plugin's behaviour unexplainable from its own source.
- **Matches declared labels, not the whole namespace.** A hypothetical `discordlogger:somethingelse` registered by someone else survives.

Labels are read from `plugin.yml` rather than hard-coded, so adding an alias needs no code change — a hard-coded list would drift and the symptom (one stray entry reappearing) is exactly the kind nobody reports.

### Verified

224 tests (+7), and it compiles against the 1.19 compat floor — `PlayerCommandSendEvent` is 1.13+, so the floor is safe.

**I have not tested this in game.** The decision logic is unit-tested, but the event wiring wants a real server — worth a look on your test box before it ships.