### PR TITLE
feat: log any plugin's commands with your own events

### DIFF
--- a/docs/assets/configs/v11/config.template.yml
+++ b/docs/assets/configs/v11/config.template.yml
@@ -268,4 +268,41 @@ log:
       color: "{{COLOR_moderation.whitelist_edit}}" # dark teal
       webhook: "{{HOOK_moderation.whitelist_edit}}" # Send just this event elsewhere. Empty = use webhook.url above
 
+  # ----------------------------------------------------------------------------------
+  # Your own events, built from any command on the server.
+  #
+  # This is how you log plugins DiscordLogger has never heard of -- Essentials homes,
+  # LuckPerms rank changes, shop purchases, anything with a command behind it. Each
+  # entry becomes a real event with its own colour and its own webhook, exactly like
+  # the built-in ones.
+  #
+  # It watches the command being RUN, not the action succeeding. That is the honest
+  # limit: for a ban, DiscordLogger checks afterwards that the ban list actually
+  # changed, and a custom rule cannot do that. If it matters that the command worked,
+  # this is the wrong tool.
+  #
+  # Placeholders: {player} {command} {args} {world} and {arg1}...{arg9}
+  #
+  # Example -- delete the leading '#' on each line to use it:
+  #
+  #   sethome:
+  #     enabled: true
+  #     match: "sethome"            # Command to watch. Multiple words match a subcommand.
+  #     title: "Home Set"
+  #     message: "{player} set a home called {arg1}"
+  #     color: "#5865F2" # blurple
+  #     webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+  #
+  #   rank_change:
+  #     enabled: true
+  #     match: "lp user"            # Fires on /lp user <name> ...
+  #     title: "Rank Changed"
+  #     message: "{player} ran {command} on {arg2}: {arg3} {arg4}"
+  #     color: "#E67E22" # orange
+  #     webhook: ""
+  #
+  # Commands in filters.ignored_commands are never logged here either -- the deny-list
+  # wins, and the console says so on startup if a rule collides with it.
+  custom: {}
+
 # CONFIG VERSION V11, GENERATED ON WEBSITE ON {{GENERATED_AT}}

--- a/docs/assets/configs/v11/config.yml
+++ b/docs/assets/configs/v11/config.yml
@@ -281,4 +281,41 @@ log:
       color: "#16A085" # dark teal
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
 
+  # ----------------------------------------------------------------------------------
+  # Your own events, built from any command on the server.
+  #
+  # This is how you log plugins DiscordLogger has never heard of -- Essentials homes,
+  # LuckPerms rank changes, shop purchases, anything with a command behind it. Each
+  # entry becomes a real event with its own colour and its own webhook, exactly like
+  # the built-in ones.
+  #
+  # It watches the command being RUN, not the action succeeding. That is the honest
+  # limit: for a ban, DiscordLogger checks afterwards that the ban list actually
+  # changed, and a custom rule cannot do that. If it matters that the command worked,
+  # this is the wrong tool.
+  #
+  # Placeholders: {player} {command} {args} {world} and {arg1}...{arg9}
+  #
+  # Example -- delete the leading '#' on each line to use it:
+  #
+  #   sethome:
+  #     enabled: true
+  #     match: "sethome"            # Command to watch. Multiple words match a subcommand.
+  #     title: "Home Set"
+  #     message: "{player} set a home called {arg1}"
+  #     color: "#5865F2" # blurple
+  #     webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+  #
+  #   rank_change:
+  #     enabled: true
+  #     match: "lp user"            # Fires on /lp user <name> ...
+  #     title: "Rank Changed"
+  #     message: "{player} ran {command} on {arg2}: {arg3} {arg4}"
+  #     color: "#E67E22" # orange
+  #     webhook: ""
+  #
+  # Commands in filters.ignored_commands are never logged here either -- the deny-list
+  # wins, and the console says so on startup if a rule collides with it.
+  custom: {}
+
 # CONFIG VERSION V11, DOWNLOADED FROM WEBSITE

--- a/docs/config/v11/index.md
+++ b/docs/config/v11/index.md
@@ -774,6 +774,68 @@ in code.
 
 ---
 
+### `log.custom` — your own events
+
+Log plugins DiscordLogger has never heard of. Each entry becomes a real event with its
+own colour and its own webhook, exactly like the built-in ones.
+
+```yaml
+log:
+  custom:
+    sethome:
+      enabled: true
+      match: "sethome"
+      title: "Home Set"
+      message: "{player} set a home called {arg1}"
+      color: "#5865F2"
+      webhook: ""
+```
+
+| Key | Meaning |
+|---|---|
+| `match` | The command to watch. **Multiple words match a subcommand** — `"lp user"` fires on `/lp user …` but not `/lp group …`. |
+| `title` | Bold first line of the message. Optional. |
+| `message` | The line itself. |
+| `color` | Embed colour, same as any other event. |
+| `webhook` | Send just this event elsewhere. Empty uses the main webhook. |
+| `enabled` | Turn one rule off without deleting it. |
+
+#### Placeholders
+
+`{player}` · `{command}` · `{args}` · `{world}` · `{arg1}` … `{arg9}`
+
+`{arg1}` is the first argument *after* the command word. An argument that was not typed
+renders as nothing rather than leaving `{arg5}` sitting in the message.
+
+#### What it can and cannot do
+
+> **It logs the command being run, not the action succeeding.**
+>
+> For a ban, DiscordLogger checks on the next tick that the ban list actually changed, so
+> a failed `/ban` from someone without permission is never logged. A custom rule cannot
+> do that — it reports that the command was typed. If it matters that the command
+> *worked*, this is the wrong tool and a proper integration is the right one.
+
+Matching ignores case, spacing, and any plugin qualifier — `/essentials:sethome`,
+`/SetHome` and `  /sethome  ` all match `"sethome"`. It matches whole **words**, so a
+rule for `"sethome"` never fires on `/sethomeall`.
+
+#### The safety rules still apply
+
+Custom events are events, not a way around the filters. `ignored_players`,
+`ignored_worlds`, `respect_vanish` and `ignored_commands` all apply exactly as they do
+elsewhere.
+
+> `filters.ignored_commands` wins. It ships with `/login` and `/msg` in it because
+> command logging posts the line verbatim — a custom rule that quietly overrode that
+> would turn a security default into a trap. If a rule collides with the deny-list, the
+> plugin says so in console on startup and the rule does not fire.
+
+Everything a player typed is escaped and redacted before sending, so a webhook URL
+pasted into a watched command is never published.
+
+---
+
 ---
 
 ## Full config.yml (v11)
@@ -1063,6 +1125,43 @@ log:
       enabled: true
       color: "#16A085" # dark teal
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+
+  # ----------------------------------------------------------------------------------
+  # Your own events, built from any command on the server.
+  #
+  # This is how you log plugins DiscordLogger has never heard of -- Essentials homes,
+  # LuckPerms rank changes, shop purchases, anything with a command behind it. Each
+  # entry becomes a real event with its own colour and its own webhook, exactly like
+  # the built-in ones.
+  #
+  # It watches the command being RUN, not the action succeeding. That is the honest
+  # limit: for a ban, DiscordLogger checks afterwards that the ban list actually
+  # changed, and a custom rule cannot do that. If it matters that the command worked,
+  # this is the wrong tool.
+  #
+  # Placeholders: {player} {command} {args} {world} and {arg1}...{arg9}
+  #
+  # Example -- delete the leading '#' on each line to use it:
+  #
+  #   sethome:
+  #     enabled: true
+  #     match: "sethome"            # Command to watch. Multiple words match a subcommand.
+  #     title: "Home Set"
+  #     message: "{player} set a home called {arg1}"
+  #     color: "#5865F2" # blurple
+  #     webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+  #
+  #   rank_change:
+  #     enabled: true
+  #     match: "lp user"            # Fires on /lp user <name> ...
+  #     title: "Rank Changed"
+  #     message: "{player} ran {command} on {arg2}: {arg3} {arg4}"
+  #     color: "#E67E22" # orange
+  #     webhook: ""
+  #
+  # Commands in filters.ignored_commands are never logged here either -- the deny-list
+  # wins, and the console says so on startup if a rule collides with it.
+  custom: {}
 
 # CONFIG VERSION V11, DOWNLOADED FROM WEBSITE
 ```

--- a/src/main/java/com/discordlogger/DiscordLogger.java
+++ b/src/main/java/com/discordlogger/DiscordLogger.java
@@ -8,6 +8,7 @@ import com.discordlogger.command.Webhook;
 import com.discordlogger.config.ConfigMigrator;
 import com.discordlogger.config.ConfigVersionNotice;
 import com.discordlogger.event.EventRegistry;
+import com.discordlogger.custom.CustomLogs;
 import com.discordlogger.filter.Filters;
 import com.discordlogger.lang.Lang;
 import com.discordlogger.log.Log;
@@ -118,6 +119,9 @@ public final class DiscordLogger extends JavaPlugin {
         // Before Log.init, so a reload cannot briefly log something the new config
         // says to filter.
         Filters.reload(this);
+        // Same point as Filters, and for the same reason: a reload must not be able
+        // to log something under rules the new config has already changed.
+        CustomLogs.reload(this);
         Lang.reload(this);
 
         final String url = getConfig().getString("webhook.url", "");

--- a/src/main/java/com/discordlogger/custom/CustomLogs.java
+++ b/src/main/java/com/discordlogger/custom/CustomLogs.java
@@ -1,0 +1,161 @@
+package com.discordlogger.custom;
+
+import com.discordlogger.filter.Filters;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Admin-defined log events, built from commands rather than from a plugin's API.
+ *
+ * <h2>Why this instead of an integration per plugin</h2>
+ *
+ * <p>Hooking Essentials, Towny, mcMMO and the rest means a compile-time dependency
+ * and a version coupling for each, forever, and a release every time someone wants
+ * a plugin nobody has heard of. This covers all of them at once and costs nothing to
+ * maintain, because it knows about commands and commands are universal.
+ *
+ * <p>What it cannot do is the honest limit: it sees a command being <em>run</em>, not
+ * an action <em>succeeding</em>. The moderation listeners exist as they do — sniff the
+ * command, then confirm on the next tick that the ban list actually changed — precisely
+ * because "someone typed /ban" and "someone was banned" are different facts. A custom
+ * rule reports the first. For anything where that distinction matters, a real
+ * integration is the answer and this is not.
+ *
+ * <h2>Live state, immutable snapshot</h2>
+ *
+ * <p>Same shape as {@link Filters}: rules are parsed once on load into an immutable
+ * list and swapped in one write, so a reload can never be observed half-applied by a
+ * command running on another thread.
+ */
+public final class CustomLogs {
+
+    /** One admin-defined rule. */
+    public record Rule(
+            String name,
+            List<String> match,
+            String title,
+            String message
+    ) {
+        /**
+         * The category this logs under, which is also how {@code Log} finds its colour
+         * and webhook — {@code log.custom.<name>} is walked by exactly the same code
+         * that handles {@code log.player.join}, so routing and colours needed no new
+         * machinery at all.
+         */
+        public String category() {
+            return "custom " + name;
+        }
+    }
+
+    private static volatile List<Rule> rules = List.of();
+
+    private CustomLogs() {}
+
+    public static List<Rule> rules() {
+        return rules;
+    }
+
+    /** Re-read the rules. Called from applyRuntimeConfig, so /reload picks them up. */
+    public static void reload(JavaPlugin plugin) {
+        final List<Rule> parsed = new ArrayList<>();
+        final ConfigurationSection custom =
+                plugin.getConfig().getConfigurationSection("log.custom");
+
+        if (custom != null) {
+            for (String name : custom.getKeys(false)) {
+                final ConfigurationSection sec = custom.getConfigurationSection(name);
+                if (sec == null || !sec.getBoolean("enabled", true)) continue;
+
+                final List<String> match = words(sec.getString("match", name));
+                if (match.isEmpty()) {
+                    plugin.getLogger().warning("log.custom." + name
+                            + " has no 'match', so it can never fire. Set it to the command "
+                            + "to watch, e.g. \"sethome\" or \"lp user\".");
+                    continue;
+                }
+
+                // The command deny-list wins, and saying so is the whole point of the
+                // warning. filters.ignored_commands ships with /login and /msg in it
+                // because command logging posts the line verbatim -- a custom rule that
+                // silently overrode that would turn a security default into a footgun
+                // for the one person who would never think to check.
+                if (Filters.blocksCommand(match.get(0))) {
+                    plugin.getLogger().warning("log.custom." + name + " watches \""
+                            + match.get(0) + "\", which filters.ignored_commands blocks. "
+                            + "The filter wins and this rule will never fire. Remove it from "
+                            + "ignored_commands if you really want that command logged.");
+                    continue;
+                }
+
+                parsed.add(new Rule(
+                        name,
+                        match,
+                        sec.getString("title", name),
+                        sec.getString("message", "{player} ran /{command} {args}")));
+            }
+        }
+
+        rules = List.copyOf(parsed);
+        if (!parsed.isEmpty()) {
+            plugin.getLogger().info("Custom logs active: " + parsed.size() + " rule(s).");
+        }
+    }
+
+    /**
+     * The first rule matching this command line, or null.
+     *
+     * <p>Matching is on <em>words</em>, not a prefix string, so {@code "lp user"} cannot
+     * be satisfied by {@code /lpuserpanel}. Multi-word matching is what makes the
+     * feature usable at all: half the interesting commands are subcommands, and a rule
+     * that could only say {@code lp} would fire on every LuckPerms command there is.
+     *
+     * <p>Split out and static so the whole decision is testable without a server.
+     */
+    public static Rule match(List<Rule> from, String rawWithSlash) {
+        final List<String> typed = words(strip(rawWithSlash));
+        if (typed.isEmpty()) return null;
+        for (Rule r : from) {
+            if (typed.size() < r.match().size()) continue;
+            boolean hit = true;
+            for (int i = 0; i < r.match().size(); i++) {
+                if (!typed.get(i).equals(r.match().get(i))) { hit = false; break; }
+            }
+            if (hit) return r;
+        }
+        return null;
+    }
+
+    /**
+     * Lower-cased words, with the leading slash and any plugin qualifier removed.
+     *
+     * <p>{@code /essentials:sethome Base} and {@code /SetHome Base} both become
+     * {@code [sethome, base]} — the qualifier strip matters for the same reason it does
+     * in {@code filters.ignored_commands}: without it, a rule is trivially bypassed by
+     * typing the long form.
+     */
+    public static List<String> words(String s) {
+        if (s == null) return List.of();
+        final List<String> out = new ArrayList<>();
+        for (String w : s.trim().split("\\s+")) {
+            if (!w.isEmpty()) out.add(w.toLowerCase(Locale.ROOT));
+        }
+        if (!out.isEmpty()) {
+            final String first = out.get(0);
+            final int colon = first.indexOf(':');
+            if (colon >= 0 && colon < first.length() - 1) {
+                out.set(0, first.substring(colon + 1));
+            }
+        }
+        return out;
+    }
+
+    private static String strip(String raw) {
+        if (raw == null) return "";
+        final String s = raw.trim();
+        return s.startsWith("/") ? s.substring(1) : s;
+    }
+}

--- a/src/main/java/com/discordlogger/custom/CustomTemplate.java
+++ b/src/main/java/com/discordlogger/custom/CustomTemplate.java
@@ -1,0 +1,76 @@
+package com.discordlogger.custom;
+
+import com.discordlogger.log.Log;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Fills an admin's {@code message} and {@code title} with what actually happened.
+ *
+ * <p>Split from the listener so the substitution can be tested exhaustively without a
+ * server, which matters more here than usual: this is the one place in the plugin
+ * where <em>the admin</em> writes the output format, so every placeholder they might
+ * reasonably try has to behave, and the ones they get wrong must fail visibly rather
+ * than producing a half-rendered line.
+ */
+public final class CustomTemplate {
+
+    private CustomTemplate() {}
+
+    /**
+     * Renders one template.
+     *
+     * <p><b>Every substituted value is escaped and redacted.</b> The text comes from a
+     * command line a player typed, so it reaches Discord as content: unescaped, a
+     * player could close the embed's markdown and forge the rest of the message, and
+     * an unredacted webhook URL pasted into a command would be published to the very
+     * channel it posts to. {@code Log.mdEscape} and {@code Log.redactWebhooks} are the
+     * same two the command listeners already apply, for the same two reasons.
+     *
+     * @param who   display name of whoever ran it, or "Console"
+     * @param words the command as typed, already lower-cased and split
+     */
+    public static String render(String template, String who, List<String> words, String world) {
+        if (template == null) return "";
+
+        final String command = words.isEmpty() ? "" : words.get(0);
+        final String args = words.size() > 1
+                ? String.join(" ", words.subList(1, words.size()))
+                : "";
+
+        String out = template
+                .replace("{player}", safe(who))
+                .replace("{command}", safe(command))
+                .replace("{args}", safe(args))
+                .replace("{world}", safe(world));
+
+        // {arg1}..{arg9}: positional access for rules that want one part of the line,
+        // e.g. "{player} promoted {arg2}" for /lp user Steve promote. Out-of-range
+        // resolves to empty rather than being left as literal "{arg3}" -- a command run
+        // with fewer arguments than usual should read as a gap, not as a broken template.
+        for (int i = 1; i <= 9; i++) {
+            final String token = "{arg" + i + "}";
+            if (!out.contains(token)) continue;
+            out = out.replace(token, i < words.size() ? safe(words.get(i)) : "");
+        }
+        return out.trim();
+    }
+
+    /** The two protections every player-controlled string in this plugin gets. */
+    private static String safe(String s) {
+        return s == null ? "" : Log.mdEscape(Log.redactWebhooks(s));
+    }
+
+    /** Title-cases a rule name for a default embed title: {@code set_home} -> "Set Home". */
+    public static String titleise(String name) {
+        final StringBuilder sb = new StringBuilder();
+        for (String part : name.replace('_', ' ').replace('-', ' ').split("\\s+")) {
+            if (part.isEmpty()) continue;
+            if (sb.length() > 0) sb.append(' ');
+            sb.append(Character.toUpperCase(part.charAt(0)))
+              .append(part.substring(1).toLowerCase(Locale.ROOT));
+        }
+        return sb.length() == 0 ? name : sb.toString();
+    }
+}

--- a/src/main/java/com/discordlogger/event/EventRegistry.java
+++ b/src/main/java/com/discordlogger/event/EventRegistry.java
@@ -1,5 +1,6 @@
 package com.discordlogger.event;
 
+import com.discordlogger.listener.custom.CustomCommandLog;
 import com.discordlogger.listener.player.*;
 import com.discordlogger.listener.server.*;
 import com.discordlogger.listener.moderation.*;
@@ -26,6 +27,9 @@ public final class EventRegistry {
         pm.registerEvents(new PlayerAdvancement(plugin), plugin);
         pm.registerEvents(new PlayerTeleport(plugin), plugin);
         pm.registerEvents(new PlayerGamemode(plugin), plugin);
+
+        // Admin-defined command rules (log.custom.*)
+        pm.registerEvents(new CustomCommandLog(plugin), plugin);
 
         // Server events
         pm.registerEvents(new ServerCommand(plugin), plugin);

--- a/src/main/java/com/discordlogger/listener/custom/CustomCommandLog.java
+++ b/src/main/java/com/discordlogger/listener/custom/CustomCommandLog.java
@@ -1,0 +1,75 @@
+package com.discordlogger.listener.custom;
+
+import com.discordlogger.custom.CustomLogs;
+import com.discordlogger.custom.CustomTemplate;
+import com.discordlogger.filter.Filters;
+import com.discordlogger.log.Log;
+import com.discordlogger.util.Names;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+import org.bukkit.event.server.ServerCommandEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.List;
+
+/**
+ * Fires the admin-defined rules in {@link CustomLogs}.
+ *
+ * <p>A command sniffer, exactly like the moderation listeners, and subject to the same
+ * filters every other player event is: {@code ignored_players}, {@code ignored_worlds},
+ * vanish and the command deny-list all apply. A custom rule is a new <em>event</em>,
+ * not a new route around the rules — an admin who has hidden a player expects that to
+ * hold everywhere, and a feature that quietly exempted itself would be the one place
+ * it silently did not.
+ */
+public final class CustomCommandLog implements Listener {
+
+    private static final String THUMB_SERVER =
+            "https://discordlogger.godtiergamers.xyz/assets/icons/server.png";
+
+    private final JavaPlugin plugin;
+
+    public CustomCommandLog(JavaPlugin plugin) { this.plugin = plugin; }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerCommand(PlayerCommandPreprocessEvent e) {
+        final Player p = e.getPlayer();
+        if (Filters.blocksPlayer(p) || Filters.blocksWorld(p.getWorld().getName())) return;
+        if (Filters.blocksCommand(e.getMessage())) return;
+        fire(e.getMessage(), Names.display(p, plugin), p.getWorld().getName(),
+                Log.playerAvatarUrl(p.getUniqueId()));
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onServerCommand(ServerCommandEvent e) {
+        // Console has no player and no world, so only the command filter can apply.
+        if (Filters.blocksCommand(e.getCommand())) return;
+        fire("/" + e.getCommand(), e.getSender().getName(), "", THUMB_SERVER);
+    }
+
+    private void fire(String raw, String who, String world, String thumb) {
+        final List<CustomLogs.Rule> rules = CustomLogs.rules();
+        if (rules.isEmpty()) return;
+
+        final CustomLogs.Rule rule = CustomLogs.match(rules, raw);
+        if (rule == null) return;
+
+        // Read live, like every other event gate, so /discordlogger reload takes effect
+        // without re-registering anything.
+        if (!plugin.getConfig().getBoolean(
+                "log.custom." + rule.name() + ".enabled", true)) return;
+
+        final List<String> words = CustomLogs.words(
+                raw.startsWith("/") ? raw.substring(1) : raw);
+
+        final String title = CustomTemplate.render(rule.title(), who, words, world);
+        final String body = CustomTemplate.render(rule.message(), who, words, world);
+        if (body.isEmpty()) return;
+
+        Log.eventWithThumb(rule.category(),
+                title.isEmpty() ? body : "**" + title + "**\n" + body, thumb);
+    }
+}

--- a/src/main/java/com/discordlogger/metrics/PluginMetrics.java
+++ b/src/main/java/com/discordlogger/metrics/PluginMetrics.java
@@ -71,6 +71,9 @@ public final class PluginMetrics {
     private static final String NO = "No";
     private static final String UNKNOWN = "Unknown";
 
+    /** The one log group whose keys the admin names rather than this project. */
+    private static final String CUSTOM = "custom";
+
     /**
      * Punishment plugins that keep their own database instead of Bukkit's ban list.
      * On a server running any of these, the moderation listeners verify a ban by
@@ -155,6 +158,9 @@ public final class PluginMetrics {
             metrics.addCustomChart(new AdvancedPie("filters_modified", () -> filtersModified(plugin)));
             metrics.addCustomChart(new SimplePie("command_filter_state",
                     () -> commandFilterState(plugin)));
+            // How MANY custom rules, never which -- the names are the admin's own words.
+            metrics.addCustomChart(new SimplePie("custom_logs",
+                    () -> bucket(customLogCount(plugin))));
 
             // ------------------------------------------------------------- reliability
             // Deltas since the last report, so the line charts show activity rather
@@ -548,10 +554,28 @@ public final class PluginMetrics {
     }
 
     /** Walks {@code log.<category>.<event>}, handing each one its section. */
+    /**
+     * How many custom rules are defined. Bucketed by the caller, never named.
+     *
+     * <p>Answers "does anyone use this feature", which is the only thing worth knowing
+     * and the most that can be known without describing a specific server's setup.
+     */
+    static int customLogCount(JavaPlugin plugin) {
+        final ConfigurationSection sec =
+                plugin.getConfig().getConfigurationSection("log." + CUSTOM);
+        return sec == null ? 0 : sec.getKeys(false).size();
+    }
+
     private static void forEachEvent(JavaPlugin plugin, EventVisitor visitor) {
         final ConfigurationSection log = plugin.getConfig().getConfigurationSection("log");
         if (log == null) return;
         for (String category : log.getKeys(false)) {
+            // log.custom.* is named by the admin, so its keys are THEIR words -- a
+            // server naming a rule after their own staff process would publish that
+            // to bStats through enabled_events. Every other value here is a fixed
+            // string this project chose; these are the only ones that are not, so
+            // they are excluded from every walk and counted as a bucket instead.
+            if (CUSTOM.equals(category)) continue;
             final ConfigurationSection section = log.getConfigurationSection(category);
             if (section == null) continue;
             for (String event : section.getKeys(false)) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -281,4 +281,41 @@ log:
       color: "#16A085" # dark teal
       webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
 
+  # ----------------------------------------------------------------------------------
+  # Your own events, built from any command on the server.
+  #
+  # This is how you log plugins DiscordLogger has never heard of -- Essentials homes,
+  # LuckPerms rank changes, shop purchases, anything with a command behind it. Each
+  # entry becomes a real event with its own colour and its own webhook, exactly like
+  # the built-in ones.
+  #
+  # It watches the command being RUN, not the action succeeding. That is the honest
+  # limit: for a ban, DiscordLogger checks afterwards that the ban list actually
+  # changed, and a custom rule cannot do that. If it matters that the command worked,
+  # this is the wrong tool.
+  #
+  # Placeholders: {player} {command} {args} {world} and {arg1}...{arg9}
+  #
+  # Example -- delete the leading '#' on each line to use it:
+  #
+  #   sethome:
+  #     enabled: true
+  #     match: "sethome"            # Command to watch. Multiple words match a subcommand.
+  #     title: "Home Set"
+  #     message: "{player} set a home called {arg1}"
+  #     color: "#5865F2" # blurple
+  #     webhook: "" # Send just this event elsewhere. Empty = use webhook.url above
+  #
+  #   rank_change:
+  #     enabled: true
+  #     match: "lp user"            # Fires on /lp user <name> ...
+  #     title: "Rank Changed"
+  #     message: "{player} ran {command} on {arg2}: {arg3} {arg4}"
+  #     color: "#E67E22" # orange
+  #     webhook: ""
+  #
+  # Commands in filters.ignored_commands are never logged here either -- the deny-list
+  # wins, and the console says so on startup if a rule collides with it.
+  custom: {}
+
 # CONFIG VERSION V11, SHIPPED WITH v2.3.0 (x-release-please-version)

--- a/src/test/java/com/discordlogger/custom/CustomLogsMatchTest.java
+++ b/src/test/java/com/discordlogger/custom/CustomLogsMatchTest.java
@@ -1,0 +1,77 @@
+package com.discordlogger.custom;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/** Rule matching — the whole decision, testable without a server. */
+class CustomLogsMatchTest {
+
+    private static CustomLogs.Rule rule(String name, String match) {
+        return new CustomLogs.Rule(name, CustomLogs.words(match), name, "{player}");
+    }
+
+    private static final List<CustomLogs.Rule> RULES = List.of(
+            rule("rank_change", "lp user"),
+            rule("sethome", "sethome"));
+
+    @Test
+    @DisplayName("a single-word rule matches its command")
+    void singleWord() {
+        assertNotNull(CustomLogs.match(RULES, "/sethome base"));
+        assertEquals("sethome", CustomLogs.match(RULES, "/sethome").name());
+    }
+
+    @Test
+    @DisplayName("a multi-word rule matches only its subcommand")
+    void multiWord() {
+        assertEquals("rank_change",
+                CustomLogs.match(RULES, "/lp user Steve parent add admin").name());
+        // The reason multi-word matching exists: a rule that could only say "lp" would
+        // fire on every LuckPerms command, including ones the admin did not ask about.
+        assertNull(CustomLogs.match(RULES, "/lp group admin permission set foo"));
+    }
+
+    @Test
+    @DisplayName("matching is on words, so a longer command name cannot satisfy a rule")
+    void notAPrefixMatch() {
+        // "/lpuserpanel" starts with "lp user" as a STRING but is a different command.
+        assertNull(CustomLogs.match(RULES, "/lpuserpanel"));
+        assertNull(CustomLogs.match(RULES, "/sethomeall"));
+    }
+
+    @Test
+    @DisplayName("a plugin qualifier cannot bypass a rule")
+    void qualifierStripped() {
+        // Same reasoning as filters.ignored_commands: without this, typing the long
+        // form is a trivial bypass.
+        assertEquals("sethome", CustomLogs.match(RULES, "/essentials:sethome base").name());
+        assertEquals("rank_change", CustomLogs.match(RULES, "/luckperms:lp user Steve info").name());
+    }
+
+    @Test
+    @DisplayName("case and spacing do not matter")
+    void caseAndSpacing() {
+        assertEquals("sethome", CustomLogs.match(RULES, "  /SetHome   Base  ").name());
+        assertEquals("rank_change", CustomLogs.match(RULES, "/LP   User  Steve").name());
+    }
+
+    @Test
+    @DisplayName("a command shorter than the rule cannot match it")
+    void tooFewWords() {
+        assertNull(CustomLogs.match(RULES, "/lp"));
+    }
+
+    @Test
+    @DisplayName("nothing matches when no rules are defined")
+    void noRules() {
+        assertNull(CustomLogs.match(List.of(), "/sethome"));
+        assertNull(CustomLogs.match(RULES, ""));
+        assertNull(CustomLogs.match(RULES, null));
+    }
+}

--- a/src/test/java/com/discordlogger/custom/CustomTemplateTest.java
+++ b/src/test/java/com/discordlogger/custom/CustomTemplateTest.java
@@ -1,0 +1,78 @@
+package com.discordlogger.custom;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Template rendering. Tested harder than most things here because this is the one
+ * place an ADMIN writes the output format, so it has to survive whatever they type.
+ */
+class CustomTemplateTest {
+
+    private static final List<String> CMD = CustomLogs.words("sethome base camp");
+
+    @Test
+    @DisplayName("the documented placeholders all resolve")
+    void placeholdersResolve() {
+        assertEquals("Steve ran /sethome base camp in world",
+                CustomTemplate.render("{player} ran /{command} {args} in {world}",
+                        "Steve", CMD, "world"));
+    }
+
+    @Test
+    @DisplayName("positional args pick out one part of the line")
+    void positionalArgs() {
+        assertEquals("base / camp",
+                CustomTemplate.render("{arg1} / {arg2}", "Steve", CMD, "world"));
+    }
+
+    @Test
+    @DisplayName("an out-of-range arg renders empty, not as literal text")
+    void missingArgIsBlankNotLiteral() {
+        // A command run with fewer arguments than usual should read as a gap. Leaving
+        // "{arg5}" in the message would look like the plugin failed to render.
+        String out = CustomTemplate.render("home:{arg5}", "Steve", CMD, "world");
+        assertFalse(out.contains("{arg5}"), out);
+        assertEquals("home:", out);
+    }
+
+    @Test
+    @DisplayName("a webhook pasted into a command is redacted")
+    void webhookRedacted() {
+        // Without this, logging a command containing a webhook URL would publish that
+        // URL to the very channel it posts to.
+        List<String> cmd = CustomLogs.words(
+                "setwebhook https://discord.com/api/webhooks/123456/SECRETTOKENVALUE");
+        String out = CustomTemplate.render("{args}", "Steve", cmd, "world");
+        assertFalse(out.contains("SECRETTOKENVALUE"), out);
+    }
+
+    @Test
+    @DisplayName("markdown in a player-typed argument cannot escape the message")
+    void markdownEscaped() {
+        List<String> cmd = CustomLogs.words("say **bold** _x_");
+        String out = CustomTemplate.render("{args}", "Steve", cmd, "world");
+        assertTrue(out.contains("\\"), "player text must be escaped, got: " + out);
+    }
+
+    @Test
+    @DisplayName("an empty or null template is not an error")
+    void emptyTemplate() {
+        assertEquals("", CustomTemplate.render(null, "Steve", CMD, "world"));
+        assertEquals("", CustomTemplate.render("", "Steve", CMD, "world"));
+    }
+
+    @Test
+    @DisplayName("a rule name becomes a readable default title")
+    void titleised() {
+        assertEquals("Set Home", CustomTemplate.titleise("set_home"));
+        assertEquals("Rank Change", CustomTemplate.titleise("rank-change"));
+        assertEquals("Sethome", CustomTemplate.titleise("sethome"));
+    }
+}

--- a/src/test/java/com/discordlogger/metrics/CustomLogPrivacyTest.java
+++ b/src/test/java/com/discordlogger/metrics/CustomLogPrivacyTest.java
@@ -1,0 +1,44 @@
+package com.discordlogger.metrics;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The custom-log names are the only strings in the config an ADMIN chooses, and the
+ * privacy contract says nothing describing a specific server leaves it. These pin the
+ * two halves of that: the walk skips the group, and what is reported is a count.
+ */
+class CustomLogPrivacyTest {
+
+    private static String metricsSource() throws Exception {
+        return Files.readString(
+                Path.of("src/main/java/com/discordlogger/metrics/PluginMetrics.java"));
+    }
+
+    @Test
+    @DisplayName("the event walk skips log.custom")
+    void walkSkipsCustom() throws Exception {
+        // enabled_events, routed_events and colors_customised all run through
+        // forEachEvent. Without the skip, a rule named after a server's own staff
+        // process would be published to bStats as a chart slice.
+        assertTrue(metricsSource().contains("if (CUSTOM.equals(category)) continue;"),
+                "forEachEvent must skip the admin-named group");
+    }
+
+    @Test
+    @DisplayName("the custom chart reports a bucket, never a name")
+    void chartIsABucket() throws Exception {
+        String src = metricsSource();
+        assertTrue(src.contains("bucket(customLogCount(plugin))"),
+                "custom_logs must report a bucketed count");
+        // The supplier must not be able to reach the keys themselves.
+        assertFalse(src.contains("new AdvancedPie(\"custom_logs\""),
+                "an advanced pie would carry one slice per rule NAME");
+    }
+}


### PR DESCRIPTION
Adds `log.custom.<name>`: an admin defines a rule and gets a **real event** — its own colour, its own webhook, its own wording.

```yaml
log:
  custom:
    sethome:
      enabled: true
      match: "sethome"
      title: "Home Set"
      message: "{player} set a home called {arg1}"
      color: "#5865F2"
      webhook: ""
```

Essentials homes, LuckPerms rank changes, shop purchases — anything with a command behind it.

### Why this instead of an integration per plugin

An integration each means a compile-time dependency and a version coupling **forever**, plus a release every time someone wants a plugin nobody here has heard of. This covers all of them at once and costs nothing to maintain, because it knows about commands and commands are universal.

### It reuses the existing machinery rather than adding any

`Log.init` already walks `log.<group>.<event>` for colour and webhook — so `log.custom.<name>` gets **per-event routing and colours with zero changes to `Log`**. Rules are an immutable snapshot swapped in one write, exactly like `Filters`.

### Matching is on words, not string prefixes

`"lp user"` fires on `/lp user Steve` but **not** `/lp group admin`. That's what makes it usable — half the interesting commands are subcommands, and a rule that could only say `lp` would fire on every LuckPerms command there is. It also can't be satisfied by `/lpuserpanel`.

Case, spacing and plugin qualifiers normalise the same way `filters.ignored_commands` does them — without that last step, typing `/essentials:sethome` is a trivial bypass.

### Three things it deliberately does not do

**It does not bypass the filters.** `ignored_players`, `ignored_worlds`, `respect_vanish` and `ignored_commands` all apply. The deny-list wins outright and the console says so at startup when a rule collides with it — `ignored_commands` ships with `/login` and `/msg` because command logging posts the line verbatim, and a custom rule that silently overrode that would turn a security default into a trap.

**It does not send unescaped text.** Everything interpolated is `mdEscape`'d and webhook-redacted, so a player can't forge the rest of an embed and a webhook URL pasted into a watched command isn't published to the channel it posts to.

**It does not claim the action succeeded.** It sees the command *run*. The moderation listeners confirm on the next tick that the ban list actually changed; a custom rule can't. Documented plainly on the docs page rather than left to be discovered.

### The rule names never leave the server

These are the only strings in the config an **admin** writes, and `forEachEvent` walks all of `log.*` — so `enabled_events` would have published a server's own words to bStats.

The walk now skips the group, and a `custom_logs` chart reports a **bucketed count** instead, which answers *"does anyone use this"* without describing anyone's setup. Two tests pin both halves.

### Verified

243 tests (+16), validator clean, compiles at the 1.19 compat floor, JAR builds, docs page renders.

Lands in the **open v11 schema**, so it costs no new schema version — worth merging before 2.3.1 freezes it.

⚠️ `custom_logs` needs creating on bStats: **Simple Pie**, title *Custom Logs*, id `custom_logs`.