### PR TITLE
feat: expand PlaceholderAPI placeholders in lang.yml

### DIFF
--- a/docs/assets/configs/v11/config.template.yml
+++ b/docs/assets/configs/v11/config.template.yml
@@ -63,6 +63,13 @@ format:
   # Show nicknames (if set) as "Nickname (RealName)" in all player-related logs
   nicknames: {{NICKNAMES}}
 
+  # Expand PlaceholderAPI placeholders in lang.yml, e.g. %vault_prefix% or
+  # %luckperms_primary_group%, so ranks and prefixes appear in your Discord messages.
+  # Ignored when PlaceholderAPI is not installed, so it is safe to leave on.
+  # Only placeholders YOU write into lang.yml are expanded -- a player typing
+  # %player_name% into chat has it logged exactly as they typed it.
+  placeholders: {{PLACEHOLDERS}}
+
 #################
 # EMBED OPTIONS #
 #################

--- a/docs/assets/configs/v11/config.yml
+++ b/docs/assets/configs/v11/config.yml
@@ -63,6 +63,13 @@ format:
   # Show nicknames (if set) as "Nickname (RealName)" in all player-related logs
   nicknames: true
 
+  # Expand PlaceholderAPI placeholders in lang.yml, e.g. %vault_prefix% or
+  # %luckperms_primary_group%, so ranks and prefixes appear in your Discord messages.
+  # Ignored when PlaceholderAPI is not installed, so it is safe to leave on.
+  # Only placeholders YOU write into lang.yml are expanded -- a player typing
+  # %player_name% into chat has it logged exactly as they typed it.
+  placeholders: true
+
 #################
 # EMBED OPTIONS #
 #################

--- a/docs/assets/configs/v11/generator.js
+++ b/docs/assets/configs/v11/generator.js
@@ -137,6 +137,7 @@
             plainName: '',
             timeFmt: TIME_PRESETS[0].value,
             nicknames: true,
+            placeholders: true,
             options: null,
             template: null,
             langTemplate: null,
@@ -403,6 +404,9 @@
             const nickInput = h('input', { type: 'checkbox', ...(state.nicknames ? { checked: true } : {}) });
             nickInput.addEventListener('change', () => { state.nicknames = nickInput.checked; });
 
+            const papiInput = h('input', { type: 'checkbox', ...(state.placeholders ? { checked: true } : {}) });
+            papiInput.addEventListener('change', () => { state.placeholders = papiInput.checked; });
+
             syncStyle();
             updatePreview();
 
@@ -415,6 +419,12 @@
                     nickInput,
                     h('span', {}, 'Show nicknames as "Nickname (RealName)"'),
                 ]),
+                h('label', { class: 'cfg-check' }, [
+                    papiInput,
+                    h('span', {}, 'Expand PlaceholderAPI placeholders in messages'),
+                ]),
+                h('p', { class: 'cfg-note cfg-note--footnote' },
+                    'Only matters if PlaceholderAPI is installed \u2014 ignored otherwise, so it is safe to leave on.'),
                 actions('Back', h('button', { class: 'cfg-btn cfg-btn--primary', type: 'button', onclick: next }, 'Next')),
             ]);
         };
@@ -915,6 +925,7 @@
             TIME_FORMAT: state.timeFmt,
             PLAIN_NAME: yamlQuote(state.plainName),
             NICKNAMES: state.nicknames ? 'true' : 'false',
+            PLACEHOLDERS: state.placeholders ? 'true' : 'false',
             EMBEDS_ENABLED: state.embedsEnabled ? 'true' : 'false',
             EMBEDS_AUTHOR: yamlQuote(state.embedAuthor),
             GENERATED_AT: generatedAt,

--- a/docs/config/v11/index.md
+++ b/docs/config/v11/index.md
@@ -110,6 +110,33 @@ format:
   time: "[HH:mm:ss dd:MM:yyyy]"     # Java DateTimeFormatter pattern
 ```
 
+#### `format.placeholders`
+Expands [PlaceholderAPI](https://www.spigotmc.org/resources/6245/) placeholders in
+`lang.yml`, so ranks and prefixes appear in your Discord messages. On by default.
+
+```yaml
+format:
+  placeholders: true
+```
+
+```yaml
+# lang.yml
+discord:
+  player-join: "%luckperms_primary_group% {player} joined"
+```
+
+**Ignored when PlaceholderAPI is not installed**, so it is safe to leave on — there is
+nothing to switch off on a server that does not have it.
+
+> **A player cannot inject a placeholder.** `{player}`, `{message}` and the rest are
+> substituted first, and their values are never re-scanned. Someone typing
+> `%player_name%` into chat has it logged exactly as they typed it. Only placeholders
+> *you* write into `lang.yml` are ever expanded.
+
+Applies to the join, quit, chat, command and death messages — the events with a player
+behind them. If an expansion misbehaves, the message is sent with the placeholder
+unexpanded rather than not sent at all.
+
 ---
 
 ### `config-version`
@@ -907,6 +934,13 @@ format:
   name: ""
   # Show nicknames (if set) as "Nickname (RealName)" in all player-related logs
   nicknames: true
+
+  # Expand PlaceholderAPI placeholders in lang.yml, e.g. %vault_prefix% or
+  # %luckperms_primary_group%, so ranks and prefixes appear in your Discord messages.
+  # Ignored when PlaceholderAPI is not installed, so it is safe to leave on.
+  # Only placeholders YOU write into lang.yml are expanded -- a player typing
+  # %player_name% into chat has it logged exactly as they typed it.
+  placeholders: true
 
 #################
 # EMBED OPTIONS #

--- a/src/main/java/com/discordlogger/DiscordLogger.java
+++ b/src/main/java/com/discordlogger/DiscordLogger.java
@@ -10,6 +10,7 @@ import com.discordlogger.config.ConfigVersionNotice;
 import com.discordlogger.event.EventRegistry;
 import com.discordlogger.custom.CustomLogs;
 import com.discordlogger.filter.Filters;
+import com.discordlogger.util.Placeholders;
 import com.discordlogger.lang.Lang;
 import com.discordlogger.log.Log;
 import com.discordlogger.metrics.PluginMetrics;
@@ -122,6 +123,9 @@ public final class DiscordLogger extends JavaPlugin {
         // Same point as Filters, and for the same reason: a reload must not be able
         // to log something under rules the new config has already changed.
         CustomLogs.reload(this);
+        // Reads format.placeholders and resolves PlaceholderAPI once, so a reload
+        // picks up both the toggle and a plugin installed since startup.
+        Placeholders.reload(this);
         Lang.reload(this);
 
         final String url = getConfig().getString("webhook.url", "");

--- a/src/main/java/com/discordlogger/lang/Lang.java
+++ b/src/main/java/com/discordlogger/lang/Lang.java
@@ -3,6 +3,8 @@ package com.discordlogger.lang;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import com.discordlogger.config.ConfigMigrator;
+import com.discordlogger.util.Placeholders;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -90,6 +92,21 @@ public final class Lang {
     /** A message for Discord: plain text, placeholders filled, no MiniMessage. */
     public static String text(String key, Object... placeholders) {
         return fill(raw(key), placeholders);
+    }
+
+    /**
+     * As {@link #text}, then expanded through PlaceholderAPI against this player.
+     *
+     * <p><b>Order matters and is the security property.</b> This plugin's own
+     * {@code {token}} substitution runs first and its results are not re-scanned, so a
+     * player who types {@code %player_name%} into chat gets it logged literally. Only
+     * placeholders the server owner wrote into {@code lang.yml} are ever expanded.
+     *
+     * <p>A no-op when PlaceholderAPI is absent or {@code format.placeholders} is off,
+     * which is why call sites can use it unconditionally.
+     */
+    public static String textFor(OfflinePlayer player, String key, Object... placeholders) {
+        return Placeholders.apply(player, fill(raw(key), placeholders));
     }
 
     /** A message for in game: MiniMessage rendered to a Component. */

--- a/src/main/java/com/discordlogger/listener/player/PlayerChat.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerChat.java
@@ -27,7 +27,7 @@ public final class PlayerChat implements Listener {
         if (Filters.blocksChat(plain)) return;
 
         String text = Log.mdEscape(plain);
-        String msg  = Lang.text("discord.player-chat", "player", who, "message", text);
+        String msg  = Lang.textFor(e.getPlayer(), "discord.player-chat", "player", who, "message", text);
         Log.eventWithThumb("Player Chat", msg, Log.playerAvatarUrl(e.getPlayer().getUniqueId()));
     }
 }

--- a/src/main/java/com/discordlogger/listener/player/PlayerCommand.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerCommand.java
@@ -27,7 +27,7 @@ public final class PlayerCommand implements Listener {
 
         String who = Names.display(e.getPlayer(), plugin);
         String cmd = Log.mdEscape(Log.redactWebhooks(e.getMessage())); // includes leading '/'
-        String msg = Lang.text("discord.player-command", "player", who, "command", cmd);
+        String msg = Lang.textFor(e.getPlayer(), "discord.player-command", "player", who, "command", cmd);
         Log.eventWithThumb("Player Command", msg, Log.playerAvatarUrl(e.getPlayer().getUniqueId()));
     }
 }

--- a/src/main/java/com/discordlogger/listener/player/PlayerDeath.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerDeath.java
@@ -52,7 +52,7 @@ public final class PlayerDeath implements Listener {
         Log.eventFieldsWithThumb(
                 "Player Death",
                 "Player Death",
-                Lang.text("discord.death.description", "player", vName),
+                Lang.textFor(victim, "discord.death.description", "player", vName),
                 null,                       // null -> use embeds.author from config
                 fields,
                 Log.playerAvatarUrl(victim.getUniqueId())

--- a/src/main/java/com/discordlogger/listener/player/PlayerJoin.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerJoin.java
@@ -26,7 +26,7 @@ public final class PlayerJoin implements Listener {
             Names.capture(e.getPlayer()); // seed/update cache
             final String who = Names.display(e.getPlayer(), plugin);
             final java.util.UUID uuid = e.getPlayer().getUniqueId();
-            final String msg = Lang.text("discord.player-join", "player", who);
+            final String msg = Lang.textFor(e.getPlayer(), "discord.player-join", "player", who);
             final String thumb = Log.playerAvatarUrl(uuid);
 
             // Only ever added for Bedrock. Nothing can prove a player IS Java --

--- a/src/main/java/com/discordlogger/listener/player/PlayerQuit.java
+++ b/src/main/java/com/discordlogger/listener/player/PlayerQuit.java
@@ -22,7 +22,7 @@ public final class PlayerQuit implements Listener {
         if (Filters.blocksPlayer(e.getPlayer()) || Filters.blocksWorld(e.getPlayer().getWorld().getName())) return;
 
         String who = Names.display(e.getPlayer(), plugin);
-        String msg = Lang.text("discord.player-quit", "player", who);
+        String msg = Lang.textFor(e.getPlayer(), "discord.player-quit", "player", who);
         Log.eventWithThumb("Player Quit", msg, Log.playerAvatarUrl(e.getPlayer().getUniqueId()));
 
         // Defer cache eviction to the next tick so that other MONITOR-priority

--- a/src/main/java/com/discordlogger/util/Placeholders.java
+++ b/src/main/java/com/discordlogger/util/Placeholders.java
@@ -1,0 +1,86 @@
+package com.discordlogger.util;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.lang.reflect.Method;
+
+/**
+ * Expands PlaceholderAPI placeholders in outgoing messages, when it is installed.
+ *
+ * <h2>Reflection, not a dependency</h2>
+ *
+ * <p>Reached by reflection for the same reason {@link ClientPlatform} reaches Floodgate
+ * that way: PlaceholderAPI is present on roughly a third of servers, and the other
+ * two-thirds should not carry a compile-time coupling to a plugin they do not run. One
+ * method is resolved once and cached; a server without it pays a single failed lookup
+ * at startup and nothing after.
+ *
+ * <h2>What it is allowed to touch</h2>
+ *
+ * <p>Only {@code lang.yml} values, and only after this plugin's own {@code {token}}
+ * substitution has already run. That ordering is deliberate: a player who types
+ * {@code %player_name%} into chat must never have it expanded. Their message reaches
+ * the template as a value, and values are not re-scanned — so the only placeholders
+ * that resolve are the ones the server owner wrote into {@code lang.yml} themselves.
+ */
+public final class Placeholders {
+
+    private static final String API_CLASS = "me.clip.placeholderapi.PlaceholderAPI";
+
+    /** Resolved once. Null when PlaceholderAPI is absent, which is the common case. */
+    private static volatile Method setPlaceholders;
+    private static volatile boolean resolved;
+
+    /** Mirrors {@code format.placeholders}; false unless the config turns it on. */
+    private static volatile boolean enabled;
+
+    private Placeholders() {}
+
+    /** Re-read the toggle. Called from applyRuntimeConfig, so /reload picks it up. */
+    public static void reload(JavaPlugin plugin) {
+        enabled = plugin.getConfig().getBoolean("format.placeholders", true) && available();
+        if (enabled) {
+            plugin.getLogger().info("PlaceholderAPI found — placeholders in lang.yml will be expanded.");
+        }
+    }
+
+    /** True when PlaceholderAPI is installed and its API can be reached. */
+    public static boolean available() {
+        if (resolved) return setPlaceholders != null;
+        synchronized (Placeholders.class) {
+            if (resolved) return setPlaceholders != null;
+            resolved = true;
+            try {
+                if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") == null) return false;
+                setPlaceholders = Class.forName(API_CLASS)
+                        .getMethod("setPlaceholders", OfflinePlayer.class, String.class);
+            } catch (Throwable absentOrChanged) {
+                setPlaceholders = null;
+            }
+            return setPlaceholders != null;
+        }
+    }
+
+    /**
+     * Expands placeholders against a player, or returns the text unchanged.
+     *
+     * <p>Never throws. An expansion is somebody else's code running inside this
+     * plugin's send path, so a misbehaving one must cost the message its placeholders
+     * and nothing more — a logging plugin that stops logging because a third-party
+     * expansion threw is worse than one that prints {@code %some_placeholder%}.
+     */
+    public static String apply(OfflinePlayer player, String text) {
+        if (!enabled || text == null || text.isEmpty() || player == null) return text;
+        if (text.indexOf('%') < 0) return text;      // nothing to expand, skip the call
+        final Method m = setPlaceholders;
+        if (m == null) return text;
+        try {
+            final Object out = m.invoke(null, player, text);
+            return (out instanceof String s) ? s : text;
+        } catch (Throwable misbehavingExpansion) {
+            return text;
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -63,6 +63,13 @@ format:
   # Show nicknames (if set) as "Nickname (RealName)" in all player-related logs
   nicknames: true
 
+  # Expand PlaceholderAPI placeholders in lang.yml, e.g. %vault_prefix% or
+  # %luckperms_primary_group%, so ranks and prefixes appear in your Discord messages.
+  # Ignored when PlaceholderAPI is not installed, so it is safe to leave on.
+  # Only placeholders YOU write into lang.yml are expanded -- a player typing
+  # %player_name% into chat has it logged exactly as they typed it.
+  placeholders: true
+
 #################
 # EMBED OPTIONS #
 #################

--- a/src/test/java/com/discordlogger/util/PlaceholdersTest.java
+++ b/src/test/java/com/discordlogger/util/PlaceholdersTest.java
@@ -1,0 +1,42 @@
+package com.discordlogger.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * {@link Placeholders} needs a running server to expand anything, so what is pinned
+ * here is the contract that holds without one: it is inert unless switched on, and it
+ * never throws. Both matter more than the expansion itself — this sits in the send
+ * path of every player event, and the two-thirds of servers with no PlaceholderAPI
+ * must not pay for it.
+ */
+class PlaceholdersTest {
+
+    @Test
+    @DisplayName("with PlaceholderAPI absent, text passes through untouched")
+    void inertWhenUnavailable() {
+        // reload() has never run in a unit test, so `enabled` is false — the state
+        // every server without PlaceholderAPI is in, permanently.
+        assertEquals("%vault_prefix% Steve joined",
+                Placeholders.apply(null, "%vault_prefix% Steve joined"));
+    }
+
+    @Test
+    @DisplayName("null and empty input are handled, not thrown on")
+    void nullSafe() {
+        assertNull(Placeholders.apply(null, null));
+        assertEquals("", Placeholders.apply(null, ""));
+    }
+
+    @Test
+    @DisplayName("text with no percent sign is returned without any work")
+    void noPercentShortCircuits() {
+        // The common case on every message: skipping the reflective call entirely
+        // keeps this off the hot path rather than merely cheap on it.
+        final String plain = "Steve joined the server";
+        assertEquals(plain, Placeholders.apply(null, plain));
+    }
+}


### PR DESCRIPTION
Ranks, prefixes and anything else an expansion provides now appear in Discord messages.

```yaml
# lang.yml
discord:
  player-join: "%luckperms_primary_group% {player} joined"
```

bStats puts PlaceholderAPI on **roughly a third** of reporting servers, and TODO called it *"the one feature a server owner comparing DiscordLogger against WebhookLogger would pick the other for."*

### Reflection, not a dependency

Same approach `ClientPlatform` uses for Floodgate — the two-thirds of servers without PlaceholderAPI shouldn't carry a compile-time coupling to a plugin they don't run.

One method resolved once and cached, so a server without it pays a single failed lookup at startup and nothing after. Text containing no `%` skips the reflective call entirely, which keeps this **off** the hot path rather than merely cheap on it.

### The ordering is the security property

`Lang.textFor` runs this plugin's own `{token}` substitution **first** and never re-scans the result.

So a player typing `%player_name%` into chat has it logged exactly as typed. Only placeholders the server owner wrote into `lang.yml` are ever expanded.

Worth stating plainly, because the obvious implementation — expand the finished string — would hand every player an injection point into their own log line.

### Scope and failure mode

Applied to **join, quit, chat, command and death** — the messages with a player behind them. The remaining lang strings are fragments like a death cause or a coordinate label, where an expansion has no player context to resolve against.

It never throws. An expansion is somebody else's code running inside this plugin's send path, so a misbehaving one costs the message its placeholders and nothing more. A logging plugin that stops logging because a third-party expansion threw is worse than one that prints `%some_placeholder%`.

### Config

`format.placeholders`, added to the **open v11 schema** with a matching checkbox in the generator — so it costs no new schema version.

246 tests (+3), validator clean, compiles at the 1.19 floor.