### PR TITLE
fix(embeds): footer named a version, and bans ignored embeds.author

### DIFF
--- a/src/main/java/com/discordlogger/listener/moderation/Ban.java
+++ b/src/main/java/com/discordlogger/listener/moderation/Ban.java
@@ -100,7 +100,10 @@ public final class Ban implements Listener {
                 Log.eventFieldsWithThumb(
                         "ban",
                         "Player Banned",
-                        "Server Logs",
+                        // null -> embeds.author from config, like every other event.
+                        // Hard-coding it here meant a server that set embeds.author got
+                        // its own name everywhere EXCEPT on bans.
+                        null,
                         fields,
                         thumb
                 );

--- a/src/main/java/com/discordlogger/log/Log.java
+++ b/src/main/java/com/discordlogger/log/Log.java
@@ -30,7 +30,7 @@ public final class Log {
     private static volatile boolean embedsEnabledFlag;
     private static volatile String embedAuthorName;
 
-    // Footer text (dynamic: "DiscordLogger v<version>")
+    // Footer text. Deliberately just the plugin name -- see Log.init.
     private static final String EMBED_FOOTER_BASE = "DiscordLogger";
     private static volatile String embedFooterText = EMBED_FOOTER_BASE;
 
@@ -59,15 +59,11 @@ public final class Log {
         ready = isValidWebhookUrl(url);
         webhookUrl = ready ? url : null;
 
-        // compute footer text with plugin version (from plugin.yml -> ${project.version})
-        try {
-            String ver = plugin.getDescription().getVersion();
-            embedFooterText = (ver != null && !ver.isBlank())
-                    ? EMBED_FOOTER_BASE + " v" + ver
-                    : EMBED_FOOTER_BASE;
-        } catch (Exception ignored) {
-            embedFooterText = EMBED_FOOTER_BASE;
-        }
+        // The footer names the plugin, not the build. A version in every embed dates
+        // the screenshots in both listings the moment a release ships, and tells the
+        // reader nothing they can act on -- anyone who needs it has /discordlogger
+        // status, which reports the channel too.
+        embedFooterText = EMBED_FOOTER_BASE;
 
         // plain-text prefix (proxy/server name)
         plainServerName = plugin.getConfig().getString("format.name", "");


### PR DESCRIPTION
Two presentation bugs, both found while checking screenshot commands against the real embed output. Both are visible in a screenshot.

### The footer named a version

```
DiscordLogger v2.3.0   →   DiscordLogger
```

A version in every embed **dates the listing galleries the moment a release ships** — every screenshot either gets retaken or quietly advertises an old build. And it tells the reader nothing they can act on; anyone who needs the version has `/discordlogger status`, which reports the build channel alongside it.

### Bans ignored `embeds.author`

`Ban.java` passed the literal `"Server Logs"` as the embed author:

```java
Log.eventFieldsWithThumb("ban", "Player Banned", "Server Logs", fields, thumb);
```

So a server that set `embeds.author: "SMP-1 Logs"` got its own name on **every event except bans**. It was the only place in the plugin doing this — passing `null` takes the configured value, exactly as the other twenty-odd call sites already do.

249 tests green, compiles at the 1.19 floor.