### PR TITLE
fix(config): custom: {} could not take rules, and migration corrupted the fix

### DIFF
--- a/docs/assets/configs/v11/config.template.yml
+++ b/docs/assets/configs/v11/config.template.yml
@@ -310,6 +310,6 @@ log:
   #
   # Commands in filters.ignored_commands are never logged here either -- the deny-list
   # wins, and the console says so on startup if a rule collides with it.
-  custom: {}
+  custom:
 
 # CONFIG VERSION V11, GENERATED ON WEBSITE ON {{GENERATED_AT}}

--- a/docs/assets/configs/v11/config.yml
+++ b/docs/assets/configs/v11/config.yml
@@ -303,7 +303,8 @@ log:
   #
   # Placeholders: {player} {command} {args} {world} and {arg1}...{arg9}
   #
-  # Example -- delete the leading '#' on each line to use it:
+  # Example -- delete the leading '#' and one space from each line to use it.
+  # Indentation matters: each rule sits under 'custom:', and its settings under it.
   #
   #   sethome:
   #     enabled: true
@@ -323,6 +324,6 @@ log:
   #
   # Commands in filters.ignored_commands are never logged here either -- the deny-list
   # wins, and the console says so on startup if a rule collides with it.
-  custom: {}
+  custom:
 
 # CONFIG VERSION V11, DOWNLOADED FROM WEBSITE

--- a/docs/config/v11/index.md
+++ b/docs/config/v11/index.md
@@ -1175,7 +1175,8 @@ log:
   #
   # Placeholders: {player} {command} {args} {world} and {arg1}...{arg9}
   #
-  # Example -- delete the leading '#' on each line to use it:
+  # Example -- delete the leading '#' and one space from each line to use it.
+  # Indentation matters: each rule sits under 'custom:', and its settings under it.
   #
   #   sethome:
   #     enabled: true
@@ -1195,7 +1196,7 @@ log:
   #
   # Commands in filters.ignored_commands are never logged here either -- the deny-list
   # wins, and the console says so on startup if a rule collides with it.
-  custom: {}
+  custom:
 
 # CONFIG VERSION V11, DOWNLOADED FROM WEBSITE
 ```

--- a/src/main/java/com/discordlogger/config/ConfigMigrator.java
+++ b/src/main/java/com/discordlogger/config/ConfigMigrator.java
@@ -479,6 +479,17 @@ public final class ConfigMigrator {
         LeafPos pos = findLeafLine(defLines, path);
         if (pos == null) return;
 
+        // A key with NO value at all -- "custom:" -- flattens to a null leaf. Writing
+        // renderScalar(null) produced "custom:null", and YAML with no space after the
+        // colon is a plain SCALAR, not a mapping: the whole block below it stopped
+        // parsing and migration corrupted the file it was meant to preserve.
+        //
+        // Leaving the default's own line untouched is also the right answer on its
+        // merits. A null leaf carries nothing to transplant, so there is no user value
+        // being dropped here -- only a rewrite that could never improve on what the
+        // shipped default already says.
+        if (userVal == null) return;
+
         String line = newLines.get(pos.index);
 
         // find the colon after the key at the known indent

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -303,7 +303,8 @@ log:
   #
   # Placeholders: {player} {command} {args} {world} and {arg1}...{arg9}
   #
-  # Example -- delete the leading '#' on each line to use it:
+  # Example -- delete the leading '#' and one space from each line to use it.
+  # Indentation matters: each rule sits under 'custom:', and its settings under it.
   #
   #   sethome:
   #     enabled: true
@@ -323,6 +324,6 @@ log:
   #
   # Commands in filters.ignored_commands are never logged here either -- the deny-list
   # wins, and the console says so on startup if a rule collides with it.
-  custom: {}
+  custom:
 
 # CONFIG VERSION V11, SHIPPED WITH v2.3.0 (x-release-please-version)

--- a/src/test/java/com/discordlogger/config/ConfigMigratorNullLeafTest.java
+++ b/src/test/java/com/discordlogger/config/ConfigMigratorNullLeafTest.java
@@ -1,0 +1,68 @@
+package com.discordlogger.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A key with no value must survive migration.
+ *
+ * <p>{@code log.custom:} is legal YAML meaning "an empty section, add entries here",
+ * and it flattens to a null leaf. Rendering that null produced {@code custom:null} —
+ * and YAML with no space after the colon is a plain <em>scalar</em>, not a mapping, so
+ * everything below it stopped parsing. Migration corrupted the file it exists to
+ * preserve, and only on configs that had reached the version introducing the key.
+ */
+class ConfigMigratorNullLeafTest {
+
+    private static final String DEFAULT_TEXT = """
+            log:
+              player:
+                join:
+                  enabled: true
+              custom:
+
+            # CONFIG VERSION V11, SHIPPED WITH v9.9.9
+            """;
+
+    @Test
+    @DisplayName("a null-valued key round-trips as valid YAML")
+    void nullLeafStaysParseable() {
+        final String user = DEFAULT_TEXT.replace("enabled: true", "enabled: false");
+        final String out = ConfigMigrator.migrateText(DEFAULT_TEXT, user, 11, 11);
+
+        final Map<?, ?> parsed = new Yaml().load(out);
+        assertNotNull(parsed, "migrated output must still be parseable YAML");
+
+        final Map<?, ?> log = (Map<?, ?>) parsed.get("log");
+        assertTrue(log.containsKey("custom"), "the empty section must survive");
+        assertEquals(null, log.get("custom"), "and must stay empty, not become the string \"null\"");
+    }
+
+    @Test
+    @DisplayName("the user's real values still transplant across it")
+    void valuesAroundItStillMove() {
+        final String user = DEFAULT_TEXT.replace("enabled: true", "enabled: false");
+        final String out = ConfigMigrator.migrateText(DEFAULT_TEXT, user, 11, 11);
+
+        final Map<?, ?> parsed = new Yaml().load(out);
+        final Map<?, ?> log = (Map<?, ?>) parsed.get("log");
+        final Map<?, ?> join = (Map<?, ?>) ((Map<?, ?>) log.get("player")).get("join");
+        assertEquals(false, join.get("enabled"),
+                "a null leaf elsewhere must not stop real values transplanting");
+    }
+
+    @Test
+    @DisplayName("the line is left exactly as the default wrote it")
+    void lineIsUntouched() {
+        final String out = ConfigMigrator.migrateText(DEFAULT_TEXT, DEFAULT_TEXT, 11, 11);
+        assertTrue(out.contains("\n  custom:\n"),
+                "the shipped line should pass through unchanged, got:\n" + out);
+    }
+}

--- a/src/test/java/com/discordlogger/config/ConfigMigratorUpgradeTest.java
+++ b/src/test/java/com/discordlogger/config/ConfigMigratorUpgradeTest.java
@@ -116,6 +116,10 @@ class ConfigMigratorUpgradeTest {
         Map<?, ?> log = (Map<?, ?>) r.get("log");
         for (Object groupName : log.keySet()) {
             Map<?, ?> group = (Map<?, ?>) log.get(groupName);
+            // log.custom ships with no rules, so it is legitimately null. Every other
+            // group is a populated map, and a null one anywhere else is a real fault --
+            // hence skipping rather than defaulting to an empty map.
+            if (group == null) continue;
             for (Object eventName : group.keySet()) {
                 Map<?, ?> ev = (Map<?, ?>) group.get(eventName);
                 assertTrue(ev.containsKey("webhook"),

--- a/src/test/java/com/discordlogger/custom/CustomConfigShapeTest.java
+++ b/src/test/java/com/discordlogger/custom/CustomConfigShapeTest.java
@@ -1,0 +1,48 @@
+package com.discordlogger.custom;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@code log.custom} must be an empty BLOCK mapping, never a flow one.
+ *
+ * <p>Shipping {@code custom: {}} made the obvious edit impossible: YAML will not accept
+ * block children under a flow mapping, so
+ *
+ * <pre>
+ *   custom: {}
+ *     rank_change:
+ *       enabled: true
+ * </pre>
+ *
+ * is a parse error. Worse, the flow syntax someone reaches for instead —
+ * {@code custom: { rank_change, enabled: true }} — <em>parses cleanly</em> and produces
+ * a rule named {@code rank_change} with no body plus three stray siblings, so the
+ * feature silently does nothing and the config looks fine.
+ */
+class CustomConfigShapeTest {
+
+    private static String shipped() throws Exception {
+        return Files.readString(Path.of("src/main/resources/config.yml"));
+    }
+
+    @Test
+    @DisplayName("log.custom is not a flow mapping")
+    void notAFlowMapping() throws Exception {
+        assertFalse(shipped().contains("custom: {}"),
+                "custom: {} cannot take block children — ship a bare 'custom:' instead");
+    }
+
+    @Test
+    @DisplayName("log.custom is present and ready for children")
+    void presentAsABlockKey() throws Exception {
+        assertTrue(shipped().contains("\n  custom:\n"),
+                "config.yml must ship 'custom:' with no value, so rules can be added under it");
+    }
+}


### PR DESCRIPTION
Reported from a real attempt to add a custom rule.

### The reported bug

Shipping `custom: {}` makes the obvious edit **impossible** — YAML won't accept block children under a flow mapping:

```yaml
custom: {}
  rank_change:      # parse error
    enabled: true
```

And the flow syntax you reach for instead **parses cleanly while doing nothing**:

```yaml
custom: { rank_change, enabled: true, match: "lp user" }
```
```python
{'rank_change': None, 'enabled': True, 'match': 'lp user'}
```

One rule with no body, plus three stray siblings. The rule never loads, the colour silently falls back, and the config looks correct. That's the worst possible failure for a feature whose whole point is that you can see what it does.

Now ships `custom:`, which takes block children normally.

### The worse bug it exposed

A key with no value flattens to a **null leaf**, and `replaceLeafValueInDefault` rendered it as:

```yaml
custom:null
```

YAML with no space after a colon is a plain **scalar**, not a mapping — so every line below it stops parsing. `ConfigMigrator` corrupted the file it exists to preserve, and only for users who had reached the version introducing the key.

Null leaves are now left exactly as the default wrote them. That's also right on the merits: a null carries nothing to transplant, so nothing is being dropped — only a rewrite that could never improve on the shipped default.

### Tests

`ConfigMigratorNullLeafTest` pins all three properties: output still parses, the section stays empty rather than becoming the string `"null"`, and real values around it still transplant.

`ConfigMigratorUpgradeTest` now skips a null group — `log.custom` legitimately has no events, while a null group anywhere else is a real fault, so it skips rather than defaulting to an empty map.

251 tests green. Lands in the open v11 schema.